### PR TITLE
feat(web): add sidebar version indicator and versioning/release guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ An integrated ERP/Point-of-Sale solution for auto parts businesses.
 [Installation](#-installation--setup) •
 [Architecture](#-architecture-overview) •
 [Usage](#-usage) •
+[Versioning & Releases](docs/APPLICATION_VERSIONING_AND_RELEASE_GUIDE.md) •
 [API Samples](#-sample-api-calls) •
 [Troubleshooting](#-troubleshooting) •
 [Deployment](#-deployment) •

--- a/docs/APPLICATION_VERSIONING_AND_RELEASE_GUIDE.md
+++ b/docs/APPLICATION_VERSIONING_AND_RELEASE_GUIDE.md
@@ -1,0 +1,148 @@
+# Application Versioning & Release Guide
+
+This guide defines how Forson Business Suite versions are established, surfaced in the UI, and released safely.
+
+## Objectives
+
+- Keep versions **traceable** (release tag ↔ build ↔ commit).
+- Keep versions **consistent** across frontend, backend, and docs.
+- Keep releases **repeatable** and **auditable**.
+- Keep rollback and incident debugging fast.
+
+## Versioning Standard
+
+Use **Semantic Versioning (SemVer)**: `MAJOR.MINOR.PATCH`.
+
+- **MAJOR**: Breaking or incompatible changes.
+- **MINOR**: Backward-compatible features.
+- **PATCH**: Backward-compatible fixes/chore updates.
+
+Examples:
+- `1.4.0` = new feature release.
+- `1.4.1` = bug fix release.
+- `2.0.0` = breaking changes.
+
+### Optional Pre-Release Suffixes
+
+Use suffixes for non-production builds:
+- `1.5.0-rc.1` (release candidate)
+- `1.5.0-beta.2`
+
+## Source of Truth for Version
+
+For the web app package, `packages/web/package.json` `version` is the baseline version.
+
+At build time, the app may be overridden by CI variables:
+
+- `VITE_APP_VERSION` (recommended; explicit release version)
+- `VITE_APP_COMMIT_SHA` (full git SHA)
+- `VITE_APP_BUILD_DATE` (ISO-8601 UTC timestamp)
+
+Best practice:
+- In CI/CD, always inject all three values for production builds.
+- For local builds, defaults are acceptable for developer convenience.
+
+## UI Version Display
+
+The sidebar (expanded state) shows a subtle version label at the bottom (`vX.Y.Z`), giving support teams and users a quick way to confirm deployed version.
+
+Guidelines:
+- Keep text unobtrusive (`text-gray-400`, small font).
+- Do not clutter with full commit and timestamp in primary UI.
+- Put detailed build metadata in logs, diagnostics page, or dev tools if needed.
+
+## Release Best Practices Checklist
+
+Before releasing:
+
+1. Ensure all tests/checks pass.
+2. Confirm migrations are prepared, reviewed, and reversible when practical.
+3. Update `packages/web/package.json` version.
+4. Update release notes/changelog.
+5. Create an annotated git tag (`vX.Y.Z`).
+6. Build artifacts with pinned version + commit + build date.
+7. Deploy progressively (staging, then production).
+8. Verify runtime health checks and smoke tests.
+9. Record release metadata in deployment logs/ticket.
+
+After releasing:
+
+1. Confirm UI version text matches the intended release.
+2. Validate API and DB compatibility.
+3. Monitor logs/metrics/alerts.
+4. Keep a documented rollback plan and previous stable tag.
+
+## Recommended Release Workflow
+
+### 1) Branch and Prepare
+
+```bash
+git checkout -b release/vX.Y.Z
+```
+
+- Finalize merged scope.
+- Freeze non-critical feature merges.
+
+### 2) Bump Version
+
+From repository root:
+
+```bash
+npm version X.Y.Z --no-git-tag-version --workspace packages/web
+```
+
+Or edit `packages/web/package.json` manually if needed.
+
+### 3) Validate
+
+```bash
+npm run -w packages/web lint
+npm run -w packages/web build
+npm run -w packages/api test
+```
+
+### 4) Commit Release Prep
+
+```bash
+git add packages/web/package.json package-lock.json docs/
+git commit -m "chore(release): prepare vX.Y.Z"
+```
+
+### 5) Tag Release
+
+```bash
+git tag -a vX.Y.Z -m "Release vX.Y.Z"
+git push origin main --tags
+```
+
+### 6) Build with Explicit Metadata
+
+In CI/CD (example):
+
+```bash
+export VITE_APP_VERSION=X.Y.Z
+export VITE_APP_COMMIT_SHA=$(git rev-parse HEAD)
+export VITE_APP_BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+npm run -w packages/web build
+```
+
+### 7) Deploy & Verify
+
+- Deploy to staging first.
+- Run smoke tests and check logs.
+- Promote to production.
+- Confirm sidebar shows `vX.Y.Z`.
+
+## Rollback Guidance
+
+- Roll back by redeploying the previous known-good tag.
+- Keep DB rollback scripts for destructive migrations.
+- If schema rollback is unsafe, use forward-fix strategy and patch release (`X.Y.(Z+1)`).
+
+## Governance Recommendations
+
+- Protect `main` with required checks.
+- Require PR review for version bumps and migration changes.
+- Keep a changelog per release.
+- Automate tagging/build metadata injection in CI/CD.
+- Use signed tags and signed commits for production compliance where required.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10348,7 +10348,7 @@
 			}
 		},
 		"packages/web": {
-			"version": "0.0.0",
+			"version": "1.2.0",
 			"dependencies": {
 				"@headlessui/react": "^2.2.7",
 				"axios": "^1.11.0",

--- a/packages/web/eslint.config.js
+++ b/packages/web/eslint.config.js
@@ -17,6 +17,9 @@ export default defineConfig([
       ecmaVersion: 2020,
       globals: {
         ...globals.browser,
+        __APP_VERSION__: 'readonly',
+        __APP_COMMIT_SHA__: 'readonly',
+        __APP_BUILD_DATE__: 'readonly',
       },
       parserOptions: {
         ecmaVersion: 'latest',

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.0.0",
+      "version": "1.2.0",
       "dependencies": {
         "@headlessui/react": "^2.2.7",
         "axios": "^1.11.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/web/src/components/layout/Sidebar.jsx
+++ b/packages/web/src/components/layout/Sidebar.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Icon from '../ui/Icon';
 import { ICONS } from '../../constants';
+import { APP_VERSION_LABEL } from '../../constants/version';
 import { useAuth } from '../../contexts/AuthContext'; // <-- NEW: Import useAuth
 
 const Sidebar = ({ onNavigate, currentPage, isOpen, setIsOpen }) => {
@@ -46,6 +47,9 @@ const Sidebar = ({ onNavigate, currentPage, isOpen, setIsOpen }) => {
                         )
                     ))}
                 </nav>
+                <div className="px-6 py-4 text-[11px] text-gray-400 border-t border-gray-100">
+                    {APP_VERSION_LABEL}
+                </div>
             </div>
         </>
     );

--- a/packages/web/src/constants/version.js
+++ b/packages/web/src/constants/version.js
@@ -1,0 +1,7 @@
+const trimCommitSha = (sha) => (sha && sha !== 'local' ? sha.slice(0, 7) : 'local')
+
+export const APP_VERSION = typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : '0.0.0'
+export const APP_COMMIT_SHA = trimCommitSha(typeof __APP_COMMIT_SHA__ !== 'undefined' ? __APP_COMMIT_SHA__ : 'local')
+export const APP_BUILD_DATE = typeof __APP_BUILD_DATE__ !== 'undefined' ? __APP_BUILD_DATE__ : null
+
+export const APP_VERSION_LABEL = `v${APP_VERSION}`

--- a/packages/web/vite.config.js
+++ b/packages/web/vite.config.js
@@ -1,9 +1,23 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const packageJsonPath = resolve(process.cwd(), 'package.json')
+const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'))
+
+const appVersion = process.env.VITE_APP_VERSION || packageJson.version || '0.0.0'
+const appCommitSha = process.env.VITE_APP_COMMIT_SHA || 'local'
+const appBuildDate = process.env.VITE_APP_BUILD_DATE || new Date().toISOString()
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(appVersion),
+    __APP_COMMIT_SHA__: JSON.stringify(appCommitSha),
+    __APP_BUILD_DATE__: JSON.stringify(appBuildDate),
+  },
   plugins: [
     react(),
     tailwindcss(),


### PR DESCRIPTION
### Motivation
- Provide an unobtrusive way for support and users to verify the deployed frontend version from the UI.  
- Standardize how build metadata (version, commit, build date) is injected so CI and local builds are traceable.  
- Document recommended release and versioning practices so teams can produce repeatable, auditable releases.  

### Description
- Added a subtle version label to the bottom of the expanded sidebar (`packages/web/src/components/layout/Sidebar.jsx`) that displays `vX.Y.Z` using a light style.  
- Introduced centralized frontend build constants and helpers (`packages/web/src/constants/version.js`) exposing `APP_VERSION`, short `APP_COMMIT_SHA`, `APP_BUILD_DATE`, and `APP_VERSION_LABEL`.  
- Extended Vite configuration to inject build metadata from CI-friendly environment variables (`VITE_APP_VERSION`, `VITE_APP_COMMIT_SHA`, `VITE_APP_BUILD_DATE`) with safe local fallbacks and exposed as global compile-time constants (`__APP_VERSION__`, `__APP_COMMIT_SHA__`, `__APP_BUILD_DATE__`) in `packages/web/vite.config.js`.  
- Updated ESLint globals (`packages/web/eslint.config.js`) so the injected build constants are recognized without lint errors.  
- Added a release and versioning guide `docs/APPLICATION_VERSIONING_AND_RELEASE_GUIDE.md` describing SemVer policy, source-of-truth, CI metadata injection, checklist, tagging, deployment verification and rollback guidance, and added a README quick link.  

### Testing
- Ran `npm run -w packages/web lint` which completed successfully and reported the repository's existing warnings (no new lint errors introduced).  
- Ran `npm run -w packages/web build` which produced a successful production build (`vite build`) with artifacts generated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1c810f7888332a89a779f29c44f10)