### PR TITLE
Async search repair jobs: background worker, progress UI, cancel and nightly reconciliation

### DIFF
--- a/database/migrations/20260416_create_search_repair_jobs.sql
+++ b/database/migrations/20260416_create_search_repair_jobs.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS search_repair_jobs (
+  job_id BIGSERIAL PRIMARY KEY,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'completed', 'failed', 'cancelled', 'cancelling')),
+  mode TEXT NOT NULL DEFAULT 'full' CHECK (mode IN ('dry', 'full', 'reconcile')),
+  created_by TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  started_at TIMESTAMPTZ,
+  finished_at TIMESTAMPTZ,
+  total INTEGER NOT NULL DEFAULT 0,
+  processed INTEGER NOT NULL DEFAULT 0,
+  success INTEGER NOT NULL DEFAULT 0,
+  failed INTEGER NOT NULL DEFAULT 0,
+  error TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_search_repair_jobs_poll
+  ON search_repair_jobs (status, created_at);

--- a/packages/api/index.js
+++ b/packages/api/index.js
@@ -6,6 +6,7 @@ const { setupMeiliSearch } = require('./meilisearch-setup');
 const { startMeiliListener } = require('./meili-listener');
 const { startMeiliApplicationsListener } = require('./meili-app-listener');
 const { startMeiliOutboxWorker } = require('./meili-outbox-worker');
+const { startSearchRepairWorker } = require('./search-repair-worker');
 
 // Set default timezone to Philippine Time
 process.env.TZ = 'Asia/Manila';
@@ -138,6 +139,13 @@ app.listen(PORT, async () => {
     startMeiliOutboxWorker();
   } else {
     console.log('Meili outbox worker disabled by DISABLE_MEILI_OUTBOX_WORKER=true');
+  }
+
+
+  if (process.env.DISABLE_SEARCH_REPAIR_WORKER !== 'true') {
+    startSearchRepairWorker();
+  } else {
+    console.log('Search repair worker disabled by DISABLE_SEARCH_REPAIR_WORKER=true');
   }
 
   // Keep applications listener enabled by default so the `applications` Meilisearch index

--- a/packages/api/routes/dataUtilsRoutes.js
+++ b/packages/api/routes/dataUtilsRoutes.js
@@ -247,77 +247,80 @@ router.get('/sync-parts-to-meili', protect, isAdmin, async (req, res) => {
     }
 });
 
-module.exports = router;
+// --- NEW: Repair search // Search repair index jobs (async)
+const {
+    JOB_MODES,
+    createRepairJob,
+    fetchJobStatusPayload,
+    cancelRepairJob
+} = require('../search-repair-worker');
 
-// --- NEW: Repair search index (apply settings + full reindex) ---
 // POST /api/data/repair-search-index?mode=dry|full
-// Modes:
-// - dry: Check connectivity, count parts, verify permissions (no changes).
-// - full: Apply Meili settings and fully reindex parts.
 router.post('/repair-search-index', protect, isAdmin, async (req, res) => {
-    const { mode = 'full' } = req.query;
-    if (!['dry', 'full'].includes(mode)) {
+    const { mode = JOB_MODES.FULL } = req.query;
+    if (![JOB_MODES.DRY, JOB_MODES.FULL].includes(mode)) {
         return res.status(400).json({ message: 'Invalid mode. Use mode=dry or mode=full.' });
     }
 
     try {
-        console.log(`[RepairSearch] Starting mode=${mode}...`);
+        const createdBy = req.user?.username || req.user?.user || req.user?.employee_id || 'unknown-admin';
+        const job = await createRepairJob({ mode, createdBy: String(createdBy) });
 
-        // Always check part count
-        const idsRes = await db.query('SELECT COUNT(*) as count FROM part');
-        const partCount = parseInt(idsRes.rows[0].count, 10);
-        console.log(`[RepairSearch] Found ${partCount} parts.`);
-
-        if (mode === 'dry') {
-            // Dry-run: just return info without changes
-            return res.status(200).json({
-                message: `Dry-run complete. Found ${partCount} parts. No changes made.`,
-                partCount,
-                mode: 'dry'
-            });
-        }
-
-        // Full mode: apply settings and reindex
-        console.log('[RepairSearch] Applying Meilisearch settings...');
-        await setupMeiliSearch();
-
-        console.log('[RepairSearch] Fetching all part IDs for reindex...');
-        const idsQueryRes = await db.query('SELECT part_id FROM part ORDER BY part_id ASC');
-        const ids = idsQueryRes.rows.map(r => r.part_id);
-        if (ids.length === 0) {
-            return res.status(200).json({ message: 'No parts found. Meilisearch settings applied.' });
-        }
-
-        let success = 0; let skipped = 0; let failed = 0;
-        const batchSize = 500;
-        let batch = [];
-
-        console.log(`[RepairSearch] Reindexing ${ids.length} parts in batches of ${batchSize}...`);
-        for (const id of ids) {
-            try {
-                const doc = await getPartDataForMeili(db, id);
-                if (doc) { batch.push(doc); success++; } else { skipped++; }
-            } catch (e) {
-                failed++;
-                console.error(`[RepairSearch] Failed to build document for part ${id}:`, e && e.message ? e.message : e);
-            }
-
-            if (batch.length >= batchSize) {
-                await syncPartWithMeili(batch);
-                batch = [];
-            }
-        }
-        if (batch.length > 0) {
-            await syncPartWithMeili(batch);
-        }
-
-        console.log(`[RepairSearch] Reindex complete. success=${success} skipped=${skipped} failed=${failed}`);
-        return res.status(200).json({
-            message: `Search index repaired. Reindexed ${success} parts. Skipped ${skipped}. Failed ${failed}.`,
-            reindexed: success, skipped, failed, partCount, mode: 'full'
+        return res.status(202).json({
+            message: 'Repair job accepted and queued.',
+            job_id: job.job_id,
+            status: job.status,
+            mode: job.mode,
+            created_at: job.created_at
         });
     } catch (error) {
-        console.error('[RepairSearch] Fatal error:', error);
-        return res.status(500).json({ message: 'Failed to repair search index.', error: error && error.message ? error.message : String(error) });
+        console.error('[RepairSearch] failed to enqueue:', error);
+        return res.status(500).json({ message: 'Failed to enqueue repair job.', error: error?.message || String(error) });
     }
 });
+
+// GET /api/data/repair-search-index/:job_id
+router.get('/repair-search-index/:job_id', protect, isAdmin, async (req, res) => {
+    try {
+        const jobId = Number(req.params.job_id);
+        if (!Number.isInteger(jobId) || jobId <= 0) {
+            return res.status(400).json({ message: 'Invalid job_id.' });
+        }
+
+        const job = await fetchJobStatusPayload(jobId);
+        if (!job) {
+            return res.status(404).json({ message: 'Repair job not found.' });
+        }
+
+        return res.status(200).json(job);
+    } catch (error) {
+        console.error('[RepairSearch] failed to fetch job status:', error);
+        return res.status(500).json({ message: 'Failed to fetch repair job status.', error: error?.message || String(error) });
+    }
+});
+
+// POST /api/data/repair-search-index/:job_id/cancel
+router.post('/repair-search-index/:job_id/cancel', protect, isAdmin, async (req, res) => {
+    try {
+        const jobId = Number(req.params.job_id);
+        if (!Number.isInteger(jobId) || jobId <= 0) {
+            return res.status(400).json({ message: 'Invalid job_id.' });
+        }
+
+        const job = await cancelRepairJob(jobId);
+        if (!job) {
+            return res.status(404).json({ message: 'Repair job not found.' });
+        }
+
+        return res.status(200).json({
+            message: job.status === 'cancelling' ? 'Cancellation requested.' : 'Job cancelled.',
+            job_id: job.job_id,
+            status: job.status
+        });
+    } catch (error) {
+        console.error('[RepairSearch] failed to cancel job:', error);
+        return res.status(500).json({ message: 'Failed to cancel repair job.', error: error?.message || String(error) });
+    }
+});
+
+module.exports = router;

--- a/packages/api/search-repair-worker.js
+++ b/packages/api/search-repair-worker.js
@@ -1,0 +1,353 @@
+const db = require('./db');
+const { meiliClient, syncPartWithMeili } = require('./meilisearch');
+const { setupMeiliSearch } = require('./meilisearch-setup');
+const { getPartDataForMeili } = require('./routes/partRoutes');
+
+const JOB_STATUS = Object.freeze({
+  PENDING: 'pending',
+  PROCESSING: 'processing',
+  COMPLETED: 'completed',
+  FAILED: 'failed',
+  CANCELLED: 'cancelled',
+  CANCELLING: 'cancelling'
+});
+
+const JOB_MODES = Object.freeze({
+  DRY: 'dry',
+  FULL: 'full',
+  RECONCILE: 'reconcile'
+});
+
+const DEFAULTS = Object.freeze({
+  pollMs: Number(process.env.SEARCH_REPAIR_POLL_MS || 2000),
+  batchSize: Number(process.env.SEARCH_REPAIR_BATCH_SIZE || 250),
+  progressEvery: Number(process.env.SEARCH_REPAIR_PROGRESS_EVERY || 100),
+  reconcileDriftThresholdAbs: Number(process.env.SEARCH_REPAIR_DRIFT_THRESHOLD_ABS || 25),
+  reconcileDriftThresholdPct: Number(process.env.SEARCH_REPAIR_DRIFT_THRESHOLD_PCT || 0.02),
+  reconcileSampleSize: Number(process.env.SEARCH_REPAIR_RECONCILE_SAMPLE_SIZE || 50)
+});
+
+const createRepairJob = async ({ mode = JOB_MODES.FULL, createdBy = null }) => {
+  const { rows } = await db.query(
+    `INSERT INTO search_repair_jobs (mode, created_by, status)
+     VALUES ($1, $2, $3)
+     RETURNING *`,
+    [mode, createdBy, JOB_STATUS.PENDING]
+  );
+  return rows[0];
+};
+
+const getRepairJob = async (jobId) => {
+  const { rows } = await db.query('SELECT * FROM search_repair_jobs WHERE job_id = $1', [jobId]);
+  return rows[0] || null;
+};
+
+const cancelRepairJob = async (jobId) => {
+  const { rows } = await db.query(
+    `UPDATE search_repair_jobs
+     SET status = CASE
+       WHEN status = $2 THEN $3
+       WHEN status = $4 THEN $5
+       ELSE status
+     END,
+     finished_at = CASE WHEN status = $4 THEN NOW() ELSE finished_at END,
+     error = CASE WHEN status = $4 THEN 'Cancelled by user before processing.' ELSE error END
+     WHERE job_id = $1
+     RETURNING *`,
+    [jobId, JOB_STATUS.PROCESSING, JOB_STATUS.CANCELLING, JOB_STATUS.PENDING, JOB_STATUS.CANCELLED]
+  );
+
+  return rows[0] || null;
+};
+
+const estimateRemainingSeconds = (job) => {
+  if (!job || !job.started_at || !job.total || !job.processed) return null;
+  const started = new Date(job.started_at).getTime();
+  const elapsed = Math.max(1, (Date.now() - started) / 1000);
+  const rate = job.processed / elapsed;
+  if (!rate || rate <= 0) return null;
+  return Math.max(0, Math.ceil((job.total - job.processed) / rate));
+};
+
+const fetchJobStatusPayload = async (jobId) => {
+  const job = await getRepairJob(jobId);
+  if (!job) return null;
+
+  const percent = job.total > 0 ? Number(((job.processed / job.total) * 100).toFixed(2)) : 0;
+  return {
+    ...job,
+    progress_pct: percent,
+    estimated_remaining_seconds: estimateRemainingSeconds(job)
+  };
+};
+
+const claimNextPendingJob = async () => {
+  const client = await db.getClient();
+  try {
+    await client.query('BEGIN');
+    const { rows } = await client.query(
+      `WITH candidate AS (
+        SELECT job_id
+        FROM search_repair_jobs
+        WHERE status = $1
+        ORDER BY created_at ASC
+        LIMIT 1
+        FOR UPDATE SKIP LOCKED
+      )
+      UPDATE search_repair_jobs j
+      SET status = $2,
+          started_at = NOW(),
+          error = NULL
+      FROM candidate c
+      WHERE j.job_id = c.job_id
+      RETURNING j.*`,
+      [JOB_STATUS.PENDING, JOB_STATUS.PROCESSING]
+    );
+    await client.query('COMMIT');
+    return rows[0] || null;
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+};
+
+const persistProgress = async ({ jobId, processed, success, failed, total }) => {
+  await db.query(
+    `UPDATE search_repair_jobs
+     SET processed = $2,
+         success = $3,
+         failed = $4,
+         total = $5
+     WHERE job_id = $1`,
+    [jobId, processed, success, failed, total]
+  );
+};
+
+const hasCancellationRequested = async (jobId) => {
+  const { rows } = await db.query('SELECT status FROM search_repair_jobs WHERE job_id = $1', [jobId]);
+  if (!rows[0]) return true;
+  return rows[0].status === JOB_STATUS.CANCELLING;
+};
+
+const finishJob = async (jobId, status, fields = {}) => {
+  await db.query(
+    `UPDATE search_repair_jobs
+     SET status = $2,
+         finished_at = NOW(),
+         processed = COALESCE($3, processed),
+         success = COALESCE($4, success),
+         failed = COALESCE($5, failed),
+         total = COALESCE($6, total),
+         error = $7
+     WHERE job_id = $1`,
+    [jobId, status, fields.processed ?? null, fields.success ?? null, fields.failed ?? null, fields.total ?? null, fields.error || null]
+  );
+};
+
+const getPartIds = async () => {
+  const { rows } = await db.query('SELECT part_id FROM part ORDER BY part_id ASC');
+  return rows.map((row) => row.part_id);
+};
+
+const processRepairJob = async (job, config) => {
+  const jobId = job.job_id;
+  const mode = job.mode;
+
+  try {
+    const idsRes = await db.query('SELECT COUNT(*)::int AS count FROM part');
+    const total = idsRes.rows[0].count || 0;
+
+    if (mode === JOB_MODES.DRY) {
+      await finishJob(jobId, JOB_STATUS.COMPLETED, {
+        processed: total,
+        success: total,
+        failed: 0,
+        total,
+        error: null
+      });
+      return;
+    }
+
+    await db.query('UPDATE search_repair_jobs SET total = $2 WHERE job_id = $1', [jobId, total]);
+
+    await setupMeiliSearch();
+
+    const ids = await getPartIds();
+
+    let processed = 0;
+    let success = 0;
+    let failed = 0;
+    let payload = [];
+
+    for (const id of ids) {
+      if (await hasCancellationRequested(jobId)) {
+        await finishJob(jobId, JOB_STATUS.CANCELLED, {
+          processed,
+          success,
+          failed,
+          total,
+          error: 'Cancelled by user.'
+        });
+        return;
+      }
+
+      try {
+        const doc = await getPartDataForMeili(db, id);
+        if (doc) {
+          payload.push(doc);
+          success += 1;
+        }
+      } catch (error) {
+        failed += 1;
+      }
+
+      processed += 1;
+
+      if (payload.length >= config.batchSize) {
+        await syncPartWithMeili(payload);
+        payload = [];
+      }
+
+      if (processed % config.progressEvery === 0) {
+        await persistProgress({ jobId, processed, success, failed, total });
+      }
+    }
+
+    if (payload.length > 0) {
+      await syncPartWithMeili(payload);
+    }
+
+    await finishJob(jobId, JOB_STATUS.COMPLETED, {
+      processed,
+      success,
+      failed,
+      total,
+      error: null
+    });
+  } catch (error) {
+    await finishJob(jobId, JOB_STATUS.FAILED, {
+      error: error && error.message ? error.message : String(error)
+    });
+  }
+};
+
+const samplePartIds = async (sampleSize) => {
+  const { rows } = await db.query(
+    `SELECT part_id
+     FROM part
+     ORDER BY RANDOM()
+     LIMIT $1`,
+    [sampleSize]
+  );
+  return rows.map((row) => row.part_id);
+};
+
+const runNightlyReconciliation = async (config = DEFAULTS) => {
+  const [{ rows: dbRows }, { rows: meiliRows }] = await Promise.all([
+    db.query('SELECT COUNT(*)::int AS count FROM part'),
+    meiliClient.index('parts').getStats().then((stats) => ({ rows: [{ count: stats.numberOfDocuments || 0 }] }))
+  ]);
+
+  const dbCount = dbRows[0].count || 0;
+  const indexedCount = meiliRows[0].count || 0;
+  const absDrift = Math.abs(dbCount - indexedCount);
+  const pctDrift = dbCount > 0 ? absDrift / dbCount : 0;
+
+  let missingFromIndex = 0;
+  const sampleIds = await samplePartIds(Math.min(config.reconcileSampleSize, Math.max(5, dbCount)));
+
+  for (const partId of sampleIds) {
+    try {
+      await meiliClient.index('parts').getDocument(partId);
+    } catch (_error) {
+      missingFromIndex += 1;
+    }
+  }
+
+  const sampleMismatchRate = sampleIds.length > 0 ? missingFromIndex / sampleIds.length : 0;
+  const shouldOpenRepair = absDrift >= config.reconcileDriftThresholdAbs
+    || pctDrift >= config.reconcileDriftThresholdPct
+    || sampleMismatchRate >= 0.1;
+
+  if (!shouldOpenRepair) {
+    return { dbCount, indexedCount, absDrift, pctDrift, sampleMismatchRate, openedJob: false };
+  }
+
+  const activeRes = await db.query(
+    `SELECT job_id
+     FROM search_repair_jobs
+     WHERE status IN ($1, $2)
+     ORDER BY created_at DESC
+     LIMIT 1`,
+    [JOB_STATUS.PENDING, JOB_STATUS.PROCESSING]
+  );
+
+  if (activeRes.rows.length > 0) {
+    return { dbCount, indexedCount, absDrift, pctDrift, sampleMismatchRate, openedJob: false, reason: 'active job exists' };
+  }
+
+  await createRepairJob({ mode: JOB_MODES.RECONCILE, createdBy: 'system:nightly-reconciliation' });
+  return { dbCount, indexedCount, absDrift, pctDrift, sampleMismatchRate, openedJob: true };
+};
+
+const startSearchRepairWorker = (options = {}) => {
+  const config = { ...DEFAULTS, ...options };
+  let running = false;
+
+  const tick = async () => {
+    if (running) return;
+    running = true;
+    try {
+      const job = await claimNextPendingJob();
+      if (!job) return;
+      console.log('[SearchRepair] picked job', job.job_id, job.mode);
+      await processRepairJob(job, config);
+    } catch (error) {
+      console.error('[SearchRepair] worker tick failed:', error && error.stack ? error.stack : error);
+    } finally {
+      running = false;
+    }
+  };
+
+  const timer = setInterval(tick, config.pollMs);
+  tick();
+
+  const scheduleNightly = () => {
+    const now = new Date();
+    const next = new Date(now);
+    next.setHours(24, 0, 0, 0);
+    const delay = next.getTime() - now.getTime();
+
+    setTimeout(async () => {
+      try {
+        const result = await runNightlyReconciliation(config);
+        console.log('[SearchRepair] nightly reconciliation:', result);
+      } catch (error) {
+        console.error('[SearchRepair] nightly reconciliation failed:', error && error.message ? error.message : error);
+      } finally {
+        scheduleNightly();
+      }
+    }, delay);
+  };
+
+  scheduleNightly();
+
+  console.log('[SearchRepair] worker started', config);
+
+  return {
+    stop: () => clearInterval(timer)
+  };
+};
+
+module.exports = {
+  JOB_MODES,
+  JOB_STATUS,
+  createRepairJob,
+  getRepairJob,
+  cancelRepairJob,
+  fetchJobStatusPayload,
+  startSearchRepairWorker,
+  runNightlyReconciliation
+};

--- a/packages/api/search-repair-worker.js
+++ b/packages/api/search-repair-worker.js
@@ -27,7 +27,43 @@ const DEFAULTS = Object.freeze({
   reconcileSampleSize: Number(process.env.SEARCH_REPAIR_RECONCILE_SAMPLE_SIZE || 50)
 });
 
+let schemaReadyPromise = null;
+
+const ensureSearchRepairSchema = async () => {
+  if (!schemaReadyPromise) {
+    schemaReadyPromise = (async () => {
+      await db.query(
+        `CREATE TABLE IF NOT EXISTS search_repair_jobs (
+          job_id BIGSERIAL PRIMARY KEY,
+          status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'completed', 'failed', 'cancelled', 'cancelling')),
+          mode TEXT NOT NULL DEFAULT 'full' CHECK (mode IN ('dry', 'full', 'reconcile')),
+          created_by TEXT,
+          created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+          started_at TIMESTAMPTZ,
+          finished_at TIMESTAMPTZ,
+          total INTEGER NOT NULL DEFAULT 0,
+          processed INTEGER NOT NULL DEFAULT 0,
+          success INTEGER NOT NULL DEFAULT 0,
+          failed INTEGER NOT NULL DEFAULT 0,
+          error TEXT
+        )`
+      );
+
+      await db.query(
+        `CREATE INDEX IF NOT EXISTS idx_search_repair_jobs_poll
+         ON search_repair_jobs (status, created_at)`
+      );
+    })().catch((error) => {
+      schemaReadyPromise = null;
+      throw error;
+    });
+  }
+
+  return schemaReadyPromise;
+};
+
 const createRepairJob = async ({ mode = JOB_MODES.FULL, createdBy = null }) => {
+  await ensureSearchRepairSchema();
   const { rows } = await db.query(
     `INSERT INTO search_repair_jobs (mode, created_by, status)
      VALUES ($1, $2, $3)
@@ -38,11 +74,13 @@ const createRepairJob = async ({ mode = JOB_MODES.FULL, createdBy = null }) => {
 };
 
 const getRepairJob = async (jobId) => {
+  await ensureSearchRepairSchema();
   const { rows } = await db.query('SELECT * FROM search_repair_jobs WHERE job_id = $1', [jobId]);
   return rows[0] || null;
 };
 
 const cancelRepairJob = async (jobId) => {
+  await ensureSearchRepairSchema();
   const { rows } = await db.query(
     `UPDATE search_repair_jobs
      SET status = CASE
@@ -82,6 +120,7 @@ const fetchJobStatusPayload = async (jobId) => {
 };
 
 const claimNextPendingJob = async () => {
+  await ensureSearchRepairSchema();
   const client = await db.getClient();
   try {
     await client.query('BEGIN');
@@ -245,6 +284,7 @@ const samplePartIds = async (sampleSize) => {
 };
 
 const runNightlyReconciliation = async (config = DEFAULTS) => {
+  await ensureSearchRepairSchema();
   const [{ rows: dbRows }, { rows: meiliRows }] = await Promise.all([
     db.query('SELECT COUNT(*)::int AS count FROM part'),
     meiliClient.index('parts').getStats().then((stats) => ({ rows: [{ count: stats.numberOfDocuments || 0 }] }))

--- a/packages/web/src/components/settings/DataUtilsSettings.jsx
+++ b/packages/web/src/components/settings/DataUtilsSettings.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-unused-vars */
-import { useState, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import api from '../../api';
 import toast from 'react-hot-toast';
 import { format } from 'date-fns';
@@ -10,7 +10,7 @@ const ExportCard = ({ entity, title, fields }) => {
     const handleExport = async () => {
         try {
             const response = await api.get(`/data/export/${entity}`, {
-                responseType: 'blob', // Important for file downloads
+                responseType: 'blob',
             });
             const url = window.URL.createObjectURL(new Blob([response.data]));
             const link = document.createElement('a');
@@ -25,7 +25,7 @@ const ExportCard = ({ entity, title, fields }) => {
             console.error(error);
         }
     };
-    
+
     const handleDownloadTemplate = () => {
         const csvHeader = fields.join(',');
         const blob = new Blob([csvHeader], { type: 'text/csv;charset=utf-8;' });
@@ -81,7 +81,7 @@ const ImportCard = ({ entity, title }) => {
                 if (fileInputRef.current) {
                     fileInputRef.current.value = '';
                 }
-                return res.data.message; // Display the detailed message from the backend
+                return res.data.message;
             },
             error: (err) => {
                 setIsUploading(false);
@@ -115,34 +115,98 @@ const ImportCard = ({ entity, title }) => {
     );
 };
 
+const formatEta = (seconds) => {
+    if (seconds == null) return 'Estimating…';
+    if (seconds <= 60) return `${seconds}s remaining`;
+    const minutes = Math.ceil(seconds / 60);
+    if (minutes < 60) return `${minutes}m remaining`;
+    const hours = Math.floor(minutes / 60);
+    const remainingMinutes = minutes % 60;
+    return `${hours}h ${remainingMinutes}m remaining`;
+};
+
+const TERMINAL_STATUSES = ['completed', 'failed', 'cancelled'];
 
 const DataUtilsSettings = () => {
-    const [isSyncing, setIsSyncing] = useState(false);
     const [showConfirmModal, setShowConfirmModal] = useState(false);
+    const [showProgressModal, setShowProgressModal] = useState(false);
     const [selectedMode, setSelectedMode] = useState('full');
+    const [activeJobId, setActiveJobId] = useState(null);
+    const [jobStatus, setJobStatus] = useState(null);
+    const [isCancelling, setIsCancelling] = useState(false);
 
-    const handleSync = () => {
-        setIsSyncing(true);
-        const promise = api.post(`/data/repair-search-index?mode=${selectedMode}`);
+    const isSyncing = useMemo(() => {
+        if (!jobStatus) return false;
+        return ['pending', 'processing', 'cancelling'].includes(jobStatus.status);
+    }, [jobStatus]);
 
-        toast.promise(promise, {
-            loading: selectedMode === 'dry' ? 'Running dry-run check...' : 'Repairing search index (apply settings + sync parts)...',
-            success: (res) => {
-                setIsSyncing(false);
-                setShowConfirmModal(false);
-                return res.data.message || 'Operation completed successfully!';
-            },
-            error: (err) => {
-                setIsSyncing(false);
-                setShowConfirmModal(false);
-                return err.response?.data?.message || 'Failed to repair search index.';
+    useEffect(() => {
+        if (!activeJobId) return undefined;
+
+        let mounted = true;
+        let timer;
+
+        const poll = async () => {
+            try {
+                const res = await api.get(`/data/repair-search-index/${activeJobId}`);
+                if (!mounted) return;
+                setJobStatus(res.data);
+
+                if (TERMINAL_STATUSES.includes(res.data.status)) {
+                    if (res.data.status === 'completed') {
+                        toast.success('Search repair completed successfully.');
+                    } else if (res.data.status === 'failed') {
+                        toast.error(res.data.error || 'Search repair failed.');
+                    } else if (res.data.status === 'cancelled') {
+                        toast('Search repair cancelled.');
+                    }
+                    return;
+                }
+            } catch (err) {
+                if (!mounted) return;
+                toast.error(err.response?.data?.message || 'Failed to load repair progress.');
             }
-        });
+
+            timer = setTimeout(poll, 3000);
+        };
+
+        poll();
+
+        return () => {
+            mounted = false;
+            if (timer) clearTimeout(timer);
+        };
+    }, [activeJobId]);
+
+    const handleStartRepair = async () => {
+        try {
+            const res = await api.post(`/data/repair-search-index?mode=${selectedMode}`);
+            setShowConfirmModal(false);
+            setActiveJobId(res.data.job_id);
+            setShowProgressModal(true);
+            toast.success(`Repair job #${res.data.job_id} queued.`);
+        } catch (err) {
+            toast.error(err.response?.data?.message || 'Failed to enqueue repair job.');
+        }
     };
 
-    const handleConfirm = () => {
-        handleSync();
+    const handleCancelJob = async () => {
+        if (!activeJobId) return;
+        try {
+            setIsCancelling(true);
+            const res = await api.post(`/data/repair-search-index/${activeJobId}/cancel`);
+            toast.success(res.data.message || 'Cancellation requested.');
+            const statusRes = await api.get(`/data/repair-search-index/${activeJobId}`);
+            setJobStatus(statusRes.data);
+        } catch (err) {
+            toast.error(err.response?.data?.message || 'Failed to cancel repair job.');
+        } finally {
+            setIsCancelling(false);
+        }
     };
+
+    const progressPct = jobStatus?.progress_pct || 0;
+    const canRetry = TERMINAL_STATUSES.includes(jobStatus?.status) && jobStatus?.status !== 'processing';
 
     return (
         <div className="space-y-8">
@@ -158,7 +222,7 @@ const DataUtilsSettings = () => {
 
             <div>
                 <h3 className="text-lg font-medium text-gray-900">Import Data</h3>
-                 <div className="p-3 bg-yellow-50 border border-yellow-200 rounded-lg text-sm text-yellow-800 mt-2">
+                <div className="p-3 bg-yellow-50 border border-yellow-200 rounded-lg text-sm text-yellow-800 mt-2">
                     <strong>Warning:</strong> Importing a file will update existing records that match the unique key (e.g., SKU, Email) and create new records for those that don't. Please use the templates provided.
                 </div>
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-4">
@@ -171,21 +235,31 @@ const DataUtilsSettings = () => {
             <div>
                 <h3 className="text-lg font-medium text-gray-900">Search Index</h3>
                 <div className="p-4 border rounded-lg mt-4">
-                    <p className="text-sm text-gray-600 mb-3">Fix search issues by applying index settings and re-syncing all parts to Meilisearch.</p>
-                    <button
-                        onClick={() => setShowConfirmModal(true)}
-                        disabled={isSyncing}
-                        className="bg-purple-600 text-white px-4 py-2 rounded-lg font-semibold hover:bg-purple-700 transition disabled:bg-purple-300"
-                    >
-                        {isSyncing ? 'Processing...' : 'Repair Search Index'}
-                    </button>
+                    <p className="text-sm text-gray-600 mb-3">Repair search index via background jobs with live progress tracking and cancellation.</p>
+                    <div className="flex gap-2">
+                        <button
+                            onClick={() => setShowConfirmModal(true)}
+                            disabled={isSyncing}
+                            className="bg-purple-600 text-white px-4 py-2 rounded-lg font-semibold hover:bg-purple-700 transition disabled:bg-purple-300"
+                        >
+                            {isSyncing ? 'Processing...' : 'Repair Search Index'}
+                        </button>
+                        {activeJobId && (
+                            <button
+                                onClick={() => setShowProgressModal(true)}
+                                className="bg-gray-200 text-gray-800 px-4 py-2 rounded-lg font-semibold hover:bg-gray-300"
+                            >
+                                View Progress
+                            </button>
+                        )}
+                    </div>
                 </div>
             </div>
 
             <Modal isOpen={showConfirmModal} onClose={() => setShowConfirmModal(false)} title="Confirm Search Index Repair">
                 <div className="space-y-4">
                     <p className="text-sm text-gray-600">
-                        This will repair the search index by applying settings and re-syncing parts. Choose the mode:
+                        This runs a background repair job. You can monitor progress and cancel it at any time.
                     </p>
                     <div className="space-y-2">
                         <label className="flex items-center">
@@ -196,7 +270,7 @@ const DataUtilsSettings = () => {
                                 onChange={(e) => setSelectedMode(e.target.value)}
                                 className="mr-2"
                             />
-                            <span className="text-sm">Dry-run: Check connectivity and count parts (no changes)</span>
+                            <span className="text-sm">Dry-run: Check connectivity and counts only</span>
                         </label>
                         <label className="flex items-center">
                             <input
@@ -214,16 +288,68 @@ const DataUtilsSettings = () => {
                             onClick={() => setShowConfirmModal(false)}
                             className="px-4 py-2 bg-gray-200 text-gray-800 rounded-lg"
                         >
-                            Cancel
+                            Close
                         </button>
                         <button
-                            onClick={handleConfirm}
+                            onClick={handleStartRepair}
                             className="px-4 py-2 bg-purple-600 text-white rounded-lg"
                         >
-                            {selectedMode === 'dry' ? 'Run Dry-run' : 'Start Repair'}
+                            {selectedMode === 'dry' ? 'Queue Dry-run' : 'Queue Repair'}
                         </button>
                     </div>
                 </div>
+            </Modal>
+
+            <Modal
+                isOpen={showProgressModal}
+                onClose={() => setShowProgressModal(false)}
+                title={`Search Repair Progress${activeJobId ? ` #${activeJobId}` : ''}`}
+                maxWidth="max-w-xl"
+            >
+                {!jobStatus && <p className="text-sm text-gray-600">Waiting for status...</p>}
+                {jobStatus && (
+                    <div className="space-y-4">
+                        <div>
+                            <div className="flex justify-between text-sm text-gray-600 mb-1">
+                                <span>Status: <strong className="capitalize">{jobStatus.status}</strong></span>
+                                <span>{progressPct}%</span>
+                            </div>
+                            <div className="w-full h-2 bg-gray-200 rounded">
+                                <div className="h-2 bg-purple-600 rounded" style={{ width: `${Math.min(100, progressPct)}%` }} />
+                            </div>
+                        </div>
+                        <div className="grid grid-cols-2 gap-2 text-sm">
+                            <p>Total: <strong>{jobStatus.total}</strong></p>
+                            <p>Processed: <strong>{jobStatus.processed}</strong></p>
+                            <p>Success: <strong>{jobStatus.success}</strong></p>
+                            <p>Failed: <strong>{jobStatus.failed}</strong></p>
+                        </div>
+                        <p className="text-sm text-gray-600">ETA: {formatEta(jobStatus.estimated_remaining_seconds)}</p>
+                        {jobStatus.error && <p className="text-sm text-red-600">{jobStatus.error}</p>}
+                        <div className="flex justify-end gap-2">
+                            {isSyncing && (
+                                <button
+                                    onClick={handleCancelJob}
+                                    disabled={isCancelling}
+                                    className="px-3 py-2 bg-red-600 text-white rounded-lg disabled:bg-red-300"
+                                >
+                                    {isCancelling ? 'Cancelling...' : 'Cancel Job'}
+                                </button>
+                            )}
+                            {canRetry && (
+                                <button
+                                    onClick={() => {
+                                        setShowProgressModal(false);
+                                        setShowConfirmModal(true);
+                                    }}
+                                    className="px-3 py-2 bg-purple-600 text-white rounded-lg"
+                                >
+                                    Retry Repair
+                                </button>
+                            )}
+                        </div>
+                    </div>
+                )}
             </Modal>
         </div>
     );


### PR DESCRIPTION
### Motivation
- The existing `/repair-search-index` endpoint performed a full Meilisearch setup and reindex synchronously inside one HTTP request, which is fragile for large datasets and prone to timeouts. 
- Move repair into a durable, observable background job with progress, cancellation and automated reconciliation to make long-running reindexes reliable and user-friendly.

### Description
- Added `search_repair_jobs` migration/table with fields `job_id, status, mode, created_by, created_at, started_at, finished_at, total, processed, success, failed, error` and a polling index. 
- Implemented `packages/api/search-repair-worker.js` which provides job helpers (`createRepairJob`, `getRepairJob`, `cancelRepairJob`, `fetchJobStatusPayload`), a claim/worker loop that processes in batches, persists progress every N rows, supports cooperative cancellation, and includes nightly reconciliation logic that auto-enqueues a reconcile job when drift thresholds are exceeded. 
- Converted the repair API to async: `POST /api/data/repair-search-index` now enqueues and returns `202 + job_id`, `GET /api/data/repair-search-index/:job_id` returns progress/ETA, and `POST /api/data/repair-search-index/:job_id/cancel` requests cancellation. 
- Wired the search-repair worker into server startup (`packages/api/index.js`) behind `DISABLE_SEARCH_REPAIR_WORKER`, and updated the web Settings UI to queue jobs, poll status, show a progress modal with ETA, cancel button and retry CTA (`packages/web/src/components/settings/DataUtilsSettings.jsx`).

### Testing
- Ran syntax/type checks for server-side modules with `node --check` against `packages/api/search-repair-worker.js`, `packages/api/routes/dataUtilsRoutes.js`, and `packages/api/index.js`, which completed without errors. 
- Linted the modified web component with `cd packages/web && npm run lint -- src/components/settings/DataUtilsSettings.jsx`, which succeeded (repository contains pre-existing lint warnings unrelated to these changes). 
- Verified the new migration file and worker module are present and the API route was updated; no additional automated integration tests were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e08e432fa083329fccb6b261012dcd)