### PR TITLE
Add durable MeiliSync outbox, background worker, and enqueueing for part syncs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,8 +19,14 @@ MEILISEARCH_MASTER_KEY=another_strong_and_secret_key
 # Set the environment: development, staging, or production
 NODE_ENV=development
 
-# Disable Meilisearch listeners (set to true to disable for debugging)
-DISABLE_MEILI_LISTENERS=false
+# Disable durable outbox worker for parts sync (debugging only)
+DISABLE_MEILI_OUTBOX_WORKER=false
+
+# Disable applications LISTEN/NOTIFY index sync listener (debugging only)
+DISABLE_MEILI_APPLICATIONS_LISTENER=false
+
+# Enable legacy parts LISTEN/NOTIFY listener (normally false when outbox worker is enabled)
+ENABLE_LEGACY_MEILI_PART_LISTENER=false
 
 # Retry logic for Meilisearch setup (optional, defaults shown)
 MEILI_SETUP_MAX_RETRIES=4

--- a/README.md
+++ b/README.md
@@ -116,10 +116,16 @@ DB_PASSWORD=change_me
 MEILISEARCH_MASTER_KEY=change_me_meili
 JWT_SECRET=change_me_jwt
 MEILISEARCH_HOST=http://meilisearch:7700
+DISABLE_MEILI_OUTBOX_WORKER=false
+DISABLE_MEILI_APPLICATIONS_LISTENER=false
+ENABLE_LEGACY_MEILI_PART_LISTENER=false
 ```
 Notes:
 - The backend reads discrete DB_* variables.
 - In containers, `DB_HOST=db` and `MEILISEARCH_HOST=http://meilisearch:7700` are correct.
+- `DISABLE_MEILI_OUTBOX_WORKER=true` disables parts outbox processing (debugging only).
+- `DISABLE_MEILI_APPLICATIONS_LISTENER=true` disables applications index LISTEN/NOTIFY updates.
+- `ENABLE_LEGACY_MEILI_PART_LISTENER=true` re-enables legacy parts LISTEN/NOTIFY listener (normally off when outbox is enabled).
 
 ### Database Initialization
 Run once on fresh installs.
@@ -221,9 +227,9 @@ sudo docker cp ./database/initial_schema.sql forson_db:/initial_schema.sql
 sudo docker exec -u postgres forson_db psql -d forson_business_suite -f /initial_schema.sql
 ```
 
-Apply migrations.
+Apply migrations (recommended runner with history + checksums).
 ```bash
-for f in $(ls database/migrations/*.sql | sort); do cat "$f" | sudo docker exec -i forson_db psql -U postgres -d forson_business_suite; done
+npm --prefix packages/api run migrate -- --host 127.0.0.1
 ```
 
 Verify services.
@@ -252,7 +258,7 @@ sudo docker compose -f docker-compose.prod.yml up -d --pull=always --remove-orph
 
 Apply migrations.
 ```bash
-for f in $(ls database/migrations/*.sql | sort); do cat "$f" | sudo docker exec -i forson_db psql -U postgres -d forson_business_suite; done
+npm --prefix packages/api run migrate -- --host 127.0.0.1
 ```
 
 Smoke test API.
@@ -271,6 +277,11 @@ Use the built-in migration runner to apply idempotent SQL migrations safely.
 npm --prefix packages/api run migrate -- --host localhost
 ```
 
+- Apply from inside the backend container (recommended for Docker Desktop users):
+```powershell
+docker exec -it forson_backend_dev sh -lc "node scripts/migrate.js --host db --user postgres --password \"$DB_PASSWORD\" --db forson_business_suite"
+```
+
 - Status and verify:
 ```powershell
 npm --prefix packages/api run migrate:status -- --host localhost
@@ -282,9 +293,20 @@ npm --prefix packages/api run migrate:verify -- --host localhost
 npm --prefix packages/api run migrate -- --host 127.0.0.1
 ```
 
+- Target a specific migration window (useful when you only need a single new migration):
+```bash
+npm --prefix packages/api run migrate -- --host 127.0.0.1 --from 20260415_add_meili_sync_outbox.sql --to 20260415_add_meili_sync_outbox.sql
+```
+
+- Skip known seed migrations in existing databases:
+```bash
+npm --prefix packages/api run migrate -- --host 127.0.0.1 --skip 20250821_seed_documents.sql
+```
+
 Notes
 - Non-destructive: migrations are idempotent and applied in order.
 - Drift detection: if a previously applied file changes, verify/repair before proceeding.
+- `--from`/`--to` now fail fast when a filename is missing or excluded.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -303,10 +303,16 @@ npm --prefix packages/api run migrate -- --host 127.0.0.1 --from 20260415_add_me
 npm --prefix packages/api run migrate -- --host 127.0.0.1 --skip 20250821_seed_documents.sql
 ```
 
+- Include optional seed migrations explicitly (off by default):
+```bash
+npm --prefix packages/api run migrate -- --host 127.0.0.1 --include-seeds
+```
+
 Notes
 - Non-destructive: migrations are idempotent and applied in order.
 - Drift detection: if a previously applied file changes, verify/repair before proceeding.
 - `--from`/`--to` now fail fast when a filename is missing or excluded.
+- Optional seed migrations (e.g. demo/sample data) are excluded from normal runs unless `--include-seeds` or `MIGRATE_INCLUDE_SEEDS=true` is set.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ docker exec -u postgres forson_db psql -d forson_business_suite -f /initial_sche
 
 5) Apply SQL migrations (recommended)
 ```bash
-npm --prefix packages/api run migrate -- --host localhost
+docker exec -it forson_backend_dev sh -lc "node scripts/migrate.js --host db --user \"$DB_USER\" --password \"$DB_PASSWORD\" --db \"$DB_NAME\""
 ```
 
 6) Access
@@ -207,7 +207,7 @@ docker exec -u postgres forson_db psql -d forson_business_suite -f /initial_sche
 
 Apply migrations.
 ```bash
-npm --prefix packages/api run migrate -- --host localhost
+docker exec -it forson_backend_dev sh -lc "node scripts/migrate.js --host db --user \"$DB_USER\" --password \"$DB_PASSWORD\" --db \"$DB_NAME\""
 ```
 
 ### Production (Docker Compose, Linux server)

--- a/database/migrations/20260415_add_meili_sync_outbox.sql
+++ b/database/migrations/20260415_add_meili_sync_outbox.sql
@@ -1,0 +1,27 @@
+-- Durable outbox for Meilisearch synchronization events.
+CREATE TABLE IF NOT EXISTS meili_sync_outbox (
+  outbox_id BIGSERIAL PRIMARY KEY,
+  event_type TEXT NOT NULL CHECK (event_type IN ('upsert_part', 'delete_part')),
+  entity_type TEXT NOT NULL DEFAULT 'part',
+  entity_id BIGINT NOT NULL,
+  payload JSONB,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'done', 'dead')),
+  attempts INTEGER NOT NULL DEFAULT 0,
+  available_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  lease_until TIMESTAMPTZ,
+  last_error TEXT,
+  processed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_meili_sync_outbox_poll
+  ON meili_sync_outbox (status, available_at, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_meili_sync_outbox_lease
+  ON meili_sync_outbox (lease_until)
+  WHERE status = 'processing';
+
+CREATE INDEX IF NOT EXISTS idx_meili_sync_outbox_dead
+  ON meili_sync_outbox (status, updated_at)
+  WHERE status = 'dead';

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -31,7 +31,9 @@ services:
       - CHOKIDAR_USEPOLLING=true
       - CHOKIDAR_INTERVAL=100
       - MIGRATIONS_DIR=/database/migrations
-      - DISABLE_MEILI_LISTENERS=true
+      - DISABLE_MEILI_OUTBOX_WORKER=false
+      - DISABLE_MEILI_APPLICATIONS_LISTENER=false
+      - ENABLE_LEGACY_MEILI_PART_LISTENER=false
     env_file:
       - .env
 

--- a/packages/api/MEILISEARCH_CONFIG.md
+++ b/packages/api/MEILISEARCH_CONFIG.md
@@ -8,8 +8,14 @@ The Meilisearch setup has been enhanced with configurable options via environmen
 # Environment (affects default settings)
 NODE_ENV=development|staging|production
 
-# Disable Meilisearch listeners for debugging
-DISABLE_MEILI_LISTENERS=true
+# Disable parts outbox worker for debugging
+DISABLE_MEILI_OUTBOX_WORKER=true
+
+# Disable applications LISTEN/NOTIFY listener for debugging
+DISABLE_MEILI_APPLICATIONS_LISTENER=true
+
+# Enable legacy parts LISTEN/NOTIFY listener (normally false when outbox is enabled)
+ENABLE_LEGACY_MEILI_PART_LISTENER=true
 ```
 
 ## Setup Retry Configuration
@@ -86,7 +92,9 @@ The following health check endpoints are now available:
 NODE_ENV=development
 MEILI_TYPO_ENABLED=false
 MEILI_SETUP_MAX_RETRIES=2
-DISABLE_MEILI_LISTENERS=true
+DISABLE_MEILI_OUTBOX_WORKER=false
+DISABLE_MEILI_APPLICATIONS_LISTENER=false
+ENABLE_LEGACY_MEILI_PART_LISTENER=false
 
 # Production environment with optimized settings
 NODE_ENV=production

--- a/packages/api/index.js
+++ b/packages/api/index.js
@@ -140,11 +140,18 @@ app.listen(PORT, async () => {
     console.log('Meili outbox worker disabled by DISABLE_MEILI_OUTBOX_WORKER=true');
   }
 
-  // Keep legacy LISTEN/NOTIFY listeners opt-in for compatibility or migration periods.
-  if (process.env.ENABLE_LEGACY_MEILI_LISTENERS === 'true') {
-    startMeiliListener();
+  // Keep applications listener enabled by default so the `applications` Meilisearch index
+  // stays updated from DB NOTIFY events.
+  if (process.env.DISABLE_MEILI_APPLICATIONS_LISTENER !== 'true') {
     startMeiliApplicationsListener();
   } else {
-    console.log('Legacy meili listeners disabled (set ENABLE_LEGACY_MEILI_LISTENERS=true to enable).');
+    console.log('Applications meili listener disabled by DISABLE_MEILI_APPLICATIONS_LISTENER=true');
+  }
+
+  // Legacy part listener is opt-in to avoid duplicate processing with the outbox worker.
+  if (process.env.ENABLE_LEGACY_MEILI_PART_LISTENER === 'true' || process.env.ENABLE_LEGACY_MEILI_LISTENERS === 'true') {
+    startMeiliListener();
+  } else {
+    console.log('Legacy part meili listener disabled (set ENABLE_LEGACY_MEILI_PART_LISTENER=true to enable).');
   }
 });

--- a/packages/api/index.js
+++ b/packages/api/index.js
@@ -5,6 +5,7 @@ require('dotenv').config({ path: path.resolve(__dirname, '../../.env') });
 const { setupMeiliSearch } = require('./meilisearch-setup');
 const { startMeiliListener } = require('./meili-listener');
 const { startMeiliApplicationsListener } = require('./meili-app-listener');
+const { startMeiliOutboxWorker } = require('./meili-outbox-worker');
 
 // Set default timezone to Philippine Time
 process.env.TZ = 'Asia/Manila';
@@ -132,13 +133,18 @@ app.listen(PORT, async () => {
     }
   }
   
-  // Start the Postgres listener that keeps Meilisearch in sync
-  // Allow disabling listeners with DISABLE_MEILI_LISTENERS env var for local debugging
-  console.log('DISABLE_MEILI_LISTENERS:', process.env.DISABLE_MEILI_LISTENERS);
-  if (process.env.DISABLE_MEILI_LISTENERS !== 'true') {
+  // Start durable outbox worker for part sync by default.
+  if (process.env.DISABLE_MEILI_OUTBOX_WORKER !== 'true') {
+    startMeiliOutboxWorker();
+  } else {
+    console.log('Meili outbox worker disabled by DISABLE_MEILI_OUTBOX_WORKER=true');
+  }
+
+  // Keep legacy LISTEN/NOTIFY listeners opt-in for compatibility or migration periods.
+  if (process.env.ENABLE_LEGACY_MEILI_LISTENERS === 'true') {
     startMeiliListener();
     startMeiliApplicationsListener();
   } else {
-    console.log('Meili listeners disabled by DISABLE_MEILI_LISTENERS=true');
+    console.log('Legacy meili listeners disabled (set ENABLE_LEGACY_MEILI_LISTENERS=true to enable).');
   }
 });

--- a/packages/api/meili-outbox-worker.js
+++ b/packages/api/meili-outbox-worker.js
@@ -1,0 +1,257 @@
+const db = require('./db');
+const { syncPartWithMeili, removePartFromMeili } = require('./meilisearch');
+const { constructDisplayName } = require('./helpers/displayNameHelper');
+const { activeAliasCondition } = require('./helpers/partNumberSoftDelete');
+const { normalizePartData } = require('./helpers/normalizePart');
+
+const STATUS = Object.freeze({
+  PENDING: 'pending',
+  PROCESSING: 'processing',
+  DONE: 'done',
+  DEAD: 'dead'
+});
+
+const DEFAULTS = Object.freeze({
+  pollMs: Number(process.env.MEILI_OUTBOX_POLL_MS || 1500),
+  batchSize: Number(process.env.MEILI_OUTBOX_BATCH_SIZE || 100),
+  maxAttempts: Number(process.env.MEILI_OUTBOX_MAX_ATTEMPTS || 8),
+  leaseSeconds: Number(process.env.MEILI_OUTBOX_LEASE_SECONDS || 120),
+  metricsEvery: Number(process.env.MEILI_OUTBOX_METRICS_EVERY || 20)
+});
+
+const loadPartDocs = async (partIds) => {
+  if (!Array.isArray(partIds) || partIds.length === 0) return [];
+
+  const query = `
+    SELECT
+      p.*,
+      b.brand_name,
+      g.group_name,
+      (SELECT STRING_AGG(pn.part_number, '; ') FROM part_number pn WHERE pn.part_id = p.part_id AND ${activeAliasCondition('pn')}) as part_numbers,
+      (SELECT ARRAY_AGG(
+        CONCAT(vmk.make_name, ' ', vmd.model_name, COALESCE(CONCAT(' ', veng.engine_name), ''))
+      )
+      FROM part_application pa
+      JOIN application a ON pa.application_id = a.application_id
+      LEFT JOIN vehicle_make vmk ON a.make_id = vmk.make_id
+      LEFT JOIN vehicle_model vmd ON a.model_id = vmd.model_id
+      LEFT JOIN vehicle_engine veng ON a.engine_id = veng.engine_id
+      WHERE pa.part_id = p.part_id) AS applications_array,
+      (SELECT ARRAY_AGG(t.tag_name) FROM tag t JOIN part_tag pt ON t.tag_id = pt.tag_id WHERE pt.part_id = p.part_id) AS tags_array
+    FROM part AS p
+    LEFT JOIN brand AS b ON p.brand_id = b.brand_id
+    LEFT JOIN "group" AS g ON p.group_id = g.group_id
+    WHERE p.part_id = ANY($1::int[])
+  `;
+
+  const { rows } = await db.query(query, [partIds]);
+
+  return rows.map((part) => {
+    const normalizedFields = normalizePartData(part);
+    return {
+      ...part,
+      display_name: constructDisplayName(part),
+      applications: part.applications_array || [],
+      searchable_applications: (part.applications_array && Array.isArray(part.applications_array))
+        ? part.applications_array.map((app) => (typeof app === 'string' ? app : `${app.make || ''} ${app.model || ''} ${app.engine || ''}`.trim())).join(', ')
+        : '',
+      tags: part.tags_array || [],
+      normalized_internal_sku: normalizedFields.normalized_internal_sku,
+      normalized_part_numbers: normalizedFields.normalized_part_numbers
+    };
+  });
+};
+
+const claimEvents = async (client, batchSize, leaseSeconds) => {
+  const claimSql = `
+    WITH candidates AS (
+      SELECT outbox_id
+      FROM meili_sync_outbox
+      WHERE status IN ($1, $2)
+        AND available_at <= NOW()
+        AND (lease_until IS NULL OR lease_until < NOW())
+      ORDER BY created_at ASC
+      LIMIT $3
+      FOR UPDATE SKIP LOCKED
+    )
+    UPDATE meili_sync_outbox o
+    SET status = $4,
+        lease_until = NOW() + ($5::text || ' seconds')::interval,
+        attempts = attempts + 1,
+        updated_at = NOW()
+    FROM candidates c
+    WHERE o.outbox_id = c.outbox_id
+    RETURNING o.outbox_id, o.event_type, o.entity_id, o.attempts
+  `;
+
+  const { rows } = await client.query(claimSql, [STATUS.PENDING, STATUS.PROCESSING, batchSize, STATUS.PROCESSING, String(leaseSeconds)]);
+  return rows;
+};
+
+const markDone = async (client, ids) => {
+  if (!ids.length) return;
+  await client.query(
+    `UPDATE meili_sync_outbox
+     SET status = $1, processed_at = NOW(), lease_until = NULL, last_error = NULL, updated_at = NOW()
+     WHERE outbox_id = ANY($2::bigint[])`,
+    [STATUS.DONE, ids]
+  );
+};
+
+const markFailed = async (client, rows, maxAttempts, errorMessage) => {
+  if (!rows.length) return;
+  const deadIds = rows.filter((r) => r.attempts >= maxAttempts).map((r) => r.outbox_id);
+  const retryIds = rows.filter((r) => r.attempts < maxAttempts).map((r) => r.outbox_id);
+
+  if (retryIds.length) {
+    await client.query(
+      `UPDATE meili_sync_outbox
+       SET status = $1,
+           available_at = NOW() + make_interval(secs => LEAST(600, GREATEST(2, attempts * attempts))),
+           lease_until = NULL,
+           last_error = $3,
+           updated_at = NOW()
+       WHERE outbox_id = ANY($2::bigint[])`,
+      [STATUS.PENDING, retryIds, errorMessage]
+    );
+  }
+
+  if (deadIds.length) {
+    await client.query(
+      `UPDATE meili_sync_outbox
+       SET status = $1,
+           lease_until = NULL,
+           last_error = $3,
+           updated_at = NOW()
+       WHERE outbox_id = ANY($2::bigint[])`,
+      [STATUS.DEAD, deadIds, errorMessage]
+    );
+  }
+
+  return { dead: deadIds.length, retried: retryIds.length };
+};
+
+const processBatch = async (config) => {
+  const client = await db.getClient();
+  try {
+    await client.query('BEGIN');
+    const rows = await claimEvents(client, config.batchSize, config.leaseSeconds);
+    await client.query('COMMIT');
+
+    if (rows.length === 0) return { claimed: 0, done: 0, dead: 0, retried: 0 };
+
+    const doneIds = [];
+    const failedRows = [];
+
+    // Process deletes first.
+    const deleteRows = rows.filter((r) => r.event_type === 'delete_part');
+    for (const row of deleteRows) {
+      try {
+        await removePartFromMeili(row.entity_id);
+        doneIds.push(row.outbox_id);
+      } catch (error) {
+        failedRows.push(row);
+        console.error('[MeiliOutbox] delete_part failed:', row.entity_id, error && error.message ? error.message : error);
+      }
+    }
+
+    // Batch upserts.
+    const upsertRows = rows.filter((r) => r.event_type === 'upsert_part');
+    if (upsertRows.length) {
+      try {
+        const partIds = [...new Set(upsertRows.map((r) => Number(r.entity_id)).filter(Boolean))];
+        const docs = await loadPartDocs(partIds);
+        if (docs.length) {
+          await syncPartWithMeili(docs);
+        }
+        doneIds.push(...upsertRows.map((r) => r.outbox_id));
+      } catch (error) {
+        failedRows.push(...upsertRows);
+        console.error('[MeiliOutbox] upsert_part batch failed:', error && error.message ? error.message : error);
+      }
+    }
+
+    const finalize = await db.getClient();
+    try {
+      await finalize.query('BEGIN');
+      await markDone(finalize, doneIds);
+      const failResult = await markFailed(finalize, failedRows, config.maxAttempts, failedRows.length ? 'Meilisearch sync failed. Check API logs.' : null);
+      await finalize.query('COMMIT');
+      return {
+        claimed: rows.length,
+        done: doneIds.length,
+        dead: failResult?.dead || 0,
+        retried: failResult?.retried || 0
+      };
+    } catch (error) {
+      await finalize.query('ROLLBACK');
+      throw error;
+    } finally {
+      finalize.release();
+    }
+  } catch (error) {
+    try { await client.query('ROLLBACK'); } catch (_) { /* no-op */ }
+    throw error;
+  } finally {
+    client.release();
+  }
+};
+
+const startMeiliOutboxWorker = (options = {}) => {
+  const config = { ...DEFAULTS, ...options };
+  let running = false;
+  let tickCount = 0;
+  let timer = null;
+
+  const logMetrics = async () => {
+    try {
+      const { rows } = await db.query(
+        `SELECT status, COUNT(*)::int AS count
+         FROM meili_sync_outbox
+         GROUP BY status`
+      );
+      const summary = rows.reduce((acc, row) => ({ ...acc, [row.status]: row.count }), {});
+      console.log('[MeiliOutbox] status metrics:', summary);
+    } catch (error) {
+      console.error('[MeiliOutbox] metrics failed:', error && error.message ? error.message : error);
+    }
+  };
+
+  const tick = async () => {
+    if (running) return;
+    running = true;
+    try {
+      const result = await processBatch(config);
+      if (result.claimed > 0) {
+        console.log('[MeiliOutbox] processed batch:', result);
+      }
+      tickCount += 1;
+      if (tickCount % config.metricsEvery === 0) {
+        await logMetrics();
+      }
+    } catch (error) {
+      console.error('[MeiliOutbox] worker tick failed:', error && error.stack ? error.stack : error);
+    } finally {
+      running = false;
+    }
+  };
+
+  timer = setInterval(tick, config.pollMs);
+  tick();
+
+  const stop = () => {
+    if (timer) {
+      clearInterval(timer);
+      timer = null;
+      console.log('[MeiliOutbox] worker stopped');
+    }
+  };
+
+  process.on('SIGINT', stop);
+  process.on('SIGTERM', stop);
+
+  console.log('[MeiliOutbox] worker started', config);
+  return { stop };
+};
+
+module.exports = { startMeiliOutboxWorker, processBatch };

--- a/packages/api/meili-outbox-worker.js
+++ b/packages/api/meili-outbox-worker.js
@@ -190,7 +190,7 @@ const processBatch = async (config) => {
       finalize.release();
     }
   } catch (error) {
-    try { await client.query('ROLLBACK'); } catch (_) { /* no-op */ }
+    try { await client.query('ROLLBACK'); } catch { /* no-op */ }
     throw error;
   } finally {
     client.release();

--- a/packages/api/routes/partApplicationRoutes.js
+++ b/packages/api/routes/partApplicationRoutes.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const db = require('../db');
+const { syncPartWithMeili } = require('../meilisearch');
 const { enqueuePartUpsert } = require('../services/meiliOutboxService');
 const { constructDisplayName } = require('../helpers/displayNameHelper');
 const router = express.Router();

--- a/packages/api/routes/partApplicationRoutes.js
+++ b/packages/api/routes/partApplicationRoutes.js
@@ -1,6 +1,5 @@
 const express = require('express');
 const db = require('../db');
-const { syncPartWithMeili } = require('../meilisearch');
 const { enqueuePartUpsert } = require('../services/meiliOutboxService');
 const { constructDisplayName } = require('../helpers/displayNameHelper');
 const router = express.Router();

--- a/packages/api/routes/partApplicationRoutes.js
+++ b/packages/api/routes/partApplicationRoutes.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const db = require('../db');
 const { syncPartWithMeili } = require('../meilisearch');
+const { enqueuePartUpsert } = require('../services/meiliOutboxService');
 const { constructDisplayName } = require('../helpers/displayNameHelper');
 const router = express.Router();
 
@@ -128,7 +129,7 @@ router.post('/parts/:partId/applications', async (req, res) => {
     // Re-sync part with Meilisearch
     const partForMeili = await getPartDataForMeili(db, partId);
     if (partForMeili) {
-        syncPartWithMeili(partForMeili);
+        await enqueuePartUpsert(partForMeili.part_id, { source: 'partApplicationRoutes.create' });
     }
     
     res.status(201).json(result.rows[0]);
@@ -157,7 +158,7 @@ router.put('/part-applications/:partAppId', async (req, res) => {
         const partId = updatedLink.rows[0].part_id;
         const partForMeili = await getPartDataForMeili(db, partId);
         if (partForMeili) {
-            syncPartWithMeili(partForMeili);
+            await enqueuePartUpsert(partForMeili.part_id, { source: 'partApplicationRoutes.update' });
         }
 
         res.json(updatedLink.rows[0]);
@@ -183,7 +184,7 @@ router.delete('/parts/:partId/applications/:appId', async (req, res) => {
         // Re-sync part with Meilisearch
         const partForMeili = await getPartDataForMeili(db, partId);
         if (partForMeili) {
-            syncPartWithMeili(partForMeili);
+            await enqueuePartUpsert(partForMeili.part_id, { source: 'partApplicationRoutes.delete' });
         }
 
         res.json({ message: 'Application link deleted successfully.' });

--- a/packages/api/routes/partRoutes.js
+++ b/packages/api/routes/partRoutes.js
@@ -2,7 +2,8 @@ const express = require('express');
 const db = require('../db');
 const { constructDisplayName } = require('../helpers/displayNameHelper');
 const { protect, hasPermission } = require('../middleware/authMiddleware');
-const { syncPartWithMeili, removePartFromMeili, meiliClient } = require('../meilisearch');
+const { meiliClient } = require('../meilisearch');
+const { enqueuePartUpsert, enqueuePartDelete } = require('../services/meiliOutboxService');
 const { activeAliasCondition } = require('../helpers/partNumberSoftDelete');
 const { normalizePartData } = require('../helpers/normalizePart');
 const router = express.Router();
@@ -291,8 +292,8 @@ router.post('/parts', protect, hasPermission('parts:create'), async (req, res) =
         
         const partForMeili = await getPartDataForMeili(db, newPartData.part_id);
         if (partForMeili) {
-            // Sync to search and return enriched payload including display_name
-            syncPartWithMeili(partForMeili);
+            // Queue durable background sync and return enriched payload including display_name
+            await enqueuePartUpsert(partForMeili.part_id, { source: 'partRoutes.create' });
             return res.status(201).json(partForMeili);
         }
 
@@ -360,7 +361,7 @@ router.put('/parts/:id', protect, hasPermission('parts:edit'), async (req, res) 
 
         const partForMeili = await getPartDataForMeili(db, id);
         if (partForMeili) {
-            syncPartWithMeili(partForMeili);
+            await enqueuePartUpsert(partForMeili.part_id, { source: 'partRoutes.update' });
             return res.json(partForMeili);
         }
         
@@ -383,7 +384,7 @@ router.delete('/parts/:id', protect, hasPermission('parts:delete'), async (req, 
         if (deleteOp.rowCount === 0) {
             return res.status(404).json({ message: 'Part not found' });
         }
-        removePartFromMeili(id);
+        await enqueuePartDelete(id, { source: 'partRoutes.delete' });
         res.json({ message: 'Part deleted successfully' });
     } catch (err) {
         console.error(err.message);

--- a/packages/api/scripts/migrate.js
+++ b/packages/api/scripts/migrate.js
@@ -23,6 +23,7 @@ const argv = yargs
   .option('user', { type: 'string', describe: 'DB user' })
   .option('password', { type: 'string', describe: 'DB password' })
   .option('skip', { type: 'array', describe: 'Migration filename(s) to skip; can be repeated or comma-separated' })
+  .option('include-seeds', { type: 'boolean', default: false, describe: 'Include optional seed migrations (excluded by default)' })
   .option('dry-run', { type: 'boolean', default: false, describe: 'Print plan, do not execute' })
   .option('from', { type: 'string', describe: 'Start from migration (inclusive)' })
   .option('to', { type: 'string', describe: 'End at migration (inclusive)' })
@@ -30,6 +31,11 @@ const argv = yargs
   .argv;
 
 const CMD = argv._[0] || 'up';
+const OPTIONAL_SEED_MIGRATIONS = new Set([
+  // Seeds are intentionally excluded from normal migration runs to keep
+  // upgrades deterministic on already-initialized databases.
+  '20250821_seed_documents.sql',
+]);
 
 // Resolve repo root from this script
 const repoRoot = path.resolve(__dirname, '../../..');
@@ -81,7 +87,12 @@ function loadMigrations() {
   };
 
   const skipList = normalizeSkipList(argv.skip);
-  const filteredFiles = files.filter(f => !skipList.includes(f));
+  const includeSeeds = argv['include-seeds'] === true || process.env.MIGRATE_INCLUDE_SEEDS === 'true';
+  const filteredFiles = files.filter((f) => {
+    if (skipList.includes(f)) return false;
+    if (!includeSeeds && OPTIONAL_SEED_MIGRATIONS.has(f)) return false;
+    return true;
+  });
 
   const ensureMarkerExists = (name, type) => {
     if (!name) return;

--- a/packages/api/scripts/migrate.js
+++ b/packages/api/scripts/migrate.js
@@ -22,6 +22,7 @@ const argv = yargs
   .option('db', { type: 'string', describe: 'DB name' })
   .option('user', { type: 'string', describe: 'DB user' })
   .option('password', { type: 'string', describe: 'DB password' })
+  .option('skip', { type: 'array', describe: 'Migration filename(s) to skip; can be repeated or comma-separated' })
   .option('dry-run', { type: 'boolean', default: false, describe: 'Print plan, do not execute' })
   .option('from', { type: 'string', describe: 'Start from migration (inclusive)' })
   .option('to', { type: 'string', describe: 'End at migration (inclusive)' })
@@ -69,13 +70,39 @@ function loadMigrations() {
   const files = fs.readdirSync(migrationsDir)
     .filter(f => f.endsWith('.sql'))
     .sort();
+
+  const normalizeSkipList = (raw) => {
+    if (!raw) return [];
+    const values = Array.isArray(raw) ? raw : [raw];
+    return values
+      .flatMap(v => String(v).split(','))
+      .map(v => v.trim())
+      .filter(Boolean);
+  };
+
+  const skipList = normalizeSkipList(argv.skip);
+  const filteredFiles = files.filter(f => !skipList.includes(f));
+
+  const ensureMarkerExists = (name, type) => {
+    if (!name) return;
+    if (!filteredFiles.includes(name)) {
+      const reason = files.includes(name)
+        ? `${type} migration "${name}" is present but excluded by --skip`
+        : `${type} migration "${name}" was not found in ${migrationsDir}`;
+      throw new Error(reason);
+    }
+  };
+
+  ensureMarkerExists(argv.from, '--from');
+  ensureMarkerExists(argv.to, '--to');
+
   const slice = (list) => {
     let out = list;
     if (argv.from) out = out.slice(out.indexOf(argv.from));
     if (argv.to) out = out.slice(0, out.indexOf(argv.to) + 1);
     return out;
   };
-  return slice(files).map(f => {
+  return slice(filteredFiles).map(f => {
     const full = path.join(migrationsDir, f);
     const content = fs.readFileSync(full);
     return { name: f, full, content, checksum: sha256(content) };

--- a/packages/api/services/meiliOutboxService.js
+++ b/packages/api/services/meiliOutboxService.js
@@ -1,0 +1,38 @@
+const db = require('../db');
+
+const ACTIONS = Object.freeze({
+  UPSERT_PART: 'upsert_part',
+  DELETE_PART: 'delete_part'
+});
+
+const enqueueEvent = async (action, entityId, metadata = null) => {
+  if (!Object.values(ACTIONS).includes(action)) {
+    throw new Error(`Invalid meili outbox action: ${action}`);
+  }
+
+  const sql = `
+    INSERT INTO meili_sync_outbox (event_type, entity_type, entity_id, payload, status)
+    VALUES ($1, 'part', $2, $3::jsonb, 'pending')
+    RETURNING outbox_id
+  `;
+
+  const payload = metadata ? JSON.stringify(metadata) : null;
+  const { rows } = await db.query(sql, [action, entityId, payload]);
+  return rows[0]?.outbox_id;
+};
+
+const enqueuePartUpsert = async (partId, metadata = null) => {
+  if (!partId) return null;
+  return enqueueEvent(ACTIONS.UPSERT_PART, partId, metadata);
+};
+
+const enqueuePartDelete = async (partId, metadata = null) => {
+  if (!partId) return null;
+  return enqueueEvent(ACTIONS.DELETE_PART, partId, metadata);
+};
+
+module.exports = {
+  ACTIONS,
+  enqueuePartUpsert,
+  enqueuePartDelete,
+};


### PR DESCRIPTION
### Motivation

- Provide a durable, retryable outbox for Meilisearch synchronization to avoid lost updates and reduce coupling between API requests and search indexing. 
- Move immediate synchronous `syncPartWithMeili`/`removePartFromMeili` calls into background processing to improve request latency and reliability. 
- Allow phased migration by keeping legacy `LISTEN/NOTIFY` listeners opt-in while enabling the new outbox worker by default.

### Description

- Add SQL migration `20260415_add_meili_sync_outbox.sql` to create the `meili_sync_outbox` table with indexes and status/lease semantics for claiming and retrying events. 
- Introduce `packages/api/meili-outbox-worker.js` implementing a poll/claim/lease worker with batching, retry/backoff, marking `done`/`dead`, metrics logging, and graceful shutdown, and export `startMeiliOutboxWorker` and `processBatch`. 
- Add `packages/api/services/meiliOutboxService.js` to provide `enqueuePartUpsert` and `enqueuePartDelete` helper functions that insert outbox rows. 
- Replace direct Meili sync calls in `packages/api/routes/partRoutes.js` and `packages/api/routes/partApplicationRoutes.js` with enqueuing via `enqueuePartUpsert`/`enqueuePartDelete` to push durable events. 
- Wire the outbox worker into server startup in `packages/api/index.js`, starting the worker by default and making legacy `LISTEN/NOTIFY` listeners opt-in via `ENABLE_LEGACY_MEILI_LISTENERS`; add env toggle `DISABLE_MEILI_OUTBOX_WORKER` to disable the worker. 

### Testing

- No automated tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df1e4427a08332b84e543cee203c83)