### PR TITLE
Fix WAC NaN display for inventory search results

### DIFF
--- a/packages/api/routes/powerSearchRoutes.js
+++ b/packages/api/routes/powerSearchRoutes.js
@@ -42,6 +42,7 @@ router.get('/power-search/parts', async (req, res) => {
                 p.detail,
                 p.last_sale_price,
                 p.last_cost,
+                COALESCE(p.wac_cost, 0) AS wac_cost,
                 p.tax_rate_id,
                 p.is_tax_inclusive_price,
                 b.brand_name,

--- a/packages/web/src/pages/InventoryPage.jsx
+++ b/packages/web/src/pages/InventoryPage.jsx
@@ -83,6 +83,10 @@ const InventoryPage = () => {
     
     // Use inventory directly to preserve server-provided ranking (MeiliSearch)
     const sortedInventory = inventory;
+    const toSafeNumber = (value) => {
+        const numeric = Number(value);
+        return Number.isFinite(numeric) ? numeric : 0;
+    };
 
     return (
         <div>
@@ -116,13 +120,20 @@ const InventoryPage = () => {
                                 </tr>
                             </thead>
                             <tbody>
-                                {sortedInventory.map(item => (
+                                {sortedInventory.map(item => {
+                                    const stockOnHand = toSafeNumber(item.stock_on_hand);
+                                    const wacCost = toSafeNumber(item.wac_cost);
+                                    const totalValue = Number.isFinite(Number(item.total_value))
+                                        ? Number(item.total_value)
+                                        : stockOnHand * wacCost;
+
+                                    return (
                                     <tr key={item.part_id} className="border-b hover:bg-gray-50">
                                         <td className="p-3 text-sm font-mono">{item.internal_sku}</td>
                                         <td className="p-3 text-sm font-medium text-gray-800">{item.display_name}</td>
-                                        <td className="p-3 text-sm text-center font-semibold">{Number(item.stock_on_hand).toLocaleString()}</td>
-                                        <td className="p-3 text-sm text-right font-mono">{settings?.DEFAULT_CURRENCY_SYMBOL || '$'}{parseFloat(item.wac_cost).toFixed(2)}</td>
-                                        <td className="p-3 text-sm text-right font-mono">{settings?.DEFAULT_CURRENCY_SYMBOL || '$'}{parseFloat(item.total_value).toFixed(2)}</td>
+                                        <td className="p-3 text-sm text-center font-semibold">{stockOnHand.toLocaleString()}</td>
+                                        <td className="p-3 text-sm text-right font-mono">{settings?.DEFAULT_CURRENCY_SYMBOL || '$'}{wacCost.toFixed(2)}</td>
+                                        <td className="p-3 text-sm text-right font-mono">{settings?.DEFAULT_CURRENCY_SYMBOL || '$'}{totalValue.toFixed(2)}</td>
                                         <td className="p-3 text-sm text-right">
                                             {hasPermission('inventory:adjust') && (
                                                 <button onClick={() => handleOpenAdjustmentModal(item)} className="text-blue-600 hover:text-blue-800 mr-4" title="Adjust Stock">
@@ -134,7 +145,7 @@ const InventoryPage = () => {
                                             </button>
                                         </td>
                                     </tr>
-                                ))}
+                                )})}
                             </tbody>
                         </table>
                     </div>


### PR DESCRIPTION
### Motivation
- Inventory rows returned from the Meili-backed `/power-search/parts` endpoint were sometimes missing `wac_cost` and `total_value`, which caused the UI to call `.toFixed(2)` on `undefined` and display `₱NaN` even when the DB value was `0` (e.g. `part_id=483`).
- Ensure search-mode responses always provide a numeric WAC and make the UI resilient to missing/invalid numeric fields so monetary columns never render `NaN`.

### Description
- Return a deterministic numeric WAC from the search endpoint by adding `COALESCE(p.wac_cost, 0) AS wac_cost` to the SQL in `packages/api/routes/powerSearchRoutes.js` so MeiliSearch-backed inventory rows include a numeric `wac_cost`.
- Harden the Inventory UI in `packages/web/src/pages/InventoryPage.jsx` by adding a `toSafeNumber` helper that normalizes values to a finite `Number` or `0` and using it for `stock_on_hand` and `wac_cost` before formatting.
- Compute a resilient `total_value` fallback in the UI as `stock_on_hand * wac_cost` when `total_value` is missing or invalid so the Total Value column also cannot produce `NaN`.

### Testing
- Ran frontend lint with `npm --prefix packages/web run lint -- src/pages/InventoryPage.jsx`, which completed successfully with repository pre-existing warnings and produced no new errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1dd7a8908833297c3ff9d7c5c3d5a)