### PR TITLE
Add reusable server-side pagination and UI controls for major list pages

### DIFF
--- a/packages/api/helpers/pagination.js
+++ b/packages/api/helpers/pagination.js
@@ -1,0 +1,40 @@
+const DEFAULT_PAGE = 1;
+const DEFAULT_PAGE_SIZE = 25;
+const MAX_PAGE_SIZE = 100;
+
+const parsePaginationQuery = (query = {}) => {
+    const page = Math.max(parseInt(query.page, 10) || DEFAULT_PAGE, 1);
+    const requestedPageSize = parseInt(query.pageSize, 10) || DEFAULT_PAGE_SIZE;
+    const pageSize = Math.min(Math.max(requestedPageSize, 1), MAX_PAGE_SIZE);
+    const offset = (page - 1) * pageSize;
+    const paginated = query.paginated === '1' || query.paginated === 'true' || query.paginated === true;
+
+    return {
+        page,
+        pageSize,
+        offset,
+        limit: pageSize,
+        paginated
+    };
+};
+
+const buildPaginationMeta = ({ page, pageSize, total }) => ({
+    page,
+    pageSize,
+    total,
+    totalPages: Math.max(Math.ceil(total / pageSize), 1)
+});
+
+const paginatedResponse = ({ data, page, pageSize, total }) => ({
+    data,
+    ...buildPaginationMeta({ page, pageSize, total })
+});
+
+module.exports = {
+    DEFAULT_PAGE,
+    DEFAULT_PAGE_SIZE,
+    MAX_PAGE_SIZE,
+    parsePaginationQuery,
+    buildPaginationMeta,
+    paginatedResponse
+};

--- a/packages/api/routes/applicationRoutes.js
+++ b/packages/api/routes/applicationRoutes.js
@@ -1,10 +1,12 @@
 const express = require('express');
 const db = require('../db');
+const { parsePaginationQuery, paginatedResponse } = require('../helpers/pagination');
 const router = express.Router();
 
 // GET all vehicle applications using the view
 router.get('/applications', async (req, res) => {
     console.log('[DEBUG] Handling GET /applications request');
+    const { paginated, page, pageSize, offset, limit } = parsePaginationQuery(req.query);
     try {
         // Ensure the view has the expected columns (including *_id). If not, drop and recreate.
         const colCheck = await db.query(`
@@ -34,7 +36,7 @@ router.get('/applications', async (req, res) => {
         }
 
         console.log('[DEBUG] Executing applications query');
-        const query = `
+        const baseQuery = `
             SELECT 
                 application_id,
                 make_id,
@@ -46,9 +48,17 @@ router.get('/applications', async (req, res) => {
             FROM application_view
             ORDER BY make NULLS LAST, model NULLS LAST, engine NULLS LAST
         `;
-        const { rows } = await db.query(query);
+        if (!paginated) {
+            const { rows } = await db.query(baseQuery);
+            console.log('[DEBUG] Query successful, returning', rows.length, 'rows');
+            return res.json(rows);
+        }
+        const countRes = await db.query('SELECT COUNT(*)::int AS total FROM application_view');
+        const total = countRes.rows[0]?.total || 0;
+        const query = `${baseQuery} LIMIT $1 OFFSET $2`;
+        const { rows } = await db.query(query, [limit, offset]);
         console.log('[DEBUG] Query successful, returning', rows.length, 'rows');
-        res.json(rows);
+        res.json(paginatedResponse({ data: rows, page, pageSize, total }));
     } catch (err) {
         console.error('[DEBUG] Error in GET /applications:', err.message);
         console.error('[DEBUG] Full error:', err);

--- a/packages/api/routes/arRoutes.js
+++ b/packages/api/routes/arRoutes.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const db = require('../db');
 const { protect, hasPermission } = require('../middleware/authMiddleware');
+const { parsePaginationQuery, paginatedResponse } = require('../helpers/pagination');
 const router = express.Router();
 
 // GET /ar/dashboard-stats - Get AR dashboard statistics
@@ -127,7 +128,7 @@ router.get('/ar/aging-summary', protect, hasPermission('ar:view'), async (req, r
 // GET /ar/customer-summary - Get customer-level AR summary
 router.get('/ar/customer-summary', protect, hasPermission('ar:view'), async (req, res) => {
     try {
-        const { limit = 50, offset = 0 } = req.query;
+        const { paginated, page, pageSize, offset, limit } = parsePaginationQuery(req.query);
         
         const query = `
             SELECT 
@@ -156,7 +157,21 @@ router.get('/ar/customer-summary', protect, hasPermission('ar:view'), async (req
         `;
         
         const { rows } = await db.query(query, [limit, offset]);
-        res.json(rows);
+        if (!paginated) return res.json(rows);
+        const countRes = await db.query(`
+            SELECT COUNT(*)::int AS total
+            FROM (
+                SELECT c.customer_id
+                FROM customer c
+                JOIN invoice i ON c.customer_id = i.customer_id
+                WHERE i.status IN ('Unpaid', 'Partially Paid')
+                AND (i.total_amount - i.amount_paid) > 0
+                GROUP BY c.customer_id, c.company_name, c.first_name, c.last_name
+                HAVING COALESCE(SUM(i.total_amount - i.amount_paid), 0) > 0
+            ) summary
+        `);
+        const total = countRes.rows[0]?.total || 0;
+        res.json(paginatedResponse({ data: rows, page, pageSize, total }));
     } catch (err) {
         console.error('AR Customer Summary Error:', err.message);
         res.status(500).json({ message: 'Failed to fetch customer summary' });
@@ -167,7 +182,7 @@ router.get('/ar/customer-summary', protect, hasPermission('ar:view'), async (req
 router.get('/ar/customer-invoices/:customerId', protect, hasPermission('ar:view'), async (req, res) => {
     try {
         const { customerId } = req.params;
-        const { limit = 100, offset = 0 } = req.query;
+        const { paginated, page, pageSize, offset, limit } = parsePaginationQuery(req.query);
         
         const query = `
             SELECT 
@@ -201,7 +216,16 @@ router.get('/ar/customer-invoices/:customerId', protect, hasPermission('ar:view'
         `;
         
         const { rows } = await db.query(query, [customerId, limit, offset]);
-        res.json(rows);
+        if (!paginated) return res.json(rows);
+        const countRes = await db.query(`
+            SELECT COUNT(*)::int AS total
+            FROM invoice i
+            WHERE i.customer_id = $1
+            AND i.status IN ('Unpaid', 'Partially Paid')
+            AND (i.total_amount - i.amount_paid) > 0
+        `, [customerId]);
+        const total = countRes.rows[0]?.total || 0;
+        res.json(paginatedResponse({ data: rows, page, pageSize, total }));
     } catch (err) {
         console.error('AR Customer Invoices Error:', err.message);
         res.status(500).json({ message: 'Failed to fetch customer invoices' });
@@ -254,7 +278,8 @@ router.get('/ar/trends', protect, hasPermission('ar:view'), async (req, res) => 
 // GET /ar/drill-down-invoices - Get invoices for a specific aging bucket
 router.get('/ar/drill-down-invoices', protect, hasPermission('ar:view'), async (req, res) => {
     try {
-        const { bucket, startDate, endDate, limit = 100, offset = 0 } = req.query;
+        const { bucket, startDate, endDate } = req.query;
+        const { paginated, page, pageSize, offset, limit } = parsePaginationQuery(req.query);
 
         if (!bucket) {
             return res.status(400).json({ message: 'Bucket parameter is required' });
@@ -276,15 +301,16 @@ router.get('/ar/drill-down-invoices', protect, hasPermission('ar:view'), async (
 
         // Build the query with date range filter if provided
         let dateRangeCondition = '';
-        let queryParams = [limit, offset];
-        let paramIndex = 3;
+        let queryParams = [];
+        let paramIndex = 1;
 
         if (startDate && endDate) {
             dateRangeCondition = ` AND i.invoice_date >= $${paramIndex} AND i.invoice_date <= $${paramIndex + 1}`;
             queryParams.push(startDate, endDate);
+            paramIndex += 2;
         }
 
-        const query = `
+        let query = `
             SELECT
                 i.invoice_id,
                 i.invoice_number,
@@ -306,11 +332,17 @@ router.get('/ar/drill-down-invoices', protect, hasPermission('ar:view'), async (
             AND ${dateCondition}
             ${dateRangeCondition}
             ORDER BY i.due_date ASC, (i.total_amount - i.amount_paid) DESC
-            LIMIT $1 OFFSET $2;
         `;
-
+        if (!paginated) {
+            const { rows } = await db.query(query, queryParams);
+            return res.json(rows);
+        }
+        const countRes = await db.query(`SELECT COUNT(*)::int AS total FROM (${query}) drilldown`, queryParams);
+        const total = countRes.rows[0]?.total || 0;
+        query += ` LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`;
+        queryParams.push(limit, offset);
         const { rows } = await db.query(query, queryParams);
-        res.json(rows);
+        res.json(paginatedResponse({ data: rows, page, pageSize, total }));
     } catch (err) {
         console.error('AR Drill-down Invoices Error:', err.message);
         res.status(500).json({ message: 'Failed to fetch drill-down invoices' });

--- a/packages/api/routes/customerRoutes.js
+++ b/packages/api/routes/customerRoutes.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const db = require('../db');
 const { protect, hasPermission } = require('../middleware/authMiddleware');
+const { parsePaginationQuery, paginatedResponse } = require('../helpers/pagination');
 const router = express.Router();
 
 // Helper function to handle tag logic
@@ -24,6 +25,7 @@ const manageTags = async (client, tags, customerId) => {
 router.get('/customers', protect, hasPermission('customers:view'), async (req, res) => {
     // Adding a filter for active/inactive/all customers
     const { status = 'active' } = req.query;
+    const { paginated, page, pageSize, offset, limit } = parsePaginationQuery(req.query);
     let whereClause = "WHERE is_active = TRUE";
     if (status === 'inactive') {
       whereClause = "WHERE is_active = FALSE";
@@ -31,8 +33,18 @@ router.get('/customers', protect, hasPermission('customers:view'), async (req, r
       whereClause = "";
     }
     try {
-        const { rows } = await db.query(`SELECT * FROM customer ${whereClause} ORDER BY first_name, last_name`);
-        res.json(rows);
+        if (!paginated) {
+            const { rows } = await db.query(`SELECT * FROM customer ${whereClause} ORDER BY first_name, last_name`);
+            return res.json(rows);
+        }
+
+        const countRes = await db.query(`SELECT COUNT(*)::int AS total FROM customer ${whereClause}`);
+        const total = countRes.rows[0]?.total || 0;
+        const { rows } = await db.query(
+            `SELECT * FROM customer ${whereClause} ORDER BY first_name, last_name LIMIT $1 OFFSET $2`,
+            [limit, offset]
+        );
+        res.json(paginatedResponse({ data: rows, page, pageSize, total }));
     } catch (err) {
         console.error(err.message);
         res.status(500).send('Server Error');
@@ -62,6 +74,7 @@ router.get('/customers/:id/tags', protect, hasPermission('customers:view'), asyn
 // GET /api/customers/with-balances
 router.get('/customers/with-balances', protect, hasPermission('ar:view'), async (req, res) => {
     try {
+        const { paginated, page, pageSize, offset, limit } = parsePaginationQuery(req.query);
         const query = `
             SELECT
                 c.customer_id,
@@ -76,8 +89,25 @@ router.get('/customers/with-balances', protect, hasPermission('ar:view'), async 
             HAVING COALESCE(SUM(CASE WHEN i.status IN ('Unpaid', 'Partially Paid') THEN i.total_amount - i.amount_paid ELSE 0 END), 0) > 0
             ORDER BY c.first_name, c.last_name;
         `;
-        const { rows } = await db.query(query);
-        res.json(rows);
+        if (!paginated) {
+            const { rows } = await db.query(query);
+            return res.json(rows);
+        }
+
+        const countQuery = `
+            SELECT COUNT(*)::int AS total FROM (
+                SELECT c.customer_id
+                FROM customer c
+                LEFT JOIN invoice i ON i.customer_id = c.customer_id
+                GROUP BY c.customer_id
+                HAVING COALESCE(SUM(CASE WHEN i.status IN ('Unpaid', 'Partially Paid') THEN i.total_amount - i.amount_paid ELSE 0 END), 0) > 0
+            ) grouped_customers;
+        `;
+        const countRes = await db.query(countQuery);
+        const total = countRes.rows[0]?.total || 0;
+        const paginatedQuery = query.replace(/;\s*$/, ' LIMIT $1 OFFSET $2;');
+        const { rows } = await db.query(paginatedQuery, [limit, offset]);
+        res.json(paginatedResponse({ data: rows, page, pageSize, total }));
     } catch (err) {
         console.error(err.message);
         res.status(500).send('Server Error');

--- a/packages/api/routes/employeeRoutes.js
+++ b/packages/api/routes/employeeRoutes.js
@@ -3,6 +3,7 @@ const bcrypt = require('bcrypt');
 const jwt = require('jsonwebtoken');
 const db = require('../db');
 const { protect, isAdmin } = require('../middleware/authMiddleware');
+const { parsePaginationQuery, paginatedResponse } = require('../helpers/pagination');
 const router = express.Router();
 
 // Helper to generate a token
@@ -63,6 +64,7 @@ router.post('/login', async (req, res) => {
 // GET /employees - list employees with status filter
 router.get('/employees', protect, isAdmin, async (req, res) => {
     const { status = 'active' } = req.query;
+    const { paginated, page, pageSize, offset, limit } = parsePaginationQuery(req.query);
 
     let whereClause = "WHERE is_active = TRUE";
     if (status === 'inactive') {
@@ -72,14 +74,23 @@ router.get('/employees', protect, isAdmin, async (req, res) => {
     }
 
     try {
-        const query = `
+        const baseQuery = `
             SELECT employee_id, employee_code, first_name, last_name, position_title, permission_level_id, username, is_active 
             FROM employee 
             ${whereClause} 
             ORDER BY last_name, first_name
         `;
-        const { rows } = await db.query(query);
-        res.json(rows);
+        if (!paginated) {
+            const { rows } = await db.query(baseQuery);
+            return res.json(rows);
+        }
+
+        const countQuery = `SELECT COUNT(*)::int AS total FROM employee ${whereClause}`;
+        const countRes = await db.query(countQuery);
+        const total = countRes.rows[0]?.total || 0;
+        const query = `${baseQuery} LIMIT $1 OFFSET $2`;
+        const { rows } = await db.query(query, [limit, offset]);
+        res.json(paginatedResponse({ data: rows, page, pageSize, total }));
     } catch (err) {
         console.error(err.message);
         res.status(500).send('Server Error');

--- a/packages/api/routes/goodsReceiptRoutes.js
+++ b/packages/api/routes/goodsReceiptRoutes.js
@@ -2,11 +2,13 @@ const express = require('express');
 const db = require('../db');
 const { getNextDocumentNumber } = require('../helpers/documentNumberGenerator');
 const { hasPermission, protect } = require('../middleware/authMiddleware');
+const { parsePaginationQuery, paginatedResponse } = require('../helpers/pagination');
 const router = express.Router();
 
 // GET /goods-receipts - Fetch list of posted GRNs with search and sorting
 router.get('/goods-receipts', protect, async (req, res) => {
   const { q: search = '', sortBy = 'receipt_date', sortOrder = 'desc' } = req.query;
+  const { paginated, page, pageSize, offset, limit } = parsePaginationQuery(req.query);
 
   // Validate sortBy and sortOrder
   const allowedSortBy = ['receipt_date', 'supplier_name', 'grn_number'];
@@ -58,8 +60,18 @@ router.get('/goods-receipts', protect, async (req, res) => {
 
     query += ` ORDER BY ${sortBy} ${sortOrder}`;
 
-    const { rows } = await db.query(query, params);
-    res.json(rows);
+    if (!paginated) {
+      const { rows } = await db.query(query, params);
+      return res.json(rows);
+    }
+
+    const countQuery = `SELECT COUNT(*)::int AS total FROM (${query}) as grn_results`;
+    const countRes = await db.query(countQuery, params);
+    const total = countRes.rows[0]?.total || 0;
+    query += ` LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`;
+    const paginatedParams = [...params, limit, offset];
+    const { rows } = await db.query(query, paginatedParams);
+    res.json(paginatedResponse({ data: rows, page, pageSize, total }));
   } catch (err) {
     console.error('Error fetching goods receipts:', err.message);
     res.status(500).json({ message: 'Server error', error: err.message });

--- a/packages/api/routes/inventoryRoutes.js
+++ b/packages/api/routes/inventoryRoutes.js
@@ -11,21 +11,21 @@ router.get('/inventory', async (req, res) => {
     const { paginated, page, pageSize, offset, limit } = parsePaginationQuery(req.query);
     const sortBy = String(req.query.sortBy || 'name').toLowerCase();
     const sortDirection = String(req.query.sortDirection || 'ASC').toUpperCase() === 'DESC' ? 'DESC' : 'ASC';
-    const shouldSortByName = sortBy === 'name' || sortBy === 'display_name';
+    const isGlobalSort = ['sku', 'name', 'display_name', 'stock_on_hand', 'wac', 'total_value'].includes(sortBy);
 
     try {
         // --- NEW: Hybrid Meilisearch + DB Query ---
 
         // 1. Get a list of part IDs from Meilisearch
         const index = meiliClient.index('parts');
-        const metadataResults = paginated && shouldSortByName
+        const metadataResults = paginated && isGlobalSort
             ? await index.search(search, { limit: 0, offset: 0, attributesToRetrieve: ['part_id'] })
             : null;
         const totalHits = metadataResults?.estimatedTotalHits || metadataResults?.totalHits || 0;
-        const fetchLimit = paginated && shouldSortByName
+        const fetchLimit = paginated && isGlobalSort
             ? Math.min(totalHits, 20000)
             : (paginated ? limit : 200);
-        const fetchOffset = paginated && shouldSortByName ? 0 : (paginated ? offset : 0);
+        const fetchOffset = paginated && isGlobalSort ? 0 : (paginated ? offset : 0);
 
         const searchResults = await index.search(search, {
             limit: fetchLimit,
@@ -49,13 +49,24 @@ router.get('/inventory', async (req, res) => {
         // Compute stock_on_hand once in a CTE to avoid duplicate subqueries and
         // coalesce wac_cost to 0 so total_value is deterministic.
         const queryParams = [partIds];
-        const sqlOffset = shouldSortByName && paginated ? 'LIMIT $2 OFFSET $3' : '';
-        if (shouldSortByName && paginated) {
+        const sqlOffset = isGlobalSort && paginated ? 'LIMIT $2 OFFSET $3' : '';
+        if (isGlobalSort && paginated) {
             queryParams.push(limit, offset);
         }
-        const orderByClause = shouldSortByName
-            ? `ORDER BY LOWER(COALESCE(g.group_name, '') || ' ' || COALESCE(b.brand_name, '') || ' ' || COALESCE(p.detail, '')) ${sortDirection}, p.part_id ${sortDirection}`
-            : 'ORDER BY p.detail ASC';
+        let orderByClause = 'ORDER BY p.detail ASC';
+        if (isGlobalSort) {
+            if (sortBy === 'sku') {
+                orderByClause = `ORDER BY LOWER(COALESCE(p.internal_sku, '')) ${sortDirection}, p.part_id ${sortDirection}`;
+            } else if (sortBy === 'stock_on_hand') {
+                orderByClause = `ORDER BY COALESCE(s.stock_on_hand, 0) ${sortDirection}, p.part_id ${sortDirection}`;
+            } else if (sortBy === 'wac') {
+                orderByClause = `ORDER BY COALESCE(p.wac_cost, 0) ${sortDirection}, p.part_id ${sortDirection}`;
+            } else if (sortBy === 'total_value') {
+                orderByClause = `ORDER BY (COALESCE(p.wac_cost, 0) * COALESCE(s.stock_on_hand, 0)) ${sortDirection}, p.part_id ${sortDirection}`;
+            } else {
+                orderByClause = `ORDER BY LOWER(COALESCE(g.group_name, '') || ' ' || COALESCE(b.brand_name, '') || ' ' || COALESCE(p.detail, '')) ${sortDirection}, p.part_id ${sortDirection}`;
+            }
+        }
 
         const query = `
             WITH stock AS (
@@ -98,7 +109,7 @@ router.get('/inventory', async (req, res) => {
         if (!paginated) {
             return res.json(inventoryWithDisplayName);
         }
-        const total = shouldSortByName
+        const total = isGlobalSort
             ? (totalHits || inventoryWithDisplayName.length)
             : (searchResults.estimatedTotalHits || searchResults.totalHits || inventoryWithDisplayName.length);
         res.json(paginatedResponse({ data: inventoryWithDisplayName, page, pageSize, total }));

--- a/packages/api/routes/inventoryRoutes.js
+++ b/packages/api/routes/inventoryRoutes.js
@@ -2,11 +2,13 @@ const express = require('express');
 const db = require('../db');
 const { constructDisplayName } = require('../helpers/displayNameHelper');
 const { meiliClient } = require('../meilisearch'); // <-- 1. Import Meili client
+const { parsePaginationQuery, paginatedResponse } = require('../helpers/pagination');
 const router = express.Router();
 
 // GET /api/inventory - Get current stock levels with search
 router.get('/inventory', async (req, res) => {
     const { search = '' } = req.query;
+    const { paginated, page, pageSize, offset, limit } = parsePaginationQuery(req.query);
 
     try {
         // --- NEW: Hybrid Meilisearch + DB Query ---
@@ -14,7 +16,8 @@ router.get('/inventory', async (req, res) => {
         // 1. Get a list of part IDs from Meilisearch
         const index = meiliClient.index('parts');
         const searchResults = await index.search(search, {
-            limit: 200, // Limit the number of results for performance
+            limit: paginated ? limit : 200, // Limit the number of results for performance
+            offset: paginated ? offset : 0,
             attributesToRetrieve: ['part_id'], // We only need the ID
         });
         // Ensure we send integer IDs to Postgres (Meili may return strings)
@@ -24,6 +27,9 @@ router.get('/inventory', async (req, res) => {
 
         // If Meilisearch returns no results, we can stop here.
         if (partIds.length === 0) {
+            if (paginated) {
+                return res.json(paginatedResponse({ data: [], page, pageSize, total: 0 }));
+            }
             return res.json([]);
         }
 
@@ -67,7 +73,11 @@ router.get('/inventory', async (req, res) => {
             display_name: constructDisplayName(item)
         }));
 
-        res.json(inventoryWithDisplayName);
+        if (!paginated) {
+            return res.json(inventoryWithDisplayName);
+        }
+        const total = searchResults.estimatedTotalHits || searchResults.totalHits || inventoryWithDisplayName.length;
+        res.json(paginatedResponse({ data: inventoryWithDisplayName, page, pageSize, total }));
     } catch (err) {
         console.error(err.message);
         res.status(500).send('Server Error');

--- a/packages/api/routes/inventoryRoutes.js
+++ b/packages/api/routes/inventoryRoutes.js
@@ -9,15 +9,27 @@ const router = express.Router();
 router.get('/inventory', async (req, res) => {
     const { search = '' } = req.query;
     const { paginated, page, pageSize, offset, limit } = parsePaginationQuery(req.query);
+    const sortBy = String(req.query.sortBy || 'name').toLowerCase();
+    const sortDirection = String(req.query.sortDirection || 'ASC').toUpperCase() === 'DESC' ? 'DESC' : 'ASC';
+    const shouldSortByName = sortBy === 'name' || sortBy === 'display_name';
 
     try {
         // --- NEW: Hybrid Meilisearch + DB Query ---
 
         // 1. Get a list of part IDs from Meilisearch
         const index = meiliClient.index('parts');
+        const metadataResults = paginated && shouldSortByName
+            ? await index.search(search, { limit: 0, offset: 0, attributesToRetrieve: ['part_id'] })
+            : null;
+        const totalHits = metadataResults?.estimatedTotalHits || metadataResults?.totalHits || 0;
+        const fetchLimit = paginated && shouldSortByName
+            ? Math.min(totalHits, 20000)
+            : (paginated ? limit : 200);
+        const fetchOffset = paginated && shouldSortByName ? 0 : (paginated ? offset : 0);
+
         const searchResults = await index.search(search, {
-            limit: paginated ? limit : 200, // Limit the number of results for performance
-            offset: paginated ? offset : 0,
+            limit: fetchLimit,
+            offset: fetchOffset,
             attributesToRetrieve: ['part_id'], // We only need the ID
         });
         // Ensure we send integer IDs to Postgres (Meili may return strings)
@@ -36,6 +48,15 @@ router.get('/inventory', async (req, res) => {
         // 2. Use those IDs to get the full inventory data from PostgreSQL
         // Compute stock_on_hand once in a CTE to avoid duplicate subqueries and
         // coalesce wac_cost to 0 so total_value is deterministic.
+        const queryParams = [partIds];
+        const sqlOffset = shouldSortByName && paginated ? 'LIMIT $2 OFFSET $3' : '';
+        if (shouldSortByName && paginated) {
+            queryParams.push(limit, offset);
+        }
+        const orderByClause = shouldSortByName
+            ? `ORDER BY LOWER(COALESCE(g.group_name, '') || ' ' || COALESCE(b.brand_name, '') || ' ' || COALESCE(p.detail, '')) ${sortDirection}, p.part_id ${sortDirection}`
+            : 'ORDER BY p.detail ASC';
+
         const query = `
             WITH stock AS (
                 SELECT part_id, COALESCE(SUM(quantity), 0) AS stock_on_hand
@@ -63,10 +84,11 @@ router.get('/inventory', async (req, res) => {
             LEFT JOIN brand b ON p.brand_id = b.brand_id
             LEFT JOIN "group" g ON p.group_id = g.group_id
             WHERE p.part_id = ANY($1::int[])
-            ORDER BY p.detail ASC;
+            ${orderByClause}
+            ${sqlOffset};
         `;
 
-        const { rows } = await db.query(query, [partIds]);
+        const { rows } = await db.query(query, queryParams);
         
         const inventoryWithDisplayName = rows.map(item => ({
             ...item,
@@ -76,7 +98,9 @@ router.get('/inventory', async (req, res) => {
         if (!paginated) {
             return res.json(inventoryWithDisplayName);
         }
-        const total = searchResults.estimatedTotalHits || searchResults.totalHits || inventoryWithDisplayName.length;
+        const total = shouldSortByName
+            ? (totalHits || inventoryWithDisplayName.length)
+            : (searchResults.estimatedTotalHits || searchResults.totalHits || inventoryWithDisplayName.length);
         res.json(paginatedResponse({ data: inventoryWithDisplayName, page, pageSize, total }));
     } catch (err) {
         console.error(err.message);

--- a/packages/api/routes/partRoutes.js
+++ b/packages/api/routes/partRoutes.js
@@ -111,9 +111,9 @@ const manageTags = async (client, tags, partId) => {
 router.get('/parts', protect, hasPermission('parts:view'), async (req, res) => {
     const { status = 'active', search = '', tags = '' } = req.query;
     const { paginated, page, pageSize, offset, limit } = parsePaginationQuery(req.query);
-    const sortBy = String(req.query.sortBy || 'relevance').toLowerCase();
+    const sortBy = String(req.query.sortBy || 'name').toLowerCase();
     const sortDirection = String(req.query.sortDirection || 'ASC').toUpperCase() === 'DESC' ? 'DESC' : 'ASC';
-    const shouldSortByName = sortBy === 'name' || sortBy === 'display_name';
+    const isGlobalSort = ['name', 'display_name', 'sku', 'application'].includes(sortBy);
     try {
         const index = meiliClient.index('parts');
         const searchOptions = {
@@ -134,14 +134,14 @@ router.get('/parts', protect, hasPermission('parts:view'), async (req, res) => {
 
         if (filter.length > 0) searchOptions.filter = filter.join(' AND ');
 
-        const metadataResults = paginated && shouldSortByName
+        const metadataResults = paginated && isGlobalSort
             ? await index.search(search, { ...searchOptions, limit: 0, offset: 0 })
             : null;
         const totalHits = metadataResults?.estimatedTotalHits || metadataResults?.totalHits || 0;
-        const fetchLimit = paginated && shouldSortByName
+        const fetchLimit = paginated && isGlobalSort
             ? Math.min(totalHits, 20000)
             : (paginated ? limit : 200);
-        const fetchOffset = paginated && shouldSortByName ? 0 : (paginated ? offset : 0);
+        const fetchOffset = paginated && isGlobalSort ? 0 : (paginated ? offset : 0);
 
         const searchResults = await index.search(search, { ...searchOptions, limit: fetchLimit, offset: fetchOffset });
         const partIds = searchResults.hits.map(hit => hit.part_id);
@@ -151,13 +151,20 @@ router.get('/parts', protect, hasPermission('parts:view'), async (req, res) => {
         }
 
         const queryParams = [partIds];
-        const sqlOffset = shouldSortByName && paginated ? `LIMIT $2 OFFSET $3` : '';
-        if (shouldSortByName && paginated) {
+        const sqlOffset = isGlobalSort && paginated ? `LIMIT $2 OFFSET $3` : '';
+        if (isGlobalSort && paginated) {
             queryParams.push(limit, offset);
         }
-        const orderByClause = shouldSortByName
-            ? `ORDER BY LOWER(COALESCE(g.group_name, '') || ' ' || COALESCE(b.brand_name, '') || ' ' || COALESCE(p.detail, '')) ${sortDirection}, p.part_id ${sortDirection}`
-            : 'ORDER BY array_position($1::int[], p.part_id)';
+        let orderByClause = 'ORDER BY array_position($1::int[], p.part_id)';
+        if (isGlobalSort) {
+            if (sortBy === 'sku') {
+                orderByClause = `ORDER BY LOWER(COALESCE(p.internal_sku, '')) ${sortDirection}, p.part_id ${sortDirection}`;
+            } else if (sortBy === 'application') {
+                orderByClause = `ORDER BY LOWER(COALESCE(applications, '')) ${sortDirection}, p.part_id ${sortDirection}`;
+            } else {
+                orderByClause = `ORDER BY LOWER(COALESCE(g.group_name, '') || ' ' || COALESCE(b.brand_name, '') || ' ' || COALESCE(p.detail, '')) ${sortDirection}, p.part_id ${sortDirection}`;
+            }
+        }
 
         const query = `
             SELECT
@@ -193,7 +200,7 @@ router.get('/parts', protect, hasPermission('parts:view'), async (req, res) => {
         if (!paginated) {
             return res.json(partsWithDisplayName);
         }
-        const total = shouldSortByName
+        const total = isGlobalSort
             ? (totalHits || partsWithDisplayName.length)
             : (searchResults.estimatedTotalHits || searchResults.totalHits || partsWithDisplayName.length);
         res.json(paginatedResponse({ data: partsWithDisplayName, page, pageSize, total }));

--- a/packages/api/routes/partRoutes.js
+++ b/packages/api/routes/partRoutes.js
@@ -111,11 +111,12 @@ const manageTags = async (client, tags, partId) => {
 router.get('/parts', protect, hasPermission('parts:view'), async (req, res) => {
     const { status = 'active', search = '', tags = '' } = req.query;
     const { paginated, page, pageSize, offset, limit } = parsePaginationQuery(req.query);
+    const sortBy = String(req.query.sortBy || 'relevance').toLowerCase();
+    const sortDirection = String(req.query.sortDirection || 'ASC').toUpperCase() === 'DESC' ? 'DESC' : 'ASC';
+    const shouldSortByName = sortBy === 'name' || sortBy === 'display_name';
     try {
         const index = meiliClient.index('parts');
-        const searchOptions = { 
-            limit: paginated ? limit : 200,
-            offset: paginated ? offset : 0,
+        const searchOptions = {
             attributesToRetrieve: ['part_id'],
             // Prioritize exact normalized matches, then fall back to fuzzy search
             attributesToSearchOn: ['normalized_internal_sku', 'normalized_part_numbers', 'internal_sku', 'part_numbers', 'display_name', 'detail', 'brand_name', 'group_name', 'searchable_applications', 'tags']
@@ -133,12 +134,30 @@ router.get('/parts', protect, hasPermission('parts:view'), async (req, res) => {
 
         if (filter.length > 0) searchOptions.filter = filter.join(' AND ');
 
-        const searchResults = await index.search(search, searchOptions);
+        const metadataResults = paginated && shouldSortByName
+            ? await index.search(search, { ...searchOptions, limit: 0, offset: 0 })
+            : null;
+        const totalHits = metadataResults?.estimatedTotalHits || metadataResults?.totalHits || 0;
+        const fetchLimit = paginated && shouldSortByName
+            ? Math.min(totalHits, 20000)
+            : (paginated ? limit : 200);
+        const fetchOffset = paginated && shouldSortByName ? 0 : (paginated ? offset : 0);
+
+        const searchResults = await index.search(search, { ...searchOptions, limit: fetchLimit, offset: fetchOffset });
         const partIds = searchResults.hits.map(hit => hit.part_id);
         if (partIds.length === 0) {
             if (paginated) return res.json(paginatedResponse({ data: [], page, pageSize, total: 0 }));
             return res.json([]);
         }
+
+        const queryParams = [partIds];
+        const sqlOffset = shouldSortByName && paginated ? `LIMIT $2 OFFSET $3` : '';
+        if (shouldSortByName && paginated) {
+            queryParams.push(limit, offset);
+        }
+        const orderByClause = shouldSortByName
+            ? `ORDER BY LOWER(COALESCE(g.group_name, '') || ' ' || COALESCE(b.brand_name, '') || ' ' || COALESCE(p.detail, '')) ${sortDirection}, p.part_id ${sortDirection}`
+            : 'ORDER BY array_position($1::int[], p.part_id)';
 
         const query = `
             SELECT
@@ -166,14 +185,17 @@ router.get('/parts', protect, hasPermission('parts:view'), async (req, res) => {
             LEFT JOIN brand AS b ON p.brand_id = b.brand_id
             LEFT JOIN "group" AS g ON p.group_id = g.group_id
             WHERE p.part_id = ANY($1::int[])
-            ORDER BY array_position($1::int[], p.part_id)
+            ${orderByClause}
+            ${sqlOffset}
         `;
-        const { rows } = await db.query(query, [partIds]);
+        const { rows } = await db.query(query, queryParams);
         const partsWithDisplayName = rows.map(part => ({ ...part, display_name: constructDisplayName(part) }));
         if (!paginated) {
             return res.json(partsWithDisplayName);
         }
-        const total = searchResults.estimatedTotalHits || searchResults.totalHits || partsWithDisplayName.length;
+        const total = shouldSortByName
+            ? (totalHits || partsWithDisplayName.length)
+            : (searchResults.estimatedTotalHits || searchResults.totalHits || partsWithDisplayName.length);
         res.json(paginatedResponse({ data: partsWithDisplayName, page, pageSize, total }));
     } catch (err) {
         console.error(err.message);

--- a/packages/api/routes/partRoutes.js
+++ b/packages/api/routes/partRoutes.js
@@ -6,6 +6,7 @@ const { meiliClient } = require('../meilisearch');
 const { enqueuePartUpsert, enqueuePartDelete } = require('../services/meiliOutboxService');
 const { activeAliasCondition } = require('../helpers/partNumberSoftDelete');
 const { normalizePartData } = require('../helpers/normalizePart');
+const { parsePaginationQuery, paginatedResponse } = require('../helpers/pagination');
 const router = express.Router();
 
 // Helper function to get all data for a part for Meilisearch indexing
@@ -109,10 +110,12 @@ const manageTags = async (client, tags, partId) => {
 // GET all parts with status filter, search, and sorting (POWERED BY MEILISEARCH)
 router.get('/parts', protect, hasPermission('parts:view'), async (req, res) => {
     const { status = 'active', search = '', tags = '' } = req.query;
+    const { paginated, page, pageSize, offset, limit } = parsePaginationQuery(req.query);
     try {
         const index = meiliClient.index('parts');
         const searchOptions = { 
-            limit: 200, 
+            limit: paginated ? limit : 200,
+            offset: paginated ? offset : 0,
             attributesToRetrieve: ['part_id'],
             // Prioritize exact normalized matches, then fall back to fuzzy search
             attributesToSearchOn: ['normalized_internal_sku', 'normalized_part_numbers', 'internal_sku', 'part_numbers', 'display_name', 'detail', 'brand_name', 'group_name', 'searchable_applications', 'tags']
@@ -132,7 +135,10 @@ router.get('/parts', protect, hasPermission('parts:view'), async (req, res) => {
 
         const searchResults = await index.search(search, searchOptions);
         const partIds = searchResults.hits.map(hit => hit.part_id);
-        if (partIds.length === 0) return res.json([]);
+        if (partIds.length === 0) {
+            if (paginated) return res.json(paginatedResponse({ data: [], page, pageSize, total: 0 }));
+            return res.json([]);
+        }
 
         const query = `
             SELECT
@@ -164,7 +170,11 @@ router.get('/parts', protect, hasPermission('parts:view'), async (req, res) => {
         `;
         const { rows } = await db.query(query, [partIds]);
         const partsWithDisplayName = rows.map(part => ({ ...part, display_name: constructDisplayName(part) }));
-        res.json(partsWithDisplayName);
+        if (!paginated) {
+            return res.json(partsWithDisplayName);
+        }
+        const total = searchResults.estimatedTotalHits || searchResults.totalHits || partsWithDisplayName.length;
+        res.json(paginatedResponse({ data: partsWithDisplayName, page, pageSize, total }));
     } catch (err) {
         console.error(err.message);
         res.status(500).send('Server Error');

--- a/packages/api/routes/purchaseOrderRoutes.js
+++ b/packages/api/routes/purchaseOrderRoutes.js
@@ -2,6 +2,7 @@ const express = require('express');
 const db = require('../db');
 const { getNextDocumentNumber } = require('../helpers/documentNumberGenerator');
 const { constructDisplayName } = require('../helpers/displayNameHelper');
+const { parsePaginationQuery, paginatedResponse } = require('../helpers/pagination');
 const fs = require('fs');
 const { protect, hasPermission } = require('../middleware/authMiddleware');
 const router = express.Router();
@@ -9,6 +10,7 @@ const router = express.Router();
 // GET /api/purchase-orders - Get all purchase orders with status filter
 router.get('/purchase-orders', protect, hasPermission('purchase_orders:view'), async (req, res) => {
     const { status = 'Pending' } = req.query; // Default to Pending
+    const { paginated, page, pageSize, offset, limit } = parsePaginationQuery(req.query);
     let whereClause = '';
     const queryParams = [];
 
@@ -18,16 +20,41 @@ router.get('/purchase-orders', protect, hasPermission('purchase_orders:view'), a
     }
 
     try {
-        const query = `
+        const baseQuery = `
             SELECT po.*, s.supplier_name, e.first_name, e.last_name
             FROM purchase_order po
             JOIN supplier s ON po.supplier_id = s.supplier_id
             JOIN employee e ON po.employee_id = e.employee_id
             ${whereClause}
-            ORDER BY po.order_date DESC
         `;
-        const { rows } = await db.query(query, queryParams);
-        res.json(rows);
+
+        if (!paginated) {
+            const { rows } = await db.query(
+                `${baseQuery}
+                 ORDER BY po.order_date DESC, po.po_id DESC`,
+                queryParams
+            );
+            return res.json(rows);
+        }
+
+        const countQuery = `
+            SELECT COUNT(*)::int AS total
+            FROM purchase_order po
+            ${whereClause}
+        `;
+        const countRes = await db.query(countQuery, queryParams);
+        const total = countRes.rows[0]?.total || 0;
+
+        const paginatedParams = [...queryParams, limit, offset];
+        const paginationPlaceholderStart = queryParams.length + 1;
+        const { rows } = await db.query(
+            `${baseQuery}
+             ORDER BY po.order_date DESC, po.po_id DESC
+             LIMIT $${paginationPlaceholderStart} OFFSET $${paginationPlaceholderStart + 1}`,
+            paginatedParams
+        );
+
+        res.json(paginatedResponse({ data: rows, page, pageSize, total }));
     } catch (err) {
         console.error(err.message);
         res.status(500).send('Server Error');

--- a/packages/api/routes/reportingRoutes.js
+++ b/packages/api/routes/reportingRoutes.js
@@ -3,16 +3,18 @@ const db = require('../db');
 const { Parser } = require('json2csv');
 const { constructDisplayName } = require('../helpers/displayNameHelper');
 const { protect, hasPermission } = require('../middleware/authMiddleware');
+const { parsePaginationQuery, paginatedResponse } = require('../helpers/pagination');
 const router = express.Router();
 
 // GET /api/reports/sales-summary
 router.get('/reports/sales-summary', protect, hasPermission('reports:view'), async (req, res) => {
     const { startDate, endDate, format = 'json' } = req.query;
+    const { paginated, page, pageSize, limit, offset } = parsePaginationQuery(req.query);
     if (!startDate || !endDate) return res.status(400).json({ message: 'Start date and end date are required.' });
     
     const client = await db.getClient();
     try {
-        const detailsQuery = `
+        const detailsBaseQuery = `
             SELECT 
                 i.invoice_date, i.invoice_number, p.detail,
                 g.group_name, b.brand_name,
@@ -26,7 +28,7 @@ router.get('/reports/sales-summary', protect, hasPermission('reports:view'), asy
             LEFT JOIN brand b ON p.brand_id = b.brand_id
             LEFT JOIN "group" g ON p.group_id = g.group_id
             WHERE (i.invoice_date AT TIME ZONE 'Asia/Manila')::date BETWEEN $1 AND $2
-            ORDER BY i.invoice_date;
+            ORDER BY i.invoice_date
         `;
         
         const summaryQuery = `
@@ -38,10 +40,24 @@ router.get('/reports/sales-summary', protect, hasPermission('reports:view'), asy
                 (SELECT COUNT(*) FROM invoice WHERE (invoice_date AT TIME ZONE 'Asia/Manila')::date BETWEEN $1 AND $2) AS total_invoices
         `;
 
-        const [detailsRes, summaryRes] = await Promise.all([
-            client.query(detailsQuery, [startDate, endDate]),
-            client.query(summaryQuery, [startDate, endDate])
-        ]);
+        const summaryPromise = client.query(summaryQuery, [startDate, endDate]);
+        const detailsPromise = (() => {
+            if (format === 'csv' || !paginated) {
+                return client.query(detailsBaseQuery, [startDate, endDate]);
+            }
+            const paginatedQuery = `${detailsBaseQuery} LIMIT $3 OFFSET $4`;
+            return client.query(paginatedQuery, [startDate, endDate, limit, offset]);
+        })();
+        const countPromise = (format === 'json' && paginated)
+            ? client.query(`
+                SELECT COUNT(*)::int AS total
+                FROM invoice i
+                JOIN invoice_line il ON i.invoice_id = il.invoice_id
+                WHERE (i.invoice_date AT TIME ZONE 'Asia/Manila')::date BETWEEN $1 AND $2
+            `, [startDate, endDate])
+            : Promise.resolve({ rows: [{ total: 0 }] });
+
+        const [detailsRes, summaryRes, countRes] = await Promise.all([detailsPromise, summaryPromise, countPromise]);
 
         const details = detailsRes.rows.map(row => ({ ...row, display_name: constructDisplayName(row) }));
         
@@ -60,6 +76,9 @@ router.get('/reports/sales-summary', protect, hasPermission('reports:view'), asy
             const json2csvParser = new Parser();
             const csv = json2csvParser.parse(details);
             res.header('Content-Type', 'text/csv').attachment(`sales-report-${startDate}-to-${endDate}.csv`).send(csv);
+        } else if (paginated) {
+            const total = countRes.rows[0]?.total || 0;
+            res.json({ summary, ...paginatedResponse({ data: details, page, pageSize, total }) });
         } else {
             res.json({ summary, details });
         }
@@ -74,11 +93,12 @@ router.get('/reports/sales-summary', protect, hasPermission('reports:view'), asy
 // GET /api/reports/top-selling - (No change needed here as it doesn't calculate profit)
 router.get('/reports/top-selling', protect, hasPermission('reports:view'), async (req, res) => {
     const { startDate, endDate, sortBy = 'revenue', format = 'json' } = req.query;
+    const { paginated, page, pageSize, limit, offset } = parsePaginationQuery(req.query);
     if (!startDate || !endDate) return res.status(400).json({ message: 'Start date and end date are required.' });
 
     const orderByClause = sortBy === 'quantity' ? 'total_quantity_sold DESC' : 'total_revenue DESC';
     try {
-        const query = `
+        let query = `
             SELECT
                 p.part_id, p.internal_sku, p.detail,
                 b.brand_name, g.group_name,
@@ -93,15 +113,41 @@ router.get('/reports/top-selling', protect, hasPermission('reports:view'), async
             WHERE (i.invoice_date AT TIME ZONE 'Asia/Manila')::date BETWEEN $1 AND $2
             GROUP BY p.part_id, b.brand_name, g.group_name
             ORDER BY ${orderByClause}
-            LIMIT 100;
         `;
-        const { rows } = await db.query(query, [startDate, endDate]);
+        const params = [startDate, endDate];
+        if (format === 'json' && paginated) {
+            query += ` LIMIT $3 OFFSET $4`;
+            params.push(limit, offset);
+        } else {
+            query += ` LIMIT 100`;
+        }
+
+        const [rowsRes, countRes] = await Promise.all([
+            db.query(query, params),
+            (format === 'json' && paginated) ? db.query(`
+                SELECT COUNT(*)::int AS total
+                FROM (
+                    SELECT p.part_id
+                    FROM invoice_line il
+                    JOIN part p ON il.part_id = p.part_id
+                    JOIN invoice i ON il.invoice_id = i.invoice_id
+                    LEFT JOIN brand b ON p.brand_id = b.brand_id
+                    LEFT JOIN "group" g ON p.group_id = g.group_id
+                    WHERE (i.invoice_date AT TIME ZONE 'Asia/Manila')::date BETWEEN $1 AND $2
+                    GROUP BY p.part_id, b.brand_name, g.group_name
+                ) ranked_parts
+            `, [startDate, endDate]) : Promise.resolve({ rows: [{ total: 0 }] })
+        ]);
+        const { rows } = rowsRes;
         const data = rows.map(row => ({ ...row, display_name: constructDisplayName(row) }));
 
         if (format === 'csv') {
             const json2csvParser = new Parser();
             const csv = json2csvParser.parse(data);
             res.header('Content-Type', 'text/csv').attachment(`top-selling-report-${startDate}-to-${endDate}.csv`).send(csv);
+        } else if (paginated) {
+            const total = countRes.rows[0]?.total || 0;
+            res.json(paginatedResponse({ data, page, pageSize, total }));
         } else {
             res.json(data);
         }
@@ -114,8 +160,9 @@ router.get('/reports/top-selling', protect, hasPermission('reports:view'), async
 // GET /api/reports/inventory-valuation
 router.get('/reports/inventory-valuation', protect, hasPermission('reports:view'), async (req, res) => {
     const { format = 'json' } = req.query;
+    const { paginated, page, pageSize, limit, offset } = parsePaginationQuery(req.query);
     try {
-        const query = `
+        let query = `
             SELECT
                 p.internal_sku,
                 p.detail,
@@ -144,10 +191,23 @@ router.get('/reports/inventory-valuation', protect, hasPermission('reports:view'
             LEFT JOIN "group" g ON p.group_id = g.group_id
             WHERE p.is_service = FALSE AND p.is_active = TRUE
             GROUP BY p.part_id, b.brand_name, g.group_name
-            ORDER BY p.detail;
+            ORDER BY p.detail
         `;
 
-        const { rows } = await db.query(query);
+        const params = [];
+        if (format === 'json' && paginated) {
+            query += ` LIMIT $1 OFFSET $2`;
+            params.push(limit, offset);
+        }
+        const [rowsRes, countRes] = await Promise.all([
+            db.query(query, params),
+            (format === 'json' && paginated) ? db.query(`
+                SELECT COUNT(*)::int AS total
+                FROM part p
+                WHERE p.is_service = FALSE AND p.is_active = TRUE
+            `) : Promise.resolve({ rows: [{ total: 0 }] })
+        ]);
+        const { rows } = rowsRes;
         const data = rows.map(row => ({ ...row, display_name: constructDisplayName(row) }));
 
         if (format === 'csv') {
@@ -158,6 +218,10 @@ router.get('/reports/inventory-valuation', protect, hasPermission('reports:view'
             return res.send(csv);
         }
 
+        if (paginated) {
+            const total = countRes.rows[0]?.total || 0;
+            return res.json(paginatedResponse({ data, page, pageSize, total }));
+        }
         res.json(data);
     } catch (err) {
         console.error(err.message);
@@ -168,8 +232,9 @@ router.get('/reports/inventory-valuation', protect, hasPermission('reports:view'
 // GET /api/reports/low-stock - (No change needed)
 router.get('/reports/low-stock', protect, hasPermission('reports:view'), async (req, res) => {
     const { format = 'json' } = req.query;
+    const { paginated, page, pageSize, limit, offset } = parsePaginationQuery(req.query);
     try {
-        const query = `
+        let query = `
             SELECT 
                 p.internal_sku,
                 p.detail,
@@ -192,15 +257,38 @@ router.get('/reports/low-stock', protect, hasPermission('reports:view'), async (
             WHERE p.is_active = TRUE AND p.low_stock_warning = TRUE
             GROUP BY p.part_id, b.brand_name, g.group_name
             HAVING COALESCE(SUM( (SELECT SUM(it.quantity) FROM inventory_transaction it WHERE it.part_id = p.part_id) ), 0) <= p.reorder_point
-            ORDER BY p.detail;
+            ORDER BY p.detail
         `;
-        const { rows } = await db.query(query);
+        const params = [];
+        if (format === 'json' && paginated) {
+            query += ` LIMIT $1 OFFSET $2`;
+            params.push(limit, offset);
+        }
+        const [rowsRes, countRes] = await Promise.all([
+            db.query(query, params),
+            (format === 'json' && paginated) ? db.query(`
+                SELECT COUNT(*)::int AS total
+                FROM (
+                    SELECT p.part_id
+                    FROM part p
+                    LEFT JOIN brand b ON p.brand_id = b.brand_id
+                    LEFT JOIN "group" g ON p.group_id = g.group_id
+                    WHERE p.is_active = TRUE AND p.low_stock_warning = TRUE
+                    GROUP BY p.part_id, b.brand_name, g.group_name
+                    HAVING COALESCE(SUM((SELECT SUM(it.quantity) FROM inventory_transaction it WHERE it.part_id = p.part_id)), 0) <= p.reorder_point
+                ) low_stock_parts
+            `) : Promise.resolve({ rows: [{ total: 0 }] })
+        ]);
+        const { rows } = rowsRes;
         const data = rows.map(row => ({ ...row, display_name: constructDisplayName(row) }));
 
         if (format === 'csv') {
             const json2csvParser = new Parser();
             const csv = json2csvParser.parse(data);
             res.header('Content-Type', 'text/csv').attachment('low-stock-report.csv').send(csv);
+        } else if (paginated) {
+            const total = countRes.rows[0]?.total || 0;
+            res.json(paginatedResponse({ data, page, pageSize, total }));
         } else {
             res.json(data);
         }
@@ -214,6 +302,7 @@ router.get('/reports/low-stock', protect, hasPermission('reports:view'), async (
 // GET /api/reports/sales-by-customer - (No change needed)
 router.get('/reports/sales-by-customer', protect, hasPermission('reports:view'), async (req, res) => {
     const { startDate, endDate, customerId, format = 'json' } = req.query;
+    const { paginated, page, pageSize, limit, offset } = parsePaginationQuery(req.query);
     if (!startDate || !endDate) return res.status(400).json({ message: 'Start date and end date are required.' });
 
     let whereClauses = ["(i.invoice_date AT TIME ZONE 'Asia/Manila')::date BETWEEN $1 AND $2"];
@@ -225,7 +314,7 @@ router.get('/reports/sales-by-customer', protect, hasPermission('reports:view'),
     }
 
     try {
-        const query = `
+        let query = `
             SELECT
                 c.customer_id,
                 c.first_name,
@@ -237,13 +326,34 @@ router.get('/reports/sales-by-customer', protect, hasPermission('reports:view'),
             JOIN invoice i ON c.customer_id = i.customer_id
             WHERE ${whereClauses.join(' AND ')}
             GROUP BY c.customer_id
-            ORDER BY total_sales DESC;
+            ORDER BY total_sales DESC
         `;
-        const { rows } = await db.query(query, queryParams);
+        const params = [...queryParams];
+        if (format === 'json' && paginated) {
+            query += ` LIMIT $${params.length + 1} OFFSET $${params.length + 2}`;
+            params.push(limit, offset);
+        }
+        const [rowsRes, countRes] = await Promise.all([
+            db.query(query, params),
+            (format === 'json' && paginated) ? db.query(`
+                SELECT COUNT(*)::int AS total
+                FROM (
+                    SELECT c.customer_id
+                    FROM customer c
+                    JOIN invoice i ON c.customer_id = i.customer_id
+                    WHERE ${whereClauses.join(' AND ')}
+                    GROUP BY c.customer_id
+                ) customer_totals
+            `, queryParams) : Promise.resolve({ rows: [{ total: 0 }] })
+        ]);
+        const { rows } = rowsRes;
         if (format === 'csv') {
             const json2csvParser = new Parser();
             const csv = json2csvParser.parse(rows);
             res.header('Content-Type', 'text/csv').attachment('sales-by-customer.csv').send(csv);
+        } else if (paginated) {
+            const total = countRes.rows[0]?.total || 0;
+            res.json(paginatedResponse({ data: rows, page, pageSize, total }));
         } else {
             res.json(rows);
         }
@@ -256,6 +366,7 @@ router.get('/reports/sales-by-customer', protect, hasPermission('reports:view'),
 // GET /api/reports/inventory-movement - (No change needed)
 router.get('/reports/inventory-movement', protect, hasPermission('reports:view'), async (req, res) => {
     const { startDate, endDate, partId, format = 'json' } = req.query;
+    const { paginated, page, pageSize, limit, offset } = parsePaginationQuery(req.query);
     if (!startDate || !endDate) return res.status(400).json({ message: 'Start date and end date are required.' });
 
     let whereClauses = ["(it.transaction_date AT TIME ZONE 'Asia/Manila')::date BETWEEN $1 AND $2"];
@@ -267,7 +378,7 @@ router.get('/reports/inventory-movement', protect, hasPermission('reports:view')
     }
 
     try {
-        const query = `
+        let query = `
             SELECT
                 it.transaction_date,
                 p.internal_sku,
@@ -285,15 +396,31 @@ router.get('/reports/inventory-movement', protect, hasPermission('reports:view')
             LEFT JOIN "group" g ON p.group_id = g.group_id
             LEFT JOIN employee e ON it.employee_id = e.employee_id
             WHERE ${whereClauses.join(' AND ')}
-            ORDER BY it.transaction_date DESC;
+            ORDER BY it.transaction_date DESC
         `;
-        const { rows } = await db.query(query, queryParams);
+        const params = [...queryParams];
+        if (format === 'json' && paginated) {
+            query += ` LIMIT $${params.length + 1} OFFSET $${params.length + 2}`;
+            params.push(limit, offset);
+        }
+        const [rowsRes, countRes] = await Promise.all([
+            db.query(query, params),
+            (format === 'json' && paginated) ? db.query(`
+                SELECT COUNT(*)::int AS total
+                FROM inventory_transaction it
+                WHERE ${whereClauses.join(' AND ')}
+            `, queryParams) : Promise.resolve({ rows: [{ total: 0 }] })
+        ]);
+        const { rows } = rowsRes;
         const data = rows.map(row => ({ ...row, display_name: constructDisplayName(row) }));
         
         if (format === 'csv') {
             const json2csvParser = new Parser();
             const csv = json2csvParser.parse(data);
             res.header('Content-Type', 'text/csv').attachment('inventory-movement.csv').send(csv);
+        } else if (paginated) {
+            const total = countRes.rows[0]?.total || 0;
+            res.json(paginatedResponse({ data, page, pageSize, total }));
         } else {
             res.json(data);
         }
@@ -306,6 +433,7 @@ router.get('/reports/inventory-movement', protect, hasPermission('reports:view')
 // GET /api/reports/profitability-by-product
 router.get('/reports/profitability-by-product', protect, hasPermission('reports:view'), async (req, res) => {
     const { startDate, endDate, brandId, groupId, format = 'json' } = req.query;
+    const { paginated, page, pageSize, limit, offset } = parsePaginationQuery(req.query);
     if (!startDate || !endDate) return res.status(400).json({ message: 'Start date and end date are required.' });
     
     let whereClauses = ["(i.invoice_date AT TIME ZONE 'Asia/Manila')::date BETWEEN $1 AND $2"];
@@ -321,7 +449,7 @@ router.get('/reports/profitability-by-product', protect, hasPermission('reports:
     }
 
     try {
-        const query = `
+        let query = `
             SELECT
                 p.internal_sku,
                 p.detail,
@@ -339,15 +467,39 @@ router.get('/reports/profitability-by-product', protect, hasPermission('reports:
             LEFT JOIN "group" g ON p.group_id = g.group_id
             WHERE ${whereClauses.join(' AND ')}
             GROUP BY p.part_id, b.brand_name, g.group_name
-            ORDER BY total_profit DESC;
+            ORDER BY total_profit DESC
         `;
-        const { rows } = await db.query(query, queryParams);
+        const params = [...queryParams];
+        if (format === 'json' && paginated) {
+            query += ` LIMIT $${params.length + 1} OFFSET $${params.length + 2}`;
+            params.push(limit, offset);
+        }
+        const [rowsRes, countRes] = await Promise.all([
+            db.query(query, params),
+            (format === 'json' && paginated) ? db.query(`
+                SELECT COUNT(*)::int AS total
+                FROM (
+                    SELECT p.part_id
+                    FROM invoice_line il
+                    JOIN part p ON il.part_id = p.part_id
+                    JOIN invoice i ON il.invoice_id = i.invoice_id
+                    LEFT JOIN brand b ON p.brand_id = b.brand_id
+                    LEFT JOIN "group" g ON p.group_id = g.group_id
+                    WHERE ${whereClauses.join(' AND ')}
+                    GROUP BY p.part_id, b.brand_name, g.group_name
+                ) profitability_rows
+            `, queryParams) : Promise.resolve({ rows: [{ total: 0 }] })
+        ]);
+        const { rows } = rowsRes;
         const data = rows.map(row => ({ ...row, display_name: constructDisplayName(row) }));
 
         if (format === 'csv') {
             const json2csvParser = new Parser();
             const csv = json2csvParser.parse(data);
             res.header('Content-Type', 'text/csv').attachment('profitability-by-product.csv').send(csv);
+        } else if (paginated) {
+            const total = countRes.rows[0]?.total || 0;
+            res.json(paginatedResponse({ data, page, pageSize, total }));
         } else {
             res.json(data);
         }
@@ -359,12 +511,13 @@ router.get('/reports/profitability-by-product', protect, hasPermission('reports:
 
 // NEW ENDPOINT: Get refunds report
 router.get('/reports/refunds', protect, hasPermission('reports:view'), async (req, res) => {
-    const { startDate, endDate } = req.query;
+    const { startDate, endDate, format = 'json' } = req.query;
+    const { paginated, page, pageSize, limit, offset } = parsePaginationQuery(req.query);
     if (!startDate || !endDate) {
         return res.status(400).json({ message: 'Start date and end date are required.' });
     }
     try {
-        const query = `
+        let query = `
             SELECT 
                 cn.cn_id,
                 cn.cn_number,
@@ -376,9 +529,32 @@ router.get('/reports/refunds', protect, hasPermission('reports:view'), async (re
             JOIN invoice i ON cn.invoice_id = i.invoice_id
             JOIN customer c ON i.customer_id = c.customer_id
             WHERE (cn.refund_date AT TIME ZONE 'Asia/Manila')::date BETWEEN $1 AND $2
-            ORDER BY cn.refund_date DESC;
+            ORDER BY cn.refund_date DESC
         `;
-        const { rows } = await db.query(query, [startDate, endDate]);
+        const params = [startDate, endDate];
+        if (format === 'json' && paginated) {
+            query += ` LIMIT $3 OFFSET $4`;
+            params.push(limit, offset);
+        }
+        const [rowsRes, countRes] = await Promise.all([
+            db.query(query, params),
+            (format === 'json' && paginated) ? db.query(`
+                SELECT COUNT(*)::int AS total
+                FROM credit_note cn
+                WHERE (cn.refund_date AT TIME ZONE 'Asia/Manila')::date BETWEEN $1 AND $2
+            `, [startDate, endDate]) : Promise.resolve({ rows: [{ total: 0 }] })
+        ]);
+        const { rows } = rowsRes;
+
+        if (format === 'csv') {
+            const json2csvParser = new Parser();
+            const csv = json2csvParser.parse(rows);
+            return res.header('Content-Type', 'text/csv').attachment('refunds-report.csv').send(csv);
+        }
+        if (paginated) {
+            const total = countRes.rows[0]?.total || 0;
+            return res.json(paginatedResponse({ data: rows, page, pageSize, total }));
+        }
         res.json(rows);
     } catch (err) {
         console.error(err.message);

--- a/packages/api/routes/supplierRoutes.js
+++ b/packages/api/routes/supplierRoutes.js
@@ -1,10 +1,12 @@
 const express = require('express');
 const db = require('../db');
+const { parsePaginationQuery, paginatedResponse } = require('../helpers/pagination');
 const router = express.Router();
 
 // GET all suppliers with status filter
 router.get('/suppliers', async (req, res) => {
   const { status = 'active' } = req.query; // Default to 'active'
+  const { paginated, page, pageSize, offset, limit } = parsePaginationQuery(req.query);
 
   let whereClause = "WHERE is_active = TRUE";
   if (status === 'inactive') {
@@ -14,8 +16,18 @@ router.get('/suppliers', async (req, res) => {
   }
 
   try {
-    const { rows } = await db.query(`SELECT * FROM supplier ${whereClause} ORDER BY supplier_name`);
-    res.json(rows);
+    if (!paginated) {
+      const { rows } = await db.query(`SELECT * FROM supplier ${whereClause} ORDER BY supplier_name`);
+      return res.json(rows);
+    }
+
+    const countRes = await db.query(`SELECT COUNT(*)::int AS total FROM supplier ${whereClause}`);
+    const total = countRes.rows[0]?.total || 0;
+    const { rows } = await db.query(
+      `SELECT * FROM supplier ${whereClause} ORDER BY supplier_name LIMIT $1 OFFSET $2`,
+      [limit, offset]
+    );
+    res.json(paginatedResponse({ data: rows, page, pageSize, total }));
   } catch (err) {
     console.error(err.message);
     res.status(500).send('Server Error');

--- a/packages/web/src/components/accounts-receivable/CustomerInvoiceDetailsModal.jsx
+++ b/packages/web/src/components/accounts-receivable/CustomerInvoiceDetailsModal.jsx
@@ -22,6 +22,7 @@ import EditHistory from '../EditHistory';
 import { formatCurrency } from '../../utils/currency';
 import api from '../../api';
 import toast from 'react-hot-toast';
+import PaginationControls from '../ui/PaginationControls';
 
 const CustomerInvoiceDetailsModal = ({
     isOpen,
@@ -29,7 +30,12 @@ const CustomerInvoiceDetailsModal = ({
     title,
     invoices = [],
     loading = false,
-    onAfterDueDateUpdate
+    onAfterDueDateUpdate,
+    page = 1,
+    pageSize = 25,
+    total = 0,
+    onPageChange,
+    onPageSizeChange
 }) => {
     const [selectedInvoice, setSelectedInvoice] = useState(null);
     const [drawerOpen, setDrawerOpen] = useState(false);
@@ -77,8 +83,10 @@ const CustomerInvoiceDetailsModal = ({
             (async () => {
                 try {
                     setRefreshing(true);
-                    const { data } = await api.get(`/ar/customer-invoices/${customerId}`);
-                    setInvoiceData(Array.isArray(data) ? data : []);
+                    const { data } = await api.get(`/ar/customer-invoices/${customerId}`, {
+                        params: { page, pageSize, paginated: 1 }
+                    });
+                    setInvoiceData(Array.isArray(data) ? data : (data?.data || []));
                 } catch (err) {
                     console.error('Failed to refresh invoices after due date update:', err);
                     toast.error('Updated due date, but failed to refresh list');
@@ -240,6 +248,15 @@ const CustomerInvoiceDetailsModal = ({
                                 </tbody>
                             </table>
                         </div>
+                    )}
+                    {!loading && typeof onPageChange === 'function' && typeof onPageSizeChange === 'function' && (
+                        <PaginationControls
+                            page={page}
+                            pageSize={pageSize}
+                            total={total}
+                            onPageChange={onPageChange}
+                            onPageSizeChange={onPageSizeChange}
+                        />
                     )}
                 </div>
             </Modal>

--- a/packages/web/src/components/accounts-receivable/CustomerSummaryTable.jsx
+++ b/packages/web/src/components/accounts-receivable/CustomerSummaryTable.jsx
@@ -44,6 +44,9 @@
  */
 import { formatCurrency } from '../../utils/currency';
 import { getCustomerStatusBadge } from '../../utils/status';
+import { useMemo, useState } from 'react';
+import SortableHeader from '../ui/SortableHeader';
+import { sortData } from '../../utils/sortData';
 
 // Enhanced Loading Skeleton Components
 const _TableSkeleton = () => (
@@ -77,6 +80,11 @@ const CustomerSummaryTable = ({
     loading = false,
     onExport
 }) => {
+    const [sortConfig, setSortConfig] = useState({ key: 'earliest_due_date', direction: 'ASC' });
+    const sortedCustomers = useMemo(() => sortData(customers, sortConfig, {
+        customer_name: (row) => row.company_name || `${row.first_name || ''} ${row.last_name || ''}`.trim(),
+        status: (row) => getCustomerStatusBadge(row)?.text || ''
+    }), [customers, sortConfig]);
     if (loading) return <_TableSkeleton />;
 
     return (
@@ -96,16 +104,16 @@ const CustomerSummaryTable = ({
                 <table className="w-full text-sm text-left text-gray-500">
                     <thead className="text-xs text-gray-700 uppercase bg-gray-50 border-b">
                         <tr>
-                            <th scope="col" className="px-6 py-3">Customer</th>
-                            <th scope="col" className="px-6 py-3">Invoice Count</th>
-                            <th scope="col" className="px-6 py-3">Next Due Date</th>
-                            <th scope="col" className="px-6 py-3">Total Balance</th>
-                            <th scope="col" className="px-6 py-3">Status</th>
+                            <SortableHeader column="customer_name" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Customer</SortableHeader>
+                            <SortableHeader column="invoice_count" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Invoice Count</SortableHeader>
+                            <SortableHeader column="earliest_due_date" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Next Due Date</SortableHeader>
+                            <SortableHeader column="total_balance_due" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Total Balance</SortableHeader>
+                            <SortableHeader column="status" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Status</SortableHeader>
                             {hasPaymentPermission && <th scope="col" className="px-6 py-3">Actions</th>}
                         </tr>
                     </thead>
                     <tbody>
-                        {customers.map((customer, index) => {
+                        {sortedCustomers.map((customer, index) => {
                             const statusBadge = getCustomerStatusBadge(customer);
                             return (
                                 <tr

--- a/packages/web/src/components/reports/InventoryMovementReport.jsx
+++ b/packages/web/src/components/reports/InventoryMovementReport.jsx
@@ -3,7 +3,9 @@ import api from '../../api';
 import toast from 'react-hot-toast';
 import Combobox from '../ui/Combobox';
 import PaginationControls from '../ui/PaginationControls';
+import SortableHeader from '../ui/SortableHeader';
 import { getPaginatedPayload } from '../../utils/paginatedResponse';
+import { sortData } from '../../utils/sortData';
 import { format, parseISO } from 'date-fns';
 import { toZonedTime } from 'date-fns-tz';
 
@@ -14,6 +16,7 @@ const InventoryMovementReport = () => {
     const [page, setPage] = useState(1);
     const [pageSize, setPageSize] = useState(25);
     const [total, setTotal] = useState(0);
+    const [sortConfig, setSortConfig] = useState({ key: 'transaction_date', direction: 'DESC' });
     const [filters, setFilters] = useState(() => {
         const now = toZonedTime(new Date(), 'Asia/Manila');
         const dateStr = format(now, 'yyyy-MM-dd');
@@ -71,6 +74,7 @@ const InventoryMovementReport = () => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [page, pageSize]);
     
+    const sortedReportData = sortData(reportData, sortConfig);
     return (
         <>
             <div className="bg-white p-6 rounded-xl border border-gray-200 mb-6">
@@ -105,16 +109,16 @@ const InventoryMovementReport = () => {
                         <table className="w-full text-left">
                             <thead className="border-b">
                                 <tr>
-                                    <th className="p-3 text-sm font-semibold text-gray-600">Date</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600">Item</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600">Type</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600 text-center">Quantity</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600">Reference</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600">User</th>
+                                    <SortableHeader column="transaction_date" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Date</SortableHeader>
+                                    <SortableHeader column="display_name" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Item</SortableHeader>
+                                    <SortableHeader column="trans_type" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Type</SortableHeader>
+                                    <SortableHeader className="text-center" column="quantity" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Quantity</SortableHeader>
+                                    <SortableHeader column="reference_no" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Reference</SortableHeader>
+                                    <SortableHeader column="employee_name" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>User</SortableHeader>
                                 </tr>
                             </thead>
                             <tbody>
-                                {reportData.map((row, index) => (
+                                {sortedReportData.map((row, index) => (
                                     <tr key={index} className="border-b hover:bg-gray-50">
                                         <td className="p-3 text-sm whitespace-nowrap">{format(toZonedTime(parseISO(row.transaction_date), 'Asia/Manila'), 'MM/dd/yyyy hh:mm a')}</td>
                                         <td className="p-3 text-sm font-medium text-gray-800">{row.display_name}</td>

--- a/packages/web/src/components/reports/InventoryMovementReport.jsx
+++ b/packages/web/src/components/reports/InventoryMovementReport.jsx
@@ -2,6 +2,8 @@ import React, { useState, useEffect } from 'react';
 import api from '../../api';
 import toast from 'react-hot-toast';
 import Combobox from '../ui/Combobox';
+import PaginationControls from '../ui/PaginationControls';
+import { getPaginatedPayload } from '../../utils/paginatedResponse';
 import { format, parseISO } from 'date-fns';
 import { toZonedTime } from 'date-fns-tz';
 
@@ -9,6 +11,9 @@ const InventoryMovementReport = () => {
     const [reportData, setReportData] = useState([]);
     const [parts, setParts] = useState([]);
     const [loading, setLoading] = useState(false);
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(25);
+    const [total, setTotal] = useState(0);
     const [filters, setFilters] = useState(() => {
         const now = toZonedTime(new Date(), 'Asia/Manila');
         const dateStr = format(now, 'yyyy-MM-dd');
@@ -27,6 +32,7 @@ const InventoryMovementReport = () => {
 
     const handleFilterChange = (name, value) => {
         setFilters(prev => ({ ...prev, [name]: value }));
+        setPage(1);
     };
 
     const fetchReport = async (format = 'json') => {
@@ -34,7 +40,7 @@ const InventoryMovementReport = () => {
         if (format === 'json') setLoading(true);
         try {
             const response = await api.get('/reports/inventory-movement', {
-                params: { ...filters, format },
+                params: { ...filters, format, page, pageSize, paginated: 1 },
                 responseType: format === 'csv' ? 'blob' : 'json',
             });
             if (format === 'csv') {
@@ -47,7 +53,9 @@ const InventoryMovementReport = () => {
                 link.remove();
                 toast.success('Report exported successfully!');
             } else {
-                setReportData(response.data);
+                const paginated = getPaginatedPayload(response.data);
+                setReportData(paginated.data);
+                setTotal(paginated.total);
             }
         } catch {
             toast.error('Failed to generate report.');
@@ -55,6 +63,13 @@ const InventoryMovementReport = () => {
             if (format === 'json') setLoading(false);
         }
     };
+
+    useEffect(() => {
+        if (reportData.length > 0) {
+            fetchReport('json');
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [page, pageSize]);
     
     return (
         <>
@@ -85,6 +100,7 @@ const InventoryMovementReport = () => {
             </div>
             <div className="bg-white p-6 rounded-xl border border-gray-200">
                 {loading ? <p>Loading report...</p> : (
+                    <>
                     <div className="overflow-x-auto">
                         <table className="w-full text-left">
                             <thead className="border-b">
@@ -109,8 +125,19 @@ const InventoryMovementReport = () => {
                                     </tr>
                                 ))}
                             </tbody>
-                        </table>
-                    </div>
+                    </table>
+                </div>
+                <PaginationControls
+                    page={page}
+                    pageSize={pageSize}
+                    total={total}
+                    onPageChange={setPage}
+                    onPageSizeChange={(size) => {
+                        setPageSize(size);
+                        setPage(1);
+                    }}
+                />
+                </>
                 )}
             </div>
         </>

--- a/packages/web/src/components/reports/InventoryValuationReport.jsx
+++ b/packages/web/src/components/reports/InventoryValuationReport.jsx
@@ -3,7 +3,9 @@ import api from '../../api';
 import toast from 'react-hot-toast';
 import { useSettings } from '../../contexts/SettingsContext';
 import PaginationControls from '../ui/PaginationControls';
+import SortableHeader from '../ui/SortableHeader';
 import { getPaginatedPayload } from '../../utils/paginatedResponse';
+import { sortData } from '../../utils/sortData';
 
 const InventoryValuationReport = () => {
     const { settings } = useSettings();
@@ -12,6 +14,7 @@ const InventoryValuationReport = () => {
     const [page, setPage] = useState(1);
     const [pageSize, setPageSize] = useState(25);
     const [total, setTotal] = useState(0);
+    const [sortConfig, setSortConfig] = useState({ key: 'total_value', direction: 'DESC' });
 
     const fetchReport = async (format = 'json') => {
         if (format === 'json') setLoading(true);
@@ -46,7 +49,8 @@ const InventoryValuationReport = () => {
         fetchReport();
     }, [page, pageSize]);
 
-    const grandTotal = reportData.reduce((acc, row) => acc + parseFloat(row.total_value), 0);
+    const sortedReportData = sortData(reportData, sortConfig);
+    const grandTotal = sortedReportData.reduce((acc, row) => acc + parseFloat(row.total_value), 0);
 
     return (
         <>
@@ -63,15 +67,15 @@ const InventoryValuationReport = () => {
                         <table className="w-full text-left">
                             <thead className="border-b">
                                 <tr>
-                                    <th className="p-3 text-sm font-semibold text-gray-600">SKU</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600">Item</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600 text-center">Stock on Hand</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600 text-right">WAC</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600 text-right">Total Value</th>
+                                    <SortableHeader column="internal_sku" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>SKU</SortableHeader>
+                                    <SortableHeader column="display_name" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Item</SortableHeader>
+                                    <SortableHeader className="text-center" column="stock_on_hand" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Stock on Hand</SortableHeader>
+                                    <SortableHeader className="text-right" column="wac_cost" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>WAC</SortableHeader>
+                                    <SortableHeader className="text-right" column="total_value" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Total Value</SortableHeader>
                                 </tr>
                             </thead>
                             <tbody>
-                                {reportData.map((row, index) => (
+                                {sortedReportData.map((row, index) => (
                                     <tr key={index} className="border-b hover:bg-gray-50">
                                         <td className="p-3 text-sm font-mono">{row.internal_sku}</td>
                                         <td className="p-3 text-sm">{row.display_name}</td>

--- a/packages/web/src/components/reports/InventoryValuationReport.jsx
+++ b/packages/web/src/components/reports/InventoryValuationReport.jsx
@@ -2,17 +2,22 @@ import React, { useState, useEffect } from 'react';
 import api from '../../api';
 import toast from 'react-hot-toast';
 import { useSettings } from '../../contexts/SettingsContext';
+import PaginationControls from '../ui/PaginationControls';
+import { getPaginatedPayload } from '../../utils/paginatedResponse';
 
 const InventoryValuationReport = () => {
     const { settings } = useSettings();
     const [reportData, setReportData] = useState([]);
     const [loading, setLoading] = useState(true);
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(25);
+    const [total, setTotal] = useState(0);
 
     const fetchReport = async (format = 'json') => {
         if (format === 'json') setLoading(true);
         try {
             const response = await api.get('/reports/inventory-valuation', {
-                params: { format },
+                params: { format, page, pageSize, paginated: 1 },
                 responseType: format === 'csv' ? 'blob' : 'json',
             });
 
@@ -26,7 +31,9 @@ const InventoryValuationReport = () => {
                 link.remove();
                 toast.success('Report exported successfully!');
             } else {
-                setReportData(response.data);
+                const paginated = getPaginatedPayload(response.data);
+                setReportData(paginated.data);
+                setTotal(paginated.total);
             }
         } catch (err) {
             toast.error('Failed to generate report.');
@@ -37,7 +44,7 @@ const InventoryValuationReport = () => {
 
     useEffect(() => {
         fetchReport();
-    }, []);
+    }, [page, pageSize]);
 
     const grandTotal = reportData.reduce((acc, row) => acc + parseFloat(row.total_value), 0);
 
@@ -51,6 +58,7 @@ const InventoryValuationReport = () => {
             </div>
             <div className="bg-white p-6 rounded-xl border border-gray-200">
                 {loading ? <p>Loading report...</p> : (
+                    <>
                     <div className="overflow-x-auto">
                         <table className="w-full text-left">
                             <thead className="border-b">
@@ -79,8 +87,19 @@ const InventoryValuationReport = () => {
                                     <td className="p-3 text-right font-mono text-blue-600">{settings?.DEFAULT_CURRENCY_SYMBOL || '₱'}{grandTotal.toFixed(2)}</td>
                                 </tr>
                             </tfoot>
-                        </table>
-                    </div>
+                    </table>
+                </div>
+                <PaginationControls
+                    page={page}
+                    pageSize={pageSize}
+                    total={total}
+                    onPageChange={setPage}
+                    onPageSizeChange={(size) => {
+                        setPageSize(size);
+                        setPage(1);
+                    }}
+                />
+                </>
                 )}
             </div>
         </>

--- a/packages/web/src/components/reports/LowStockReport.jsx
+++ b/packages/web/src/components/reports/LowStockReport.jsx
@@ -2,7 +2,9 @@ import React, { useState, useEffect } from 'react';
 import api from '../../api';
 import toast from 'react-hot-toast';
 import PaginationControls from '../ui/PaginationControls';
+import SortableHeader from '../ui/SortableHeader';
 import { getPaginatedPayload } from '../../utils/paginatedResponse';
+import { sortData } from '../../utils/sortData';
 
 const LowStockReport = () => {
     const [reportData, setReportData] = useState([]);
@@ -10,6 +12,7 @@ const LowStockReport = () => {
     const [page, setPage] = useState(1);
     const [pageSize, setPageSize] = useState(25);
     const [total, setTotal] = useState(0);
+    const [sortConfig, setSortConfig] = useState({ key: 'stock_on_hand', direction: 'ASC' });
 
     const fetchReport = async (format = 'json') => {
         if (format === 'json') setLoading(true);
@@ -44,6 +47,7 @@ const LowStockReport = () => {
         fetchReport();
     }, [page, pageSize]);
 
+    const sortedReportData = sortData(reportData, sortConfig);
     return (
         <>
             <div className="bg-white p-6 rounded-xl border border-gray-200 mb-6 flex justify-between items-center">
@@ -59,14 +63,14 @@ const LowStockReport = () => {
                         <table className="w-full text-left">
                             <thead className="border-b">
                                 <tr>
-                                    <th className="p-3 text-sm font-semibold text-gray-600">SKU</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600">Item Name</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600 text-center">Stock on Hand</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600 text-center">Reorder Point</th>
+                                    <SortableHeader column="internal_sku" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>SKU</SortableHeader>
+                                    <SortableHeader column="display_name" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Item Name</SortableHeader>
+                                    <SortableHeader className="text-center" column="stock_on_hand" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Stock on Hand</SortableHeader>
+                                    <SortableHeader className="text-center" column="reorder_point" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Reorder Point</SortableHeader>
                                 </tr>
                             </thead>
                             <tbody>
-                                {reportData.map((row, index) => (
+                                {sortedReportData.map((row, index) => (
                                     <tr key={index} className="border-b hover:bg-gray-50">
                                         <td className="p-3 text-sm font-mono">{row.internal_sku}</td>
                                         <td className="p-3 text-sm">{row.display_name}</td>

--- a/packages/web/src/components/reports/LowStockReport.jsx
+++ b/packages/web/src/components/reports/LowStockReport.jsx
@@ -1,16 +1,21 @@
 import React, { useState, useEffect } from 'react';
 import api from '../../api';
 import toast from 'react-hot-toast';
+import PaginationControls from '../ui/PaginationControls';
+import { getPaginatedPayload } from '../../utils/paginatedResponse';
 
 const LowStockReport = () => {
     const [reportData, setReportData] = useState([]);
     const [loading, setLoading] = useState(true);
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(25);
+    const [total, setTotal] = useState(0);
 
     const fetchReport = async (format = 'json') => {
         if (format === 'json') setLoading(true);
         try {
             const response = await api.get('/reports/low-stock', {
-                params: { format },
+                params: { format, page, pageSize, paginated: 1 },
                 responseType: format === 'csv' ? 'blob' : 'json',
             });
 
@@ -24,7 +29,9 @@ const LowStockReport = () => {
                 link.remove();
                 toast.success('Report exported successfully!');
             } else {
-                setReportData(response.data);
+                const paginated = getPaginatedPayload(response.data);
+                setReportData(paginated.data);
+                setTotal(paginated.total);
             }
         } catch (err) {
             toast.error('Failed to generate report.');
@@ -35,7 +42,7 @@ const LowStockReport = () => {
 
     useEffect(() => {
         fetchReport();
-    }, []);
+    }, [page, pageSize]);
 
     return (
         <>
@@ -47,6 +54,7 @@ const LowStockReport = () => {
             </div>
             <div className="bg-white p-6 rounded-xl border border-gray-200">
                 {loading ? <p>Loading report...</p> : (
+                    <>
                     <div className="overflow-x-auto">
                         <table className="w-full text-left">
                             <thead className="border-b">
@@ -72,8 +80,19 @@ const LowStockReport = () => {
                                     </tr>
                                 )}
                             </tbody>
-                        </table>
-                    </div>
+                    </table>
+                </div>
+                <PaginationControls
+                    page={page}
+                    pageSize={pageSize}
+                    total={total}
+                    onPageChange={setPage}
+                    onPageSizeChange={(size) => {
+                        setPageSize(size);
+                        setPage(1);
+                    }}
+                />
+                </>
                 )}
             </div>
         </>

--- a/packages/web/src/components/reports/ProfitabilityReport.jsx
+++ b/packages/web/src/components/reports/ProfitabilityReport.jsx
@@ -3,6 +3,8 @@ import api from '../../api';
 import toast from 'react-hot-toast';
 import { useSettings } from '../../contexts/SettingsContext';
 import Combobox from '../ui/Combobox';
+import PaginationControls from '../ui/PaginationControls';
+import { getPaginatedPayload } from '../../utils/paginatedResponse';
 import { format } from 'date-fns';
 import { toZonedTime } from 'date-fns-tz';
 
@@ -12,6 +14,9 @@ const ProfitabilityReport = () => {
     const [brands, setBrands] = useState([]);
     const [groups, setGroups] = useState([]);
     const [loading, setLoading] = useState(false);
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(25);
+    const [total, setTotal] = useState(0);
     const [filters, setFilters] = useState(() => {
         const now = toZonedTime(new Date(), 'Asia/Manila');
         const dateStr = format(now, 'yyyy-MM-dd');
@@ -33,6 +38,7 @@ const ProfitabilityReport = () => {
 
     const handleFilterChange = (name, value) => {
         setFilters(prev => ({ ...prev, [name]: value }));
+        setPage(1);
     };
 
     const fetchReport = async (format = 'json') => {
@@ -40,7 +46,7 @@ const ProfitabilityReport = () => {
         if (format === 'json') setLoading(true);
         try {
             const response = await api.get('/reports/profitability-by-product', {
-                params: { ...filters, format },
+                params: { ...filters, format, page, pageSize, paginated: 1 },
                 responseType: format === 'csv' ? 'blob' : 'json',
             });
             if (format === 'csv') {
@@ -53,7 +59,9 @@ const ProfitabilityReport = () => {
                 link.remove();
                 toast.success('Report exported successfully!');
             } else {
-                setReportData(response.data);
+                const paginated = getPaginatedPayload(response.data);
+                setReportData(paginated.data);
+                setTotal(paginated.total);
             }
         } catch {
             toast.error('Failed to generate report.');
@@ -61,6 +69,13 @@ const ProfitabilityReport = () => {
             if (format === 'json') setLoading(false);
         }
     };
+
+    useEffect(() => {
+        if (reportData.length > 0) {
+            fetchReport('json');
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [page, pageSize]);
 
     return (
         <>
@@ -100,6 +115,7 @@ const ProfitabilityReport = () => {
             </div>
             <div className="bg-white p-6 rounded-xl border border-gray-200">
                 {loading ? <p>Loading report...</p> : (
+                    <>
                     <div className="overflow-x-auto">
                         <table className="w-full text-left">
                             <thead className="border-b">
@@ -120,8 +136,19 @@ const ProfitabilityReport = () => {
                                     </tr>
                                 ))}
                             </tbody>
-                        </table>
-                    </div>
+                    </table>
+                </div>
+                <PaginationControls
+                    page={page}
+                    pageSize={pageSize}
+                    total={total}
+                    onPageChange={setPage}
+                    onPageSizeChange={(size) => {
+                        setPageSize(size);
+                        setPage(1);
+                    }}
+                />
+                </>
                 )}
             </div>
         </>

--- a/packages/web/src/components/reports/ProfitabilityReport.jsx
+++ b/packages/web/src/components/reports/ProfitabilityReport.jsx
@@ -4,7 +4,9 @@ import toast from 'react-hot-toast';
 import { useSettings } from '../../contexts/SettingsContext';
 import Combobox from '../ui/Combobox';
 import PaginationControls from '../ui/PaginationControls';
+import SortableHeader from '../ui/SortableHeader';
 import { getPaginatedPayload } from '../../utils/paginatedResponse';
+import { sortData } from '../../utils/sortData';
 import { format } from 'date-fns';
 import { toZonedTime } from 'date-fns-tz';
 
@@ -17,6 +19,7 @@ const ProfitabilityReport = () => {
     const [page, setPage] = useState(1);
     const [pageSize, setPageSize] = useState(25);
     const [total, setTotal] = useState(0);
+    const [sortConfig, setSortConfig] = useState({ key: 'total_profit', direction: 'DESC' });
     const [filters, setFilters] = useState(() => {
         const now = toZonedTime(new Date(), 'Asia/Manila');
         const dateStr = format(now, 'yyyy-MM-dd');
@@ -77,6 +80,8 @@ const ProfitabilityReport = () => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [page, pageSize]);
 
+    const sortedReportData = sortData(reportData, sortConfig);
+
     return (
         <>
             <div className="bg-white p-6 rounded-xl border border-gray-200 mb-6">
@@ -120,14 +125,14 @@ const ProfitabilityReport = () => {
                         <table className="w-full text-left">
                             <thead className="border-b">
                                 <tr>
-                                    <th className="p-3 text-sm font-semibold text-gray-600">Item</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600 text-right">Total Revenue</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600 text-right">Total Cost</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600 text-right">Total Profit</th>
+                                    <SortableHeader column="display_name" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Item</SortableHeader>
+                                    <SortableHeader className="text-right" column="total_revenue" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Total Revenue</SortableHeader>
+                                    <SortableHeader className="text-right" column="total_cost" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Total Cost</SortableHeader>
+                                    <SortableHeader className="text-right" column="total_profit" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Total Profit</SortableHeader>
                                 </tr>
                             </thead>
                             <tbody>
-                                {reportData.map((row) => (
+                                {sortedReportData.map((row) => (
                                     <tr key={row.internal_sku} className="border-b hover:bg-gray-50">
                                         <td className="p-3 text-sm font-medium text-gray-800">{row.display_name}</td>
                                         <td className="p-3 text-sm text-right font-mono">{settings?.DEFAULT_CURRENCY_SYMBOL || '₱'}{parseFloat(row.total_revenue).toFixed(2)}</td>

--- a/packages/web/src/components/reports/RefundsReport.jsx
+++ b/packages/web/src/components/reports/RefundsReport.jsx
@@ -3,6 +3,8 @@ import api from '../../api';
 import toast from 'react-hot-toast';
 import { useSettings } from '../../contexts/SettingsContext';
 import DateRangeShortcuts from '../ui/DateRangeShortcuts';
+import PaginationControls from '../ui/PaginationControls';
+import { getPaginatedPayload } from '../../utils/paginatedResponse';
 import { format, parseISO } from 'date-fns';
 import { toZonedTime } from 'date-fns-tz';
 
@@ -10,6 +12,9 @@ const RefundsReport = () => {
     const { settings } = useSettings();
     const [reportData, setReportData] = useState([]);
     const [loading, setLoading] = useState(false);
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(25);
+    const [total, setTotal] = useState(0);
     const [dates, setDates] = useState(() => {
         const now = toZonedTime(new Date(), 'Asia/Manila');
         const dateStr = format(now, 'yyyy-MM-dd');
@@ -22,18 +27,20 @@ const RefundsReport = () => {
     const fetchReport = useCallback(async () => {
         setLoading(true);
         try {
-            // Note: This endpoint will be created in the backend reportingRoutes.js
-            const response = await api.get('/reports/refunds', { params: dates });
-            setReportData(response.data);
+            const response = await api.get('/reports/refunds', { params: { ...dates, page, pageSize, paginated: 1 } });
+            const paginated = getPaginatedPayload(response.data);
+            setReportData(paginated.data);
+            setTotal(paginated.total);
         } catch {
             toast.error('Failed to generate refunds report.');
         } finally {
             setLoading(false);
         }
-    }, [dates]);
+    }, [dates, page, pageSize]);
 
     const handleDateChange = (e) => {
         setDates(prev => ({ ...prev, [e.target.name]: e.target.value }));
+        setPage(1);
     };
 
     // Fetch report when dates change
@@ -60,6 +67,7 @@ const RefundsReport = () => {
             </div>
             <div className="bg-white p-6 rounded-xl border border-gray-200">
                 {loading ? <p>Loading report...</p> : (
+                    <>
                     <div className="overflow-x-auto">
                         <table className="w-full text-left">
                             <thead className="border-b">
@@ -87,8 +95,19 @@ const RefundsReport = () => {
                                     </tr>
                                 )}
                             </tbody>
-                        </table>
-                    </div>
+                    </table>
+                </div>
+                <PaginationControls
+                    page={page}
+                    pageSize={pageSize}
+                    total={total}
+                    onPageChange={setPage}
+                    onPageSizeChange={(size) => {
+                        setPageSize(size);
+                        setPage(1);
+                    }}
+                />
+                </>
                 )}
             </div>
         </>

--- a/packages/web/src/components/reports/RefundsReport.jsx
+++ b/packages/web/src/components/reports/RefundsReport.jsx
@@ -4,7 +4,9 @@ import toast from 'react-hot-toast';
 import { useSettings } from '../../contexts/SettingsContext';
 import DateRangeShortcuts from '../ui/DateRangeShortcuts';
 import PaginationControls from '../ui/PaginationControls';
+import SortableHeader from '../ui/SortableHeader';
 import { getPaginatedPayload } from '../../utils/paginatedResponse';
+import { sortData } from '../../utils/sortData';
 import { format, parseISO } from 'date-fns';
 import { toZonedTime } from 'date-fns-tz';
 
@@ -15,6 +17,7 @@ const RefundsReport = () => {
     const [page, setPage] = useState(1);
     const [pageSize, setPageSize] = useState(25);
     const [total, setTotal] = useState(0);
+    const [sortConfig, setSortConfig] = useState({ key: 'refund_date', direction: 'DESC' });
     const [dates, setDates] = useState(() => {
         const now = toZonedTime(new Date(), 'Asia/Manila');
         const dateStr = format(now, 'yyyy-MM-dd');
@@ -48,6 +51,7 @@ const RefundsReport = () => {
         fetchReport();
     }, [fetchReport]);
 
+    const sortedReportData = sortData(reportData, sortConfig);
     return (
         <>
             <div className="bg-white p-6 rounded-xl border border-gray-200 mb-6">
@@ -72,15 +76,15 @@ const RefundsReport = () => {
                         <table className="w-full text-left">
                             <thead className="border-b">
                                 <tr>
-                                    <th className="p-3 text-sm font-semibold text-gray-600">Credit Note #</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600">Original Invoice #</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600">Date</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600">Customer</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600 text-right">Amount</th>
+                                    <SortableHeader column="cn_number" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Credit Note #</SortableHeader>
+                                    <SortableHeader column="invoice_number" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Original Invoice #</SortableHeader>
+                                    <SortableHeader column="refund_date" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Date</SortableHeader>
+                                    <SortableHeader column="customer_name" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Customer</SortableHeader>
+                                    <SortableHeader className="text-right" column="total_amount" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Amount</SortableHeader>
                                 </tr>
                             </thead>
                             <tbody>
-                                {reportData.map((row) => (
+                                {sortedReportData.map((row) => (
                                     <tr key={row.cn_id} className="border-b hover:bg-gray-50">
                                         <td className="p-3 text-sm font-mono">{row.cn_number}</td>
                                         <td className="p-3 text-sm font-mono">{row.invoice_number}</td>

--- a/packages/web/src/components/reports/SalesByCustomerReport.jsx
+++ b/packages/web/src/components/reports/SalesByCustomerReport.jsx
@@ -3,6 +3,8 @@ import api from '../../api';
 import toast from 'react-hot-toast';
 import { useSettings } from '../../contexts/SettingsContext';
 import Combobox from '../ui/Combobox';
+import PaginationControls from '../ui/PaginationControls';
+import { getPaginatedPayload } from '../../utils/paginatedResponse';
 import { format } from 'date-fns';
 import { toZonedTime } from 'date-fns-tz';
 
@@ -11,6 +13,9 @@ const SalesByCustomerReport = () => {
     const [reportData, setReportData] = useState([]);
     const [customers, setCustomers] = useState([]);
     const [loading, setLoading] = useState(false);
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(25);
+    const [total, setTotal] = useState(0);
     const [filters, setFilters] = useState(() => {
         const now = toZonedTime(new Date(), 'Asia/Manila');
         const dateStr = format(now, 'yyyy-MM-dd');
@@ -29,6 +34,7 @@ const SalesByCustomerReport = () => {
 
     const handleFilterChange = (name, value) => {
         setFilters(prev => ({ ...prev, [name]: value }));
+        setPage(1);
     };
 
     const fetchReport = async (format = 'json') => {
@@ -36,7 +42,7 @@ const SalesByCustomerReport = () => {
         if (format === 'json') setLoading(true);
         try {
             const response = await api.get('/reports/sales-by-customer', {
-                params: { ...filters, format },
+                params: { ...filters, format, page, pageSize, paginated: 1 },
                 responseType: format === 'csv' ? 'blob' : 'json',
             });
             if (format === 'csv') {
@@ -49,7 +55,9 @@ const SalesByCustomerReport = () => {
                 link.remove();
                 toast.success('Report exported successfully!');
             } else {
-                setReportData(response.data);
+                const paginated = getPaginatedPayload(response.data);
+                setReportData(paginated.data);
+                setTotal(paginated.total);
             }
         } catch {
             toast.error('Failed to generate report.');
@@ -57,6 +65,13 @@ const SalesByCustomerReport = () => {
             if (format === 'json') setLoading(false);
         }
     };
+
+    useEffect(() => {
+        if (reportData.length > 0) {
+            fetchReport('json');
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [page, pageSize]);
 
     return (
         <>
@@ -87,6 +102,7 @@ const SalesByCustomerReport = () => {
             </div>
             <div className="bg-white p-6 rounded-xl border border-gray-200">
                 {loading ? <p>Loading report...</p> : (
+                    <>
                     <div className="overflow-x-auto">
                         <table className="w-full text-left">
                             <thead className="border-b">
@@ -105,8 +121,19 @@ const SalesByCustomerReport = () => {
                                     </tr>
                                 ))}
                             </tbody>
-                        </table>
-                    </div>
+                    </table>
+                </div>
+                <PaginationControls
+                    page={page}
+                    pageSize={pageSize}
+                    total={total}
+                    onPageChange={setPage}
+                    onPageSizeChange={(size) => {
+                        setPageSize(size);
+                        setPage(1);
+                    }}
+                />
+                </>
                 )}
             </div>
         </>

--- a/packages/web/src/components/reports/SalesByCustomerReport.jsx
+++ b/packages/web/src/components/reports/SalesByCustomerReport.jsx
@@ -4,7 +4,9 @@ import toast from 'react-hot-toast';
 import { useSettings } from '../../contexts/SettingsContext';
 import Combobox from '../ui/Combobox';
 import PaginationControls from '../ui/PaginationControls';
+import SortableHeader from '../ui/SortableHeader';
 import { getPaginatedPayload } from '../../utils/paginatedResponse';
+import { sortData } from '../../utils/sortData';
 import { format } from 'date-fns';
 import { toZonedTime } from 'date-fns-tz';
 
@@ -16,6 +18,7 @@ const SalesByCustomerReport = () => {
     const [page, setPage] = useState(1);
     const [pageSize, setPageSize] = useState(25);
     const [total, setTotal] = useState(0);
+    const [sortConfig, setSortConfig] = useState({ key: 'total_sales', direction: 'DESC' });
     const [filters, setFilters] = useState(() => {
         const now = toZonedTime(new Date(), 'Asia/Manila');
         const dateStr = format(now, 'yyyy-MM-dd');
@@ -73,6 +76,10 @@ const SalesByCustomerReport = () => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [page, pageSize]);
 
+    const sortedReportData = sortData(reportData, sortConfig, {
+        customer_name: (row) => `${row.first_name || ''} ${row.last_name || ''}`.trim()
+    });
+
     return (
         <>
             <div className="bg-white p-6 rounded-xl border border-gray-200 mb-6">
@@ -107,13 +114,13 @@ const SalesByCustomerReport = () => {
                         <table className="w-full text-left">
                             <thead className="border-b">
                                 <tr>
-                                    <th className="p-3 text-sm font-semibold text-gray-600">Customer</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600 text-center">Total Invoices</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600 text-right">Total Sales</th>
+                                    <SortableHeader column="customer_name" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Customer</SortableHeader>
+                                    <SortableHeader className="text-center" column="total_invoices" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Total Invoices</SortableHeader>
+                                    <SortableHeader className="text-right" column="total_sales" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Total Sales</SortableHeader>
                                 </tr>
                             </thead>
                             <tbody>
-                                {reportData.map((row) => (
+                                {sortedReportData.map((row) => (
                                     <tr key={row.customer_id} className="border-b hover:bg-gray-50">
                                         <td className="p-3 text-sm font-medium text-gray-800">{row.first_name} {row.last_name}</td>
                                         <td className="p-3 text-sm text-center">{row.total_invoices}</td>

--- a/packages/web/src/components/reports/SalesReport.jsx
+++ b/packages/web/src/components/reports/SalesReport.jsx
@@ -4,6 +4,8 @@ import toast from 'react-hot-toast';
 import { useSettings } from '../../contexts/SettingsContext';
 import { ICONS } from '../../constants';
 import ReportCard from './ReportCard';
+import PaginationControls from '../ui/PaginationControls';
+import { getPaginatedPayload } from '../../utils/paginatedResponse';
 import { format, parseISO } from 'date-fns';
 import { toZonedTime } from 'date-fns-tz';
 
@@ -12,6 +14,9 @@ const SalesReport = () => {
     const [reportData, setReportData] = useState([]);
     const [summary, setSummary] = useState(null);
     const [loading, setLoading] = useState(true);
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(25);
+    const [total, setTotal] = useState(0);
     const [dates, setDates] = useState(() => {
         const now = toZonedTime(new Date(), 'Asia/Manila');
         const dateStr = format(now, 'yyyy-MM-dd');
@@ -35,7 +40,7 @@ const SalesReport = () => {
 
         try {
             const response = await api.get('/reports/sales-summary', {
-                params: { ...dates, format },
+                params: { ...dates, format, page, pageSize, paginated: 1 },
                 responseType: format === 'csv' ? 'blob' : 'json',
             });
 
@@ -49,19 +54,25 @@ const SalesReport = () => {
                 link.remove();
                 toast.success('Report exported successfully!');
             } else {
-                setReportData(response.data.details);
+                const paginated = getPaginatedPayload(response.data, response.data?.details?.length || 0);
+                setReportData(response.data.details || paginated.data);
                 setSummary(response.data.summary);
+                setTotal(response.data?.total || paginated.total || 0);
             }
         } catch {
             toast.error('Failed to generate report.');
         } finally {
             if (format === 'json') setLoading(false);
         }
-    }, [dates]);
+    }, [dates, page, pageSize]);
 
     useEffect(() => {
         fetchReport();
     }, [fetchReport]);
+
+    useEffect(() => {
+        setPage(1);
+    }, [dates.startDate, dates.endDate]);
 
     return (
         <>
@@ -123,6 +134,16 @@ const SalesReport = () => {
                         </tbody>
                     </table>
                 </div>
+                <PaginationControls
+                    page={page}
+                    pageSize={pageSize}
+                    total={total}
+                    onPageChange={setPage}
+                    onPageSizeChange={(size) => {
+                        setPageSize(size);
+                        setPage(1);
+                    }}
+                />
             </div>
         </>
     );

--- a/packages/web/src/components/reports/SalesReport.jsx
+++ b/packages/web/src/components/reports/SalesReport.jsx
@@ -5,7 +5,9 @@ import { useSettings } from '../../contexts/SettingsContext';
 import { ICONS } from '../../constants';
 import ReportCard from './ReportCard';
 import PaginationControls from '../ui/PaginationControls';
+import SortableHeader from '../ui/SortableHeader';
 import { getPaginatedPayload } from '../../utils/paginatedResponse';
+import { sortData } from '../../utils/sortData';
 import { format, parseISO } from 'date-fns';
 import { toZonedTime } from 'date-fns-tz';
 
@@ -17,6 +19,7 @@ const SalesReport = () => {
     const [page, setPage] = useState(1);
     const [pageSize, setPageSize] = useState(25);
     const [total, setTotal] = useState(0);
+    const [sortConfig, setSortConfig] = useState({ key: 'invoice_date', direction: 'ASC' });
     const [dates, setDates] = useState(() => {
         const now = toZonedTime(new Date(), 'Asia/Manila');
         const dateStr = format(now, 'yyyy-MM-dd');
@@ -74,6 +77,8 @@ const SalesReport = () => {
         setPage(1);
     }, [dates.startDate, dates.endDate]);
 
+    const sortedReportData = sortData(reportData, sortConfig);
+
     return (
         <>
             <div className="bg-white p-6 rounded-xl border border-gray-200 mb-6">
@@ -111,14 +116,14 @@ const SalesReport = () => {
                     <table className="w-full text-left">
                         <thead className="border-b">
                             <tr>
-                                <th className="p-3 text-sm font-semibold text-gray-600">Date</th>
-                                <th className="p-3 text-sm font-semibold text-gray-600">Invoice #</th>
-                                <th className="p-3 text-sm font-semibold text-gray-600">Item</th>
-                                <th className="p-3 text-sm font-semibold text-gray-600 text-right">Total</th>
+                                <SortableHeader column="invoice_date" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Date</SortableHeader>
+                                <SortableHeader column="invoice_number" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Invoice #</SortableHeader>
+                                <SortableHeader column="display_name" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Item</SortableHeader>
+                                <SortableHeader className="text-right" column="line_total" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Total</SortableHeader>
                             </tr>
                         </thead>
                         <tbody>
-                            {reportData.map((row, index) => (
+                            {sortedReportData.map((row, index) => (
                                 <tr key={index} className="border-b hover:bg-gray-50">
                                     <td className="p-3 text-sm">{format(toZonedTime(parseISO(row.invoice_date), 'Asia/Manila'), 'MM/dd/yyyy')}</td>
                                     <td className="p-3 text-sm font-mono">{row.invoice_number}</td>

--- a/packages/web/src/components/reports/TopSellingReport.jsx
+++ b/packages/web/src/components/reports/TopSellingReport.jsx
@@ -2,6 +2,8 @@ import React, { useState, useEffect } from 'react';
 import api from '../../api';
 import toast from 'react-hot-toast';
 import { useSettings } from '../../contexts/SettingsContext';
+import PaginationControls from '../ui/PaginationControls';
+import { getPaginatedPayload } from '../../utils/paginatedResponse';
 import { format } from 'date-fns';
 import { toZonedTime } from 'date-fns-tz';
 
@@ -9,6 +11,10 @@ const TopSellingReport = () => {
     const { settings } = useSettings();
     const [reportData, setReportData] = useState([]);
     const [loading, setLoading] = useState(false);
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(25);
+    const [total, setTotal] = useState(0);
+    const [hasLoaded, setHasLoaded] = useState(false);
     const [dates, setDates] = useState(() => {
         const now = toZonedTime(new Date(), 'Asia/Manila');
         const dateStr = format(now, 'yyyy-MM-dd');
@@ -33,7 +39,7 @@ const TopSellingReport = () => {
 
         try {
             const response = await api.get('/reports/top-selling', {
-                params: { ...dates, sortBy, format },
+                params: { ...dates, sortBy, format, page, pageSize, paginated: 1 },
                 responseType: format === 'csv' ? 'blob' : 'json',
             });
 
@@ -47,7 +53,10 @@ const TopSellingReport = () => {
                 link.remove();
                 toast.success('Report exported successfully!');
             } else {
-                setReportData(response.data);
+                const paginated = getPaginatedPayload(response.data);
+                setReportData(paginated.data);
+                setTotal(paginated.total);
+                setHasLoaded(true);
             }
         } catch {
             toast.error('Failed to generate report.');
@@ -55,6 +64,17 @@ const TopSellingReport = () => {
             if (format === 'json') setLoading(false);
         }
     };
+
+    useEffect(() => {
+        setPage(1);
+    }, [dates.startDate, dates.endDate, sortBy]);
+
+    useEffect(() => {
+        if (hasLoaded) {
+            fetchReport('json');
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [page, pageSize]);
 
     return (
         <>
@@ -113,6 +133,16 @@ const TopSellingReport = () => {
                         </tbody>
                     </table>
                 </div>
+                <PaginationControls
+                    page={page}
+                    pageSize={pageSize}
+                    total={total}
+                    onPageChange={setPage}
+                    onPageSizeChange={(size) => {
+                        setPageSize(size);
+                        setPage(1);
+                    }}
+                />
             </div>
         </>
     );

--- a/packages/web/src/components/reports/TopSellingReport.jsx
+++ b/packages/web/src/components/reports/TopSellingReport.jsx
@@ -3,7 +3,9 @@ import api from '../../api';
 import toast from 'react-hot-toast';
 import { useSettings } from '../../contexts/SettingsContext';
 import PaginationControls from '../ui/PaginationControls';
+import SortableHeader from '../ui/SortableHeader';
 import { getPaginatedPayload } from '../../utils/paginatedResponse';
+import { sortData } from '../../utils/sortData';
 import { format } from 'date-fns';
 import { toZonedTime } from 'date-fns-tz';
 
@@ -15,6 +17,7 @@ const TopSellingReport = () => {
     const [pageSize, setPageSize] = useState(25);
     const [total, setTotal] = useState(0);
     const [hasLoaded, setHasLoaded] = useState(false);
+    const [sortConfig, setSortConfig] = useState({ key: 'total_revenue', direction: 'DESC' });
     const [dates, setDates] = useState(() => {
         const now = toZonedTime(new Date(), 'Asia/Manila');
         const dateStr = format(now, 'yyyy-MM-dd');
@@ -76,6 +79,7 @@ const TopSellingReport = () => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [page, pageSize]);
 
+    const sortedReportData = sortData(reportData, sortConfig);
     return (
         <>
             <div className="bg-white p-6 rounded-xl border border-gray-200 mb-6">
@@ -110,14 +114,14 @@ const TopSellingReport = () => {
                     <table className="w-full text-left">
                         <thead className="border-b">
                             <tr>
-                                <th className="p-3 text-sm font-semibold text-gray-600">SKU</th>
-                                <th className="p-3 text-sm font-semibold text-gray-600">Item Name</th>
-                                <th className="p-3 text-sm font-semibold text-gray-600 text-center">Qty Sold</th>
-                                <th className="p-3 text-sm font-semibold text-gray-600 text-right">Total Revenue</th>
+                                <SortableHeader column="internal_sku" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>SKU</SortableHeader>
+                                <SortableHeader column="display_name" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Item Name</SortableHeader>
+                                <SortableHeader className="text-center" column="total_quantity_sold" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Qty Sold</SortableHeader>
+                                <SortableHeader className="text-right" column="total_revenue" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Total Revenue</SortableHeader>
                             </tr>
                         </thead>
                         <tbody>
-                            {reportData.map((row, index) => (
+                            {sortedReportData.map((row, index) => (
                                 <tr key={index} className="border-b hover:bg-gray-50">
                                     <td className="p-3 text-sm font-mono">{row.internal_sku}</td>
                                     <td className="p-3 text-sm">{row.display_name}</td>

--- a/packages/web/src/components/ui/PaginationControls.jsx
+++ b/packages/web/src/components/ui/PaginationControls.jsx
@@ -1,0 +1,56 @@
+const PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
+
+const PaginationControls = ({
+    page,
+    pageSize,
+    total,
+    onPageChange,
+    onPageSizeChange,
+    className = ''
+}) => {
+    const totalPages = Math.max(Math.ceil((total || 0) / pageSize), 1);
+    const start = total === 0 ? 0 : (page - 1) * pageSize + 1;
+    const end = total === 0 ? 0 : Math.min(page * pageSize, total);
+
+    return (
+        <div className={`mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between ${className}`}>
+            <div className="text-sm text-gray-600">
+                Showing {start}-{end} of {total} items
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+                <label htmlFor="pageSize" className="text-sm text-gray-600">Rows per page</label>
+                <select
+                    id="pageSize"
+                    className="rounded-md border border-gray-300 px-2 py-1 text-sm"
+                    value={pageSize}
+                    onChange={(e) => onPageSizeChange(Number(e.target.value))}
+                >
+                    {PAGE_SIZE_OPTIONS.map(size => (
+                        <option key={size} value={size}>{size}</option>
+                    ))}
+                </select>
+                <button
+                    type="button"
+                    className="rounded-md border border-gray-300 px-3 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+                    onClick={() => onPageChange(page - 1)}
+                    disabled={page <= 1}
+                >
+                    Previous
+                </button>
+                <span className="text-sm text-gray-700">
+                    Page {page} / {totalPages}
+                </span>
+                <button
+                    type="button"
+                    className="rounded-md border border-gray-300 px-3 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+                    onClick={() => onPageChange(page + 1)}
+                    disabled={page >= totalPages}
+                >
+                    Next
+                </button>
+            </div>
+        </div>
+    );
+};
+
+export default PaginationControls;

--- a/packages/web/src/components/ui/PaginationControls.jsx
+++ b/packages/web/src/components/ui/PaginationControls.jsx
@@ -1,5 +1,7 @@
 const PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
 
+import { useEffect, useMemo, useState } from 'react';
+
 const PaginationControls = ({
     page,
     pageSize,
@@ -9,8 +11,29 @@ const PaginationControls = ({
     className = ''
 }) => {
     const totalPages = Math.max(Math.ceil((total || 0) / pageSize), 1);
-    const start = total === 0 ? 0 : (page - 1) * pageSize + 1;
-    const end = total === 0 ? 0 : Math.min(page * pageSize, total);
+    const safePage = Math.min(Math.max(page || 1, 1), totalPages);
+    const start = total === 0 ? 0 : (safePage - 1) * pageSize + 1;
+    const end = total === 0 ? 0 : Math.min(safePage * pageSize, total);
+    const [jumpPage, setJumpPage] = useState(String(safePage));
+
+    useEffect(() => {
+        setJumpPage(String(safePage));
+    }, [safePage]);
+
+    const pageButtons = useMemo(() => {
+        const spread = 2;
+        const from = Math.max(1, safePage - spread);
+        const to = Math.min(totalPages, safePage + spread);
+        const pages = [];
+        for (let i = from; i <= to; i += 1) pages.push(i);
+        return pages;
+    }, [safePage, totalPages]);
+
+    const handlePageChange = (nextPage) => {
+        const clamped = Math.min(Math.max(nextPage, 1), totalPages);
+        onPageChange(clamped);
+        setJumpPage(String(clamped));
+    };
 
     return (
         <div className={`mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between ${className}`}>
@@ -32,22 +55,65 @@ const PaginationControls = ({
                 <button
                     type="button"
                     className="rounded-md border border-gray-300 px-3 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-50"
-                    onClick={() => onPageChange(page - 1)}
-                    disabled={page <= 1}
+                    onClick={() => handlePageChange(safePage - 1)}
+                    disabled={safePage <= 1}
                 >
                     Previous
                 </button>
+                <div className="hidden items-center gap-1 md:flex">
+                    {pageButtons[0] > 1 && (
+                        <>
+                            <button type="button" className="rounded-md border border-gray-300 px-2 py-1 text-sm" onClick={() => handlePageChange(1)}>1</button>
+                            {pageButtons[0] > 2 && <span className="px-1 text-xs text-gray-500">…</span>}
+                        </>
+                    )}
+                    {pageButtons.map((pageNumber) => (
+                        <button
+                            key={pageNumber}
+                            type="button"
+                            className={`rounded-md border px-2 py-1 text-sm ${pageNumber === safePage ? 'border-blue-600 bg-blue-50 text-blue-700' : 'border-gray-300'}`}
+                            onClick={() => handlePageChange(pageNumber)}
+                        >
+                            {pageNumber}
+                        </button>
+                    ))}
+                    {pageButtons[pageButtons.length - 1] < totalPages && (
+                        <>
+                            {pageButtons[pageButtons.length - 1] < totalPages - 1 && <span className="px-1 text-xs text-gray-500">…</span>}
+                            <button type="button" className="rounded-md border border-gray-300 px-2 py-1 text-sm" onClick={() => handlePageChange(totalPages)}>{totalPages}</button>
+                        </>
+                    )}
+                </div>
                 <span className="text-sm text-gray-700">
-                    Page {page} / {totalPages}
+                    Page {safePage} / {totalPages}
                 </span>
                 <button
                     type="button"
                     className="rounded-md border border-gray-300 px-3 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-50"
-                    onClick={() => onPageChange(page + 1)}
-                    disabled={page >= totalPages}
+                    onClick={() => handlePageChange(safePage + 1)}
+                    disabled={safePage >= totalPages}
                 >
                     Next
                 </button>
+                <div className="flex items-center gap-1">
+                    <label htmlFor="jumpPage" className="text-sm text-gray-600">Jump</label>
+                    <input
+                        id="jumpPage"
+                        type="number"
+                        min={1}
+                        max={totalPages}
+                        value={jumpPage}
+                        onChange={(e) => setJumpPage(e.target.value)}
+                        className="w-16 rounded-md border border-gray-300 px-2 py-1 text-sm"
+                    />
+                    <button
+                        type="button"
+                        className="rounded-md border border-gray-300 px-2 py-1 text-sm"
+                        onClick={() => handlePageChange(Number(jumpPage || safePage))}
+                    >
+                        Go
+                    </button>
+                </div>
             </div>
         </div>
     );

--- a/packages/web/src/components/ui/SortableHeader.jsx
+++ b/packages/web/src/components/ui/SortableHeader.jsx
@@ -1,7 +1,7 @@
 import Icon from './Icon';
 import { ICONS } from '../../constants';
 
-const SortableHeader = ({ children, column, sortConfig, onSort }) => {
+const SortableHeader = ({ children, column, sortConfig, onSort, className = '' }) => {
     const isSorted = sortConfig.key === column;
     const isAsc = sortConfig.direction === 'ASC';
 
@@ -16,7 +16,7 @@ const SortableHeader = ({ children, column, sortConfig, onSort }) => {
     };
 
     return (
-    <th className="p-3 text-sm font-semibold text-gray-600 cursor-pointer hover:bg-gray-50 select-none" onClick={() => onSort(column, getNextDirection())}>
+    <th className={`p-3 text-sm font-semibold text-gray-600 cursor-pointer hover:bg-gray-50 select-none ${className}`} onClick={() => onSort(column, getNextDirection())}>
             <div className="flex items-center justify-between">
                 <span>{children}</span>
         <Icon path={getIcon()} className={`h-4 w-4 ${isSorted ? 'text-blue-600' : 'text-gray-300'}`} />

--- a/packages/web/src/pages/AccountsReceivablePage.jsx
+++ b/packages/web/src/pages/AccountsReceivablePage.jsx
@@ -70,6 +70,9 @@ const AccountsReceivablePage = () => {
     const [customerInvoices, setCustomerInvoices] = useState([]);
     const [customerInvoicesLoading, setCustomerInvoicesLoading] = useState(false);
     const [selectedCustomerForInvoices, setSelectedCustomerForInvoices] = useState(null);
+    const [customerInvoicesPage, setCustomerInvoicesPage] = useState(1);
+    const [customerInvoicesPageSize, setCustomerInvoicesPageSize] = useState(25);
+    const [customerInvoicesTotal, setCustomerInvoicesTotal] = useState(0);
     const [customerSummaryPage, setCustomerSummaryPage] = useState(1);
     const [customerSummaryPageSize, setCustomerSummaryPageSize] = useState(25);
     const [customerSummaryTotal, setCustomerSummaryTotal] = useState(0);
@@ -167,7 +170,7 @@ const AccountsReceivablePage = () => {
                 setAgingData(agingRes.data);
             } else {
                 // Calculate mock aging data based on total receivables
-                const totalReceivables = dashboardStats.totalReceivables || customersRes.data.reduce((sum, customer) => sum + Number(customer.balance_due || 0), 0);
+                const totalReceivables = dashboardStats.totalReceivables || customersWithBalances.reduce((sum, customer) => sum + Number(customer.balance_due || 0), 0);
                 const current = totalReceivables * 0.6;
                 const days1to30 = totalReceivables * 0.2;
                 const days31to60 = totalReceivables * 0.1;
@@ -226,11 +229,16 @@ const AccountsReceivablePage = () => {
         try {
             setCustomerInvoicesLoading(true);
             setSelectedCustomerForInvoices(customer);
+            setCustomerInvoicesPage(1);
             
-            const response = await api.get(`/ar/customer-invoices/${customer.customer_id}`);
+            const response = await api.get(`/ar/customer-invoices/${customer.customer_id}`, {
+                params: { page: 1, pageSize: customerInvoicesPageSize, paginated: 1 }
+            });
             // Filter only payable invoices (balance_due > 0)
-            const payableInvoices = response.data.filter(invoice => Number(invoice.balance_due) > 0) || [];
+            const invoiceRows = response.data?.data || response.data || [];
+            const payableInvoices = invoiceRows.filter(invoice => Number(invoice.balance_due) > 0) || [];
             setCustomerInvoices(payableInvoices);
+            setCustomerInvoicesTotal(response.data?.total || payableInvoices.length);
             
         } catch (error) {
             console.error('Failed to fetch customer invoices:', error);
@@ -238,7 +246,29 @@ const AccountsReceivablePage = () => {
         } finally {
             setCustomerInvoicesLoading(false);
         }
-    }, []);
+    }, [customerInvoicesPageSize]);
+
+    useEffect(() => {
+        const fetchInvoicesPage = async () => {
+            if (!selectedCustomerForInvoices?.customer_id) return;
+            try {
+                setCustomerInvoicesLoading(true);
+                const response = await api.get(`/ar/customer-invoices/${selectedCustomerForInvoices.customer_id}`, {
+                    params: { page: customerInvoicesPage, pageSize: customerInvoicesPageSize, paginated: 1 }
+                });
+                const invoiceRows = response.data?.data || response.data || [];
+                const payableInvoices = invoiceRows.filter(invoice => Number(invoice.balance_due) > 0) || [];
+                setCustomerInvoices(payableInvoices);
+                setCustomerInvoicesTotal(response.data?.total || payableInvoices.length);
+            } catch (error) {
+                console.error('Failed to fetch customer invoices:', error);
+                toast.error('Failed to load customer invoice details');
+            } finally {
+                setCustomerInvoicesLoading(false);
+            }
+        };
+        fetchInvoicesPage();
+    }, [selectedCustomerForInvoices, customerInvoicesPage, customerInvoicesPageSize]);
 
     // Handle receive payment for individual invoices
     const handleReceivePaymentClick = useCallback((invoice) => {
@@ -575,6 +605,14 @@ const AccountsReceivablePage = () => {
                 title={`Payable Invoices for ${selectedCustomerForInvoices?.company_name || `${selectedCustomerForInvoices?.first_name || ''} ${selectedCustomerForInvoices?.last_name || ''}`.trim()}`}
                 invoices={customerInvoices}
                 loading={customerInvoicesLoading}
+                page={customerInvoicesPage}
+                pageSize={customerInvoicesPageSize}
+                total={customerInvoicesTotal}
+                onPageChange={setCustomerInvoicesPage}
+                onPageSizeChange={(size) => {
+                    setCustomerInvoicesPageSize(size);
+                    setCustomerInvoicesPage(1);
+                }}
                 onAfterDueDateUpdate={async () => {
                     // Refresh overall dashboard and summaries
                     await fetchDashboardData();
@@ -583,9 +621,13 @@ const AccountsReceivablePage = () => {
                     if (selectedCustomerForInvoices?.customer_id) {
                         try {
                             setCustomerInvoicesLoading(true);
-                            const response = await api.get(`/ar/customer-invoices/${selectedCustomerForInvoices.customer_id}`);
-                            const payableInvoices = response.data.filter(invoice => Number(invoice.balance_due) > 0) || [];
+                            const response = await api.get(`/ar/customer-invoices/${selectedCustomerForInvoices.customer_id}`, {
+                                params: { page: customerInvoicesPage, pageSize: customerInvoicesPageSize, paginated: 1 }
+                            });
+                            const invoiceRows = response.data?.data || response.data || [];
+                            const payableInvoices = invoiceRows.filter(invoice => Number(invoice.balance_due) > 0) || [];
                             setCustomerInvoices(payableInvoices);
+                            setCustomerInvoicesTotal(response.data?.total || payableInvoices.length);
                         } catch (e) {
                             console.error('Failed to refresh customer invoices after due date update:', e);
                         } finally {

--- a/packages/web/src/pages/AccountsReceivablePage.jsx
+++ b/packages/web/src/pages/AccountsReceivablePage.jsx
@@ -18,6 +18,7 @@ import KPICard from '../components/ui/KPICard';
 import InvoiceAgingSummaryChart from '../components/accounts-receivable/InvoiceAgingSummaryChart';
 import CustomerSummaryTable from '../components/accounts-receivable/CustomerSummaryTable';
 import CustomerInvoiceDetailsModal from '../components/accounts-receivable/CustomerInvoiceDetailsModal';
+import PaginationControls from '../components/ui/PaginationControls';
 
 // Utility for currency formatting - now imported from utils/currency.js
 
@@ -69,6 +70,12 @@ const AccountsReceivablePage = () => {
     const [customerInvoices, setCustomerInvoices] = useState([]);
     const [customerInvoicesLoading, setCustomerInvoicesLoading] = useState(false);
     const [selectedCustomerForInvoices, setSelectedCustomerForInvoices] = useState(null);
+    const [customerSummaryPage, setCustomerSummaryPage] = useState(1);
+    const [customerSummaryPageSize, setCustomerSummaryPageSize] = useState(25);
+    const [customerSummaryTotal, setCustomerSummaryTotal] = useState(0);
+    const [drillDownPage, setDrillDownPage] = useState(1);
+    const [drillDownPageSize, setDrillDownPageSize] = useState(25);
+    const [drillDownTotal, setDrillDownTotal] = useState(0);
 
     const MAX_RETRIES = 3;
 
@@ -98,11 +105,15 @@ const AccountsReceivablePage = () => {
             const dateParams = {
                 startDate: dateRange.startDate.toISOString(),
                 endDate: dateRange.endDate.toISOString(),
-                bucket: bucketParam
+                bucket: bucketParam,
+                page: drillDownPage,
+                pageSize: drillDownPageSize,
+                paginated: 1
             };
             
             const response = await api.get('/ar/drill-down-invoices', { params: dateParams });
-            setDrillDownInvoices(response.data || []);
+            setDrillDownInvoices(response.data?.data || []);
+            setDrillDownTotal(response.data?.total || 0);
             
         } catch (error) {
             console.error('Failed to fetch drill-down invoices:', error);
@@ -110,7 +121,7 @@ const AccountsReceivablePage = () => {
         } finally {
             setDrillDownLoading(false);
         }
-    }, [dateRange]);
+    }, [dateRange, drillDownPage, drillDownPageSize]);
 
     // Enhanced data fetching with retry logic
     const fetchDashboardData = useCallback(async (isRetry = false) => {
@@ -124,14 +135,15 @@ const AccountsReceivablePage = () => {
             
             // Fetch all data in parallel with proper error handling
             const [customersRes, dashboardRes, agingRes, customerSummaryRes, trendsRes] = await Promise.all([
-                api.get('/customers/with-balances'),
+                api.get('/customers/with-balances', { params: { paginated: 1, page: 1, pageSize: 100 } }),
                 api.get('/ar/dashboard-stats', { params: dateParams }).catch(() => ({ data: {} })),
                 api.get('/ar/aging-summary').catch(() => ({ data: [] })),
-                api.get('/ar/customer-summary').catch(() => ({ data: [] })),
+                api.get('/ar/customer-summary', { params: { page: customerSummaryPage, pageSize: customerSummaryPageSize, paginated: 1 } }).catch(() => ({ data: { data: [], total: 0 } })),
                 api.get('/ar/trends').catch(() => ({ data: {} }))
             ]);
 
-            setCustomers(customersRes.data || []);
+            const customersWithBalances = customersRes.data?.data || customersRes.data || [];
+            setCustomers(customersWithBalances);
             setTrends(trendsRes.data || {});
 
             // Use API data if available, otherwise calculate from customers data
@@ -139,8 +151,8 @@ const AccountsReceivablePage = () => {
                 setDashboardStats(dashboardRes.data);
             } else {
                 // Fallback calculation from customers data
-                const totalReceivables = customersRes.data.reduce((sum, customer) => sum + Number(customer.balance_due || 0), 0);
-                const overdueCount = customerSummaryRes.data.length || customersRes.data.filter(c => Number(c.balance_due || 0) > 0).length;
+                const totalReceivables = customersWithBalances.reduce((sum, customer) => sum + Number(customer.balance_due || 0), 0);
+                const overdueCount = (customerSummaryRes.data?.data || []).length || customersWithBalances.filter(c => Number(c.balance_due || 0) > 0).length;
 
                 setDashboardStats({
                     totalReceivables: totalReceivables,
@@ -172,7 +184,8 @@ const AccountsReceivablePage = () => {
             }
 
             // Set customer summary data
-            setCustomerSummary(customerSummaryRes.data || []);
+            setCustomerSummary(customerSummaryRes.data?.data || []);
+            setCustomerSummaryTotal(customerSummaryRes.data?.total || 0);
             setRetryCount(0); // Reset retry count on success
 
         } catch (err) {
@@ -188,7 +201,7 @@ const AccountsReceivablePage = () => {
         } finally {
             setLoading(false);
         }
-    }, [dateRange, retryCount, dashboardStats.totalReceivables]);
+    }, [dateRange, retryCount, dashboardStats.totalReceivables, customerSummaryPage, customerSummaryPageSize]);
 
     // Auto-refresh functionality
     useEffect(() => {
@@ -440,6 +453,16 @@ const AccountsReceivablePage = () => {
                 loading={loading}
                 onExport={handleExportCustomerSummary}
             />
+            <PaginationControls
+                page={customerSummaryPage}
+                pageSize={customerSummaryPageSize}
+                total={customerSummaryTotal}
+                onPageChange={setCustomerSummaryPage}
+                onPageSizeChange={(value) => {
+                    setCustomerSummaryPageSize(value);
+                    setCustomerSummaryPage(1);
+                }}
+            />
 
             <Modal 
                 isOpen={isPaymentModalOpen} 
@@ -529,6 +552,18 @@ const AccountsReceivablePage = () => {
                                 </tbody>
                             </table>
                         </div>
+                    )}
+                    {!drillDownLoading && (
+                        <PaginationControls
+                            page={drillDownPage}
+                            pageSize={drillDownPageSize}
+                            total={drillDownTotal}
+                            onPageChange={setDrillDownPage}
+                            onPageSizeChange={(value) => {
+                                setDrillDownPageSize(value);
+                                setDrillDownPage(1);
+                            }}
+                        />
                     )}
                 </div>
             </Modal>

--- a/packages/web/src/pages/ApplicationsPage.jsx
+++ b/packages/web/src/pages/ApplicationsPage.jsx
@@ -6,7 +6,9 @@ import Modal from '../components/ui/Modal';
 import Icon from '../components/ui/Icon';
 import { ICONS } from '../constants';
 import PaginationControls from '../components/ui/PaginationControls';
+import SortableHeader from '../components/ui/SortableHeader';
 import { useAuth } from '../contexts/AuthContext'; // <-- NEW: Import useAuth
+import { sortData } from '../utils/sortData';
 
 const ApplicationForm = ({ application, onSave, onCancel }) => {
     const [makes, setMakes] = useState([]);
@@ -407,6 +409,7 @@ const ApplicationsPage = () => {
     const [error, setError] = useState('');
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [currentApp, setCurrentApp] = useState(null);
+    const [sortConfig, setSortConfig] = useState({ key: 'make', direction: 'ASC' });
     const [page, setPage] = useState(1);
     const [pageSize, setPageSize] = useState(25);
     const [total, setTotal] = useState(0);
@@ -494,6 +497,8 @@ const ApplicationsPage = () => {
         });
     };
 
+    const sortedApplications = sortData(applications, sortConfig);
+
     return (
         <div>
             <div className="flex justify-between items-center mb-6">
@@ -513,14 +518,14 @@ const ApplicationsPage = () => {
                         <table className="w-full text-left">
                             <thead className="border-b">
                                 <tr>
-                                    <th className="p-3 text-sm font-semibold text-gray-600">Make</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600">Model</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600">Engine</th>
+                                    <SortableHeader column="make" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Make</SortableHeader>
+                                    <SortableHeader column="model" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Model</SortableHeader>
+                                    <SortableHeader column="engine" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Engine</SortableHeader>
                                     <th className="p-3 text-sm font-semibold text-gray-600 text-right">Actions</th>
                                 </tr>
                             </thead>
                             <tbody>
-                                {applications.map(app => (
+                                {sortedApplications.map(app => (
                                     <tr key={app.application_id} className="border-b hover:bg-gray-50">
                                         <td className="p-3 text-sm font-medium text-gray-800">{app.make}</td>
                                         <td className="p-3 text-sm">{app.model}</td>

--- a/packages/web/src/pages/ApplicationsPage.jsx
+++ b/packages/web/src/pages/ApplicationsPage.jsx
@@ -5,6 +5,7 @@ import toast from 'react-hot-toast';
 import Modal from '../components/ui/Modal';
 import Icon from '../components/ui/Icon';
 import { ICONS } from '../constants';
+import PaginationControls from '../components/ui/PaginationControls';
 import { useAuth } from '../contexts/AuthContext'; // <-- NEW: Import useAuth
 
 const ApplicationForm = ({ application, onSave, onCancel }) => {
@@ -406,13 +407,17 @@ const ApplicationsPage = () => {
     const [error, setError] = useState('');
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [currentApp, setCurrentApp] = useState(null);
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(25);
+    const [total, setTotal] = useState(0);
 
     const fetchApplications = async () => {
         try {
             setError('');
             setLoading(true);
-            const response = await api.get('/applications');
-            setApplications(response.data);
+            const response = await api.get('/applications', { params: { page, pageSize, paginated: 1 } });
+            setApplications(response.data?.data || []);
+            setTotal(response.data?.total || 0);
         } catch (error) {
             console.error('Failed to fetch applications:', error);
             setError('Failed to fetch applications.');
@@ -423,7 +428,7 @@ const ApplicationsPage = () => {
 
     useEffect(() => {
         fetchApplications();
-    }, []);
+    }, [page, pageSize]);
 
     const handleAdd = () => {
         setCurrentApp(null);
@@ -503,6 +508,7 @@ const ApplicationsPage = () => {
                 {loading && <p>Loading applications...</p>}
                 {error && <p className="text-red-500">{error}</p>}
                 {!loading && !error && (
+                    <>
                     <div className="overflow-x-auto">
                         <table className="w-full text-left">
                             <thead className="border-b">
@@ -532,6 +538,17 @@ const ApplicationsPage = () => {
                             </tbody>
                         </table>
                     </div>
+                    <PaginationControls
+                        page={page}
+                        pageSize={pageSize}
+                        total={total}
+                        onPageChange={setPage}
+                        onPageSizeChange={(value) => {
+                            setPageSize(value);
+                            setPage(1);
+                        }}
+                    />
+                    </>
                 )}
             </div>
             <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} title={currentApp ? 'Edit Application' : 'Add New Application'}>
@@ -542,4 +559,3 @@ const ApplicationsPage = () => {
 };
 
 export default ApplicationsPage;
-

--- a/packages/web/src/pages/CustomersPage.jsx
+++ b/packages/web/src/pages/CustomersPage.jsx
@@ -6,6 +6,7 @@ import Icon from '../components/ui/Icon';
 import { ICONS } from '../constants';
 import CustomerForm from '../components/forms/CustomerForm';
 import FilterBar from '../components/ui/FilterBar';
+import PaginationControls from '../components/ui/PaginationControls';
 import { useAuth } from '../contexts/AuthContext'; // <-- NEW: Import useAuth
 
 const CustomersPage = () => {
@@ -16,6 +17,9 @@ const CustomersPage = () => {
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [currentCustomer, setCurrentCustomer] = useState(null);
     const [statusFilter, setStatusFilter] = useState('active');
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(25);
+    const [total, setTotal] = useState(0);
 
     const filterTabs = [
         { key: 'active', label: 'Active' },
@@ -27,8 +31,9 @@ const CustomersPage = () => {
         try {
             setError('');
             setLoading(true);
-            const response = await api.get(`/customers?status=${statusFilter}`);
-            setCustomers(response.data);
+            const response = await api.get('/customers', { params: { status: statusFilter, page, pageSize, paginated: 1 } });
+            setCustomers(response.data?.data || []);
+            setTotal(response.data?.total || 0);
         } catch (err) {
             setError('Failed to fetch customers.');
         } finally {
@@ -38,6 +43,10 @@ const CustomersPage = () => {
 
     useEffect(() => {
         fetchCustomers();
+    }, [statusFilter, page, pageSize]);
+
+    useEffect(() => {
+        setPage(1);
     }, [statusFilter]);
 
     const handleAdd = () => {
@@ -108,6 +117,7 @@ const CustomersPage = () => {
                 {loading && <p>Loading customers...</p>}
                 {error && <p className="text-red-500">{error}</p>}
                 {!loading && !error && (
+                    <>
                     <div className="overflow-x-auto">
                         <table className="w-full text-left">
                             <thead className="border-b">
@@ -143,6 +153,17 @@ const CustomersPage = () => {
                             </tbody>
                         </table>
                     </div>
+                    <PaginationControls
+                        page={page}
+                        pageSize={pageSize}
+                        total={total}
+                        onPageChange={setPage}
+                        onPageSizeChange={(value) => {
+                            setPageSize(value);
+                            setPage(1);
+                        }}
+                    />
+                    </>
                 )}
             </div>
             <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} title={currentCustomer ? 'Edit Customer' : 'Add New Customer'}>

--- a/packages/web/src/pages/CustomersPage.jsx
+++ b/packages/web/src/pages/CustomersPage.jsx
@@ -7,7 +7,9 @@ import { ICONS } from '../constants';
 import CustomerForm from '../components/forms/CustomerForm';
 import FilterBar from '../components/ui/FilterBar';
 import PaginationControls from '../components/ui/PaginationControls';
+import SortableHeader from '../components/ui/SortableHeader';
 import { useAuth } from '../contexts/AuthContext'; // <-- NEW: Import useAuth
+import { sortData } from '../utils/sortData';
 
 const CustomersPage = () => {
     const { hasPermission } = useAuth(); // <-- NEW: Use the auth context
@@ -17,6 +19,7 @@ const CustomersPage = () => {
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [currentCustomer, setCurrentCustomer] = useState(null);
     const [statusFilter, setStatusFilter] = useState('active');
+    const [sortConfig, setSortConfig] = useState({ key: 'first_name', direction: 'ASC' });
     const [page, setPage] = useState(1);
     const [pageSize, setPageSize] = useState(25);
     const [total, setTotal] = useState(0);
@@ -96,6 +99,11 @@ const CustomersPage = () => {
         });
     };
 
+    const sortedCustomers = sortData(customers, sortConfig, {
+        full_name: (row) => `${row.first_name || ''} ${row.last_name || ''}`.trim(),
+        status: (row) => (row.is_active ? 1 : 0)
+    });
+
     return (
         <div>
             <div className="flex justify-between items-center mb-6">
@@ -122,15 +130,15 @@ const CustomersPage = () => {
                         <table className="w-full text-left">
                             <thead className="border-b">
                                 <tr>
-                                    <th className="p-3 text-sm font-semibold text-gray-600">Name</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600">Company</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600 hidden sm:table-cell">Phone</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600 text-center">Status</th>
+                                    <SortableHeader column="full_name" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Name</SortableHeader>
+                                    <SortableHeader column="company_name" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Company</SortableHeader>
+                                    <SortableHeader className="hidden sm:table-cell" column="phone" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Phone</SortableHeader>
+                                    <SortableHeader className="text-center" column="status" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Status</SortableHeader>
                                     <th className="p-3 text-sm font-semibold text-gray-600 text-right">Actions</th>
                                 </tr>
                             </thead>
                             <tbody>
-                                {customers.map(customer => (
+                                {sortedCustomers.map(customer => (
                                     <tr key={customer.customer_id} className="border-b hover:bg-gray-50">
                                         <td className="p-3 text-sm font-medium text-gray-800">{customer.first_name} {customer.last_name}</td>
                                         <td className="p-3 text-sm">{customer.company_name}</td>

--- a/packages/web/src/pages/EmployeesPage.jsx
+++ b/packages/web/src/pages/EmployeesPage.jsx
@@ -6,7 +6,9 @@ import Icon from '../components/ui/Icon';
 import { ICONS } from '../constants';
 import FilterBar from '../components/ui/FilterBar';
 import PaginationControls from '../components/ui/PaginationControls';
+import SortableHeader from '../components/ui/SortableHeader';
 import { useAuth } from '../contexts/AuthContext';
+import { sortData } from '../utils/sortData';
 
 const EmployeeForm = ({ employee, onSave, onCancel, roles }) => { // <-- NEW: roles prop
     const [formData, setFormData] = useState({
@@ -152,6 +154,7 @@ const EmployeesPage = () => {
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [currentEmployee, setCurrentEmployee] = useState(null);
     const [statusFilter, setStatusFilter] = useState('active');
+    const [sortConfig, setSortConfig] = useState({ key: 'full_name', direction: 'ASC' });
     const [page, setPage] = useState(1);
     const [pageSize, setPageSize] = useState(25);
     const [total, setTotal] = useState(0);
@@ -220,6 +223,11 @@ const EmployeesPage = () => {
             error: (err) => err.response?.data?.message || 'Failed to save employee.',
         });
     };
+
+    const sortedEmployees = sortData(employees, sortConfig, {
+        full_name: (row) => `${row.first_name || ''} ${row.last_name || ''}`.trim(),
+        status: (row) => (row.is_active ? 1 : 0)
+    });
     
     if (!hasPermission('employees:view')) {
         return (
@@ -256,15 +264,15 @@ const EmployeesPage = () => {
                         <table className="w-full text-left">
                             <thead className="border-b">
                                 <tr>
-                                    <th className="p-3 text-sm font-semibold text-gray-600">Name</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600">Username</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600">Position</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600 text-center">Status</th>
+                                    <SortableHeader column="full_name" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Name</SortableHeader>
+                                    <SortableHeader column="username" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Username</SortableHeader>
+                                    <SortableHeader column="position_title" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Position</SortableHeader>
+                                    <SortableHeader className="text-center" column="status" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Status</SortableHeader>
                                     <th className="p-3 text-sm font-semibold text-gray-600 text-right">Actions</th>
                                 </tr>
                             </thead>
                             <tbody>
-                                {employees.map(emp => (
+                                {sortedEmployees.map(emp => (
                                     <tr key={emp.employee_id} className="border-b hover:bg-gray-50">
                                         <td className="p-3 text-sm font-medium text-gray-800">{emp.first_name} {emp.last_name}</td>
                                         <td className="p-3 text-sm">{emp.username}</td>

--- a/packages/web/src/pages/EmployeesPage.jsx
+++ b/packages/web/src/pages/EmployeesPage.jsx
@@ -5,6 +5,7 @@ import Modal from '../components/ui/Modal';
 import Icon from '../components/ui/Icon';
 import { ICONS } from '../constants';
 import FilterBar from '../components/ui/FilterBar';
+import PaginationControls from '../components/ui/PaginationControls';
 import { useAuth } from '../contexts/AuthContext';
 
 const EmployeeForm = ({ employee, onSave, onCancel, roles }) => { // <-- NEW: roles prop
@@ -151,6 +152,9 @@ const EmployeesPage = () => {
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [currentEmployee, setCurrentEmployee] = useState(null);
     const [statusFilter, setStatusFilter] = useState('active');
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(25);
+    const [total, setTotal] = useState(0);
 
     const filterTabs = [
         { key: 'active', label: 'Active' },
@@ -165,10 +169,11 @@ const EmployeesPage = () => {
                     setLoading(true);
                     // Fetch both employees and roles
                     const [employeesRes, rolesRes] = await Promise.all([
-                        api.get('/employees', { params: { status: statusFilter } }),
+                        api.get('/employees', { params: { status: statusFilter, page, pageSize, paginated: 1 } }),
                         api.get('/roles') // <-- NEW: Fetch roles
                     ]);
-                    setEmployees(employeesRes.data);
+                    setEmployees(employeesRes.data?.data || []);
+                    setTotal(employeesRes.data?.total || 0);
                     setRoles(rolesRes.data); // <-- NEW: Set roles state
                 } catch {
                     setError('Failed to fetch data.');
@@ -179,7 +184,11 @@ const EmployeesPage = () => {
             }
         };
         fetchData();
-    }, [statusFilter, hasPermission]);
+    }, [statusFilter, page, pageSize, hasPermission]);
+
+    useEffect(() => {
+        setPage(1);
+    }, [statusFilter]);
 
 
     const handleAdd = () => {
@@ -201,7 +210,11 @@ const EmployeesPage = () => {
             loading: 'Saving employee...',
             success: () => {
                 setIsModalOpen(false);
-                api.get('/employees', { params: { status: statusFilter } }).then(res => setEmployees(res.data));
+                api.get('/employees', { params: { status: statusFilter, page, pageSize, paginated: 1 } })
+                    .then(res => {
+                        setEmployees(res.data?.data || []);
+                        setTotal(res.data?.total || 0);
+                    });
                 return 'Employee saved successfully!';
             },
             error: (err) => err.response?.data?.message || 'Failed to save employee.',
@@ -238,6 +251,7 @@ const EmployeesPage = () => {
                 {loading && <p>Loading employees...</p>}
                 {error && <p className="text-red-500">{error}</p>}
                 {!loading && !error && (
+                    <>
                     <div className="overflow-x-auto">
                         <table className="w-full text-left">
                             <thead className="border-b">
@@ -270,6 +284,17 @@ const EmployeesPage = () => {
                             </tbody>
                         </table>
                     </div>
+                    <PaginationControls
+                        page={page}
+                        pageSize={pageSize}
+                        total={total}
+                        onPageChange={setPage}
+                        onPageSizeChange={(value) => {
+                            setPageSize(value);
+                            setPage(1);
+                        }}
+                    />
+                    </>
                 )}
             </div>
             <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} title={currentEmployee ? 'Edit Employee' : 'Add New Employee'}>

--- a/packages/web/src/pages/GoodsReceiptHistoryPage.jsx
+++ b/packages/web/src/pages/GoodsReceiptHistoryPage.jsx
@@ -6,6 +6,7 @@ import SortableHeader from '../components/ui/SortableHeader';
 import Modal from '../components/ui/Modal';
 import Icon from '../components/ui/Icon';
 import { ICONS } from '../constants';
+import PaginationControls from '../components/ui/PaginationControls';
 import { useAuth } from '../contexts/AuthContext';
 
 const GoodsReceiptHistoryPage = ({ user: _user }) => {
@@ -21,6 +22,9 @@ const GoodsReceiptHistoryPage = ({ user: _user }) => {
     const [modalLoading, setModalLoading] = useState(false);
     const [isEditMode, setIsEditMode] = useState(false);
     const [editedLines, setEditedLines] = useState([]);
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(25);
+    const [total, setTotal] = useState(0);
 
     const fetchGrns = useCallback(async () => {
         try {
@@ -28,17 +32,21 @@ const GoodsReceiptHistoryPage = ({ user: _user }) => {
             const params = {
                 q: debouncedQuery || undefined,
                 sortBy: sortConfig.key,
-                sortOrder: sortConfig.direction.toLowerCase()
+                sortOrder: sortConfig.direction.toLowerCase(),
+                page,
+                pageSize,
+                paginated: 1
             };
             const response = await api.get('/goods-receipts', { params });
-            setGrns(response.data);
+            setGrns(response.data?.data || []);
+            setTotal(response.data?.total || 0);
         } catch (error) {
             console.error('Error fetching GRNs:', error);
             toast.error('Failed to load goods receipt history');
         } finally {
             setLoading(false);
         }
-    }, [debouncedQuery, sortConfig]);
+    }, [debouncedQuery, sortConfig, page, pageSize]);
 
     useEffect(() => {
         fetchGrns();
@@ -55,7 +63,12 @@ const GoodsReceiptHistoryPage = ({ user: _user }) => {
 
     const handleSort = (key, direction) => {
         setSortConfig({ key, direction });
+        setPage(1);
     };
+
+    useEffect(() => {
+        setPage(1);
+    }, [debouncedQuery]);
 
     const handleRowClick = async (grn) => {
         setSelectedGrn(grn);
@@ -256,6 +269,16 @@ const GoodsReceiptHistoryPage = ({ user: _user }) => {
                         </tbody>
                     </table>
                 </div>
+                <PaginationControls
+                    page={page}
+                    pageSize={pageSize}
+                    total={total}
+                    onPageChange={setPage}
+                    onPageSizeChange={(value) => {
+                        setPageSize(value);
+                        setPage(1);
+                    }}
+                />
             </div>
 
             <Modal

--- a/packages/web/src/pages/InventoryPage.jsx
+++ b/packages/web/src/pages/InventoryPage.jsx
@@ -9,8 +9,10 @@ import Modal from '../components/ui/Modal';
 import StockAdjustmentForm from '../components/forms/StockAdjustmentForm';
 import TransactionHistoryModal from '../components/ui/TransactionHistoryModal';
 import PaginationControls from '../components/ui/PaginationControls';
+import SortableHeader from '../components/ui/SortableHeader';
 import { useAuth } from '../contexts/AuthContext';
 import { useSettings } from '../contexts/SettingsContext';
+import { sortData } from '../utils/sortData';
 
 const InventoryPage = () => {
     const { user, hasPermission } = useAuth();
@@ -25,6 +27,7 @@ const InventoryPage = () => {
     const [page, setPage] = useState(1);
     const [pageSize, setPageSize] = useState(25);
     const [total, setTotal] = useState(0);
+    const [sortConfig, setSortConfig] = useState({ key: 'internal_sku', direction: 'ASC' });
     // No client-side sort: preserve backend / MeiliSearch ordering
 
     const fetchInventory = useCallback(async () => {
@@ -91,8 +94,7 @@ const InventoryPage = () => {
         });
     };
     
-    // Use inventory directly to preserve server-provided ranking (MeiliSearch)
-    const sortedInventory = inventory;
+    const sortedInventory = sortData(inventory, sortConfig);
     const toSafeNumber = (value) => {
         const numeric = Number(value);
         return Number.isFinite(numeric) ? numeric : 0;
@@ -122,11 +124,11 @@ const InventoryPage = () => {
                         <table className="w-full text-left">
                             <thead>
                                 <tr className="border-b">
-                                    <th className="p-3 text-sm font-semibold text-gray-600">SKU</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600">Item Name</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600 text-center">Stock on Hand</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600 text-right">WAC</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600 text-right">Total Value</th>
+                                    <SortableHeader column="internal_sku" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>SKU</SortableHeader>
+                                    <SortableHeader column="display_name" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Item Name</SortableHeader>
+                                    <SortableHeader className="text-center" column="stock_on_hand" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Stock on Hand</SortableHeader>
+                                    <SortableHeader className="text-right" column="wac_cost" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>WAC</SortableHeader>
+                                    <SortableHeader className="text-right" column="total_value" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Total Value</SortableHeader>
                                     <th className="p-3 text-sm font-semibold text-gray-600 text-right">Actions</th>
                                 </tr>
                             </thead>

--- a/packages/web/src/pages/InventoryPage.jsx
+++ b/packages/web/src/pages/InventoryPage.jsx
@@ -8,6 +8,7 @@ import { enrichPartsArray } from '../helpers/applicationCache';
 import Modal from '../components/ui/Modal';
 import StockAdjustmentForm from '../components/forms/StockAdjustmentForm';
 import TransactionHistoryModal from '../components/ui/TransactionHistoryModal';
+import PaginationControls from '../components/ui/PaginationControls';
 import { useAuth } from '../contexts/AuthContext';
 import { useSettings } from '../contexts/SettingsContext';
 
@@ -21,6 +22,9 @@ const InventoryPage = () => {
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [isHistoryModalOpen, setIsHistoryModalOpen] = useState(false);
     const [selectedPart, setSelectedPart] = useState(null);
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(25);
+    const [total, setTotal] = useState(0);
     // No client-side sort: preserve backend / MeiliSearch ordering
 
     const fetchInventory = useCallback(async () => {
@@ -29,13 +33,15 @@ const InventoryPage = () => {
             setLoading(true);
             // If there's no search term, use the inventory endpoint (full list)
             if (!searchTerm || !searchTerm.trim()) {
-                const response = await api.get(`/inventory`);
-                setInventory(response.data);
+                const response = await api.get('/inventory', { params: { page, pageSize, paginated: 1 } });
+                setInventory(response.data?.data || []);
+                setTotal(response.data?.total || 0);
             } else {
                 // Use MeiliSearch-backed endpoint for smart searching (same as POS/Invoicing)
-                const response = await api.get('/power-search/parts', { params: { keyword: searchTerm } });
-                const enriched = await enrichPartsArray(response.data || []);
+                const response = await api.get('/inventory', { params: { search: searchTerm, page, pageSize, paginated: 1 } });
+                const enriched = await enrichPartsArray(response.data?.data || []);
                 setInventory(enriched);
+                setTotal(response.data?.total || 0);
             }
         } catch (error) {
             console.error('Failed to fetch inventory', error);
@@ -43,7 +49,7 @@ const InventoryPage = () => {
         } finally {
             setLoading(false);
         }
-    }, [searchTerm]);
+    }, [searchTerm, page, pageSize]);
 
     useEffect(() => {
         const debounceTimer = setTimeout(() => {
@@ -52,6 +58,10 @@ const InventoryPage = () => {
 
         return () => clearTimeout(debounceTimer);
     }, [fetchInventory]);
+
+    useEffect(() => {
+        setPage(1);
+    }, [searchTerm]);
 
     const handleOpenAdjustmentModal = (part) => {
         setSelectedPart(part);
@@ -107,6 +117,7 @@ const InventoryPage = () => {
                 {loading && <p>Loading inventory...</p>}
                 {error && <p className="text-red-500">{error}</p>}
                 {!loading && !error && (
+                    <>
                     <div className="overflow-x-auto">
                         <table className="w-full text-left">
                             <thead>
@@ -149,6 +160,17 @@ const InventoryPage = () => {
                             </tbody>
                         </table>
                     </div>
+                    <PaginationControls
+                        page={page}
+                        pageSize={pageSize}
+                        total={total}
+                        onPageChange={setPage}
+                        onPageSizeChange={(value) => {
+                            setPageSize(value);
+                            setPage(1);
+                        }}
+                    />
+                    </>
                 )}
             </div>
 

--- a/packages/web/src/pages/InventoryPage.jsx
+++ b/packages/web/src/pages/InventoryPage.jsx
@@ -27,7 +27,7 @@ const InventoryPage = () => {
     const [page, setPage] = useState(1);
     const [pageSize, setPageSize] = useState(25);
     const [total, setTotal] = useState(0);
-    const [sortConfig, setSortConfig] = useState({ key: 'internal_sku', direction: 'ASC' });
+    const [sortConfig, setSortConfig] = useState({ key: null, direction: 'ASC' });
     const [globalSortBy, setGlobalSortBy] = useState('name');
     const [globalSortDirection, setGlobalSortDirection] = useState('ASC');
     // No client-side sort: preserve backend / MeiliSearch ordering
@@ -68,6 +68,10 @@ const InventoryPage = () => {
         setPage(1);
     }, [searchTerm, globalSortBy, globalSortDirection]);
 
+    useEffect(() => {
+        setSortConfig({ key: null, direction: 'ASC' });
+    }, [globalSortBy, globalSortDirection]);
+
     const handleOpenAdjustmentModal = (part) => {
         setSelectedPart(part);
         setIsModalOpen(true);
@@ -96,11 +100,15 @@ const InventoryPage = () => {
         });
     };
     
-    const sortedInventory = sortData(inventory, sortConfig);
     const toSafeNumber = (value) => {
         const numeric = Number(value);
         return Number.isFinite(numeric) ? numeric : 0;
     };
+    const sortedInventory = sortData(inventory, sortConfig, {
+        stock_on_hand: (row) => toSafeNumber(row.stock_on_hand),
+        wac_cost: (row) => toSafeNumber(row.wac_cost),
+        total_value: (row) => toSafeNumber(row.total_value)
+    });
 
     return (
         <div>

--- a/packages/web/src/pages/InventoryPage.jsx
+++ b/packages/web/src/pages/InventoryPage.jsx
@@ -28,6 +28,7 @@ const InventoryPage = () => {
     const [pageSize, setPageSize] = useState(25);
     const [total, setTotal] = useState(0);
     const [sortConfig, setSortConfig] = useState({ key: 'internal_sku', direction: 'ASC' });
+    const [globalSortBy, setGlobalSortBy] = useState('name');
     const [globalSortDirection, setGlobalSortDirection] = useState('ASC');
     // No client-side sort: preserve backend / MeiliSearch ordering
 
@@ -37,12 +38,12 @@ const InventoryPage = () => {
             setLoading(true);
             // If there's no search term, use the inventory endpoint (full list)
             if (!searchTerm || !searchTerm.trim()) {
-                const response = await api.get('/inventory', { params: { page, pageSize, paginated: 1, sortBy: 'name', sortDirection: globalSortDirection } });
+                const response = await api.get('/inventory', { params: { page, pageSize, paginated: 1, sortBy: globalSortBy, sortDirection: globalSortDirection } });
                 setInventory(response.data?.data || []);
                 setTotal(response.data?.total || 0);
             } else {
                 // Use MeiliSearch-backed endpoint for smart searching (same as POS/Invoicing)
-                const response = await api.get('/inventory', { params: { search: searchTerm, page, pageSize, paginated: 1, sortBy: 'name', sortDirection: globalSortDirection } });
+                const response = await api.get('/inventory', { params: { search: searchTerm, page, pageSize, paginated: 1, sortBy: globalSortBy, sortDirection: globalSortDirection } });
                 const enriched = await enrichPartsArray(response.data?.data || []);
                 setInventory(enriched);
                 setTotal(response.data?.total || 0);
@@ -53,7 +54,7 @@ const InventoryPage = () => {
         } finally {
             setLoading(false);
         }
-    }, [searchTerm, page, pageSize, globalSortDirection]);
+    }, [searchTerm, page, pageSize, globalSortBy, globalSortDirection]);
 
     useEffect(() => {
         const debounceTimer = setTimeout(() => {
@@ -65,7 +66,7 @@ const InventoryPage = () => {
 
     useEffect(() => {
         setPage(1);
-    }, [searchTerm, globalSortDirection]);
+    }, [searchTerm, globalSortBy, globalSortDirection]);
 
     const handleOpenAdjustmentModal = (part) => {
         setSelectedPart(part);
@@ -103,10 +104,10 @@ const InventoryPage = () => {
 
     return (
         <div>
-            <div className="flex justify-between items-center mb-6">
+            <div className="mb-6">
                 <h1 className="text-2xl font-semibold text-gray-800">Inventory Management</h1>
-                <div className="flex items-center gap-3">
-                    <div className="relative w-full max-w-xs">
+                <div className="mt-3 flex flex-wrap items-center gap-3">
+                    <div className="relative w-full max-w-md">
                         <SearchBar
                             value={searchTerm}
                             onChange={setSearchTerm}
@@ -115,15 +116,30 @@ const InventoryPage = () => {
                         />
                     </div>
                     <div className="flex items-center gap-2">
-                        <label htmlFor="inventory-global-sort" className="text-sm text-gray-600 whitespace-nowrap">Sort all:</label>
+                        <label htmlFor="inventory-global-sort-by" className="text-sm text-gray-600 whitespace-nowrap">Sort all by</label>
                         <select
-                            id="inventory-global-sort"
+                            id="inventory-global-sort-by"
+                            value={globalSortBy}
+                            onChange={(e) => setGlobalSortBy(e.target.value)}
+                            className="rounded-md border border-gray-300 px-2 py-2 text-sm"
+                        >
+                            <option value="sku">SKU</option>
+                            <option value="name">Name</option>
+                            <option value="stock_on_hand">Stock on Hand</option>
+                            <option value="wac">WAC</option>
+                            <option value="total_value">Total Value</option>
+                        </select>
+                    </div>
+                    <div className="flex items-center gap-2">
+                        <label htmlFor="inventory-global-sort-direction" className="text-sm text-gray-600 whitespace-nowrap">Order</label>
+                        <select
+                            id="inventory-global-sort-direction"
                             value={globalSortDirection}
                             onChange={(e) => setGlobalSortDirection(e.target.value)}
                             className="rounded-md border border-gray-300 px-2 py-2 text-sm"
                         >
-                            <option value="ASC">Name (A-Z)</option>
-                            <option value="DESC">Name (Z-A)</option>
+                            <option value="ASC">Ascending</option>
+                            <option value="DESC">Descending</option>
                         </select>
                     </div>
                 </div>

--- a/packages/web/src/pages/InventoryPage.jsx
+++ b/packages/web/src/pages/InventoryPage.jsx
@@ -28,6 +28,7 @@ const InventoryPage = () => {
     const [pageSize, setPageSize] = useState(25);
     const [total, setTotal] = useState(0);
     const [sortConfig, setSortConfig] = useState({ key: 'internal_sku', direction: 'ASC' });
+    const [globalSortDirection, setGlobalSortDirection] = useState('ASC');
     // No client-side sort: preserve backend / MeiliSearch ordering
 
     const fetchInventory = useCallback(async () => {
@@ -36,12 +37,12 @@ const InventoryPage = () => {
             setLoading(true);
             // If there's no search term, use the inventory endpoint (full list)
             if (!searchTerm || !searchTerm.trim()) {
-                const response = await api.get('/inventory', { params: { page, pageSize, paginated: 1 } });
+                const response = await api.get('/inventory', { params: { page, pageSize, paginated: 1, sortBy: 'name', sortDirection: globalSortDirection } });
                 setInventory(response.data?.data || []);
                 setTotal(response.data?.total || 0);
             } else {
                 // Use MeiliSearch-backed endpoint for smart searching (same as POS/Invoicing)
-                const response = await api.get('/inventory', { params: { search: searchTerm, page, pageSize, paginated: 1 } });
+                const response = await api.get('/inventory', { params: { search: searchTerm, page, pageSize, paginated: 1, sortBy: 'name', sortDirection: globalSortDirection } });
                 const enriched = await enrichPartsArray(response.data?.data || []);
                 setInventory(enriched);
                 setTotal(response.data?.total || 0);
@@ -52,7 +53,7 @@ const InventoryPage = () => {
         } finally {
             setLoading(false);
         }
-    }, [searchTerm, page, pageSize]);
+    }, [searchTerm, page, pageSize, globalSortDirection]);
 
     useEffect(() => {
         const debounceTimer = setTimeout(() => {
@@ -64,7 +65,7 @@ const InventoryPage = () => {
 
     useEffect(() => {
         setPage(1);
-    }, [searchTerm]);
+    }, [searchTerm, globalSortDirection]);
 
     const handleOpenAdjustmentModal = (part) => {
         setSelectedPart(part);
@@ -104,14 +105,27 @@ const InventoryPage = () => {
         <div>
             <div className="flex justify-between items-center mb-6">
                 <h1 className="text-2xl font-semibold text-gray-800">Inventory Management</h1>
-                <div className="relative w-full max-w-xs">
-                    <SearchBar
-                        value={searchTerm}
-                        onChange={setSearchTerm}
-                        onClear={() => setSearchTerm('')}
-                        placeholder="Search inventory..."
-                    />
-                    
+                <div className="flex items-center gap-3">
+                    <div className="relative w-full max-w-xs">
+                        <SearchBar
+                            value={searchTerm}
+                            onChange={setSearchTerm}
+                            onClear={() => setSearchTerm('')}
+                            placeholder="Search inventory..."
+                        />
+                    </div>
+                    <div className="flex items-center gap-2">
+                        <label htmlFor="inventory-global-sort" className="text-sm text-gray-600 whitespace-nowrap">Sort all:</label>
+                        <select
+                            id="inventory-global-sort"
+                            value={globalSortDirection}
+                            onChange={(e) => setGlobalSortDirection(e.target.value)}
+                            className="rounded-md border border-gray-300 px-2 py-2 text-sm"
+                        >
+                            <option value="ASC">Name (A-Z)</option>
+                            <option value="DESC">Name (Z-A)</option>
+                        </select>
+                    </div>
                 </div>
             </div>
 

--- a/packages/web/src/pages/PartsPage.jsx
+++ b/packages/web/src/pages/PartsPage.jsx
@@ -8,6 +8,7 @@ import Modal from '../components/ui/Modal';
 import PartForm from '../components/forms/PartForm';
 import FilterBar from '../components/ui/FilterBar';
 import TagPopover from '../components/ui/TagPopover';
+import PaginationControls from '../components/ui/PaginationControls';
 import { useAuth } from '../contexts/AuthContext';
 import PartNumberManager from './PartNumberManager';
 import PartApplicationManager from './PartApplicationManager';
@@ -27,16 +28,20 @@ const PartsPage = ({ user, onNavigate }) => {
     const [searchTerm, setSearchTerm] = useState('');
     const [selectedParts, setSelectedParts] = useState([]);
     const [isBulkEditModalOpen, setIsBulkEditModalOpen] = useState(false);
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(25);
+    const [total, setTotal] = useState(0);
 
     const fetchInitialData = useCallback(async () => {
         try {
             setLoading(true);
             const [partsRes, brandsRes, groupsRes] = await Promise.all([
-                api.get('/parts', { params: { status: statusFilter, search: searchTerm } }),
+                api.get('/parts', { params: { status: statusFilter, search: searchTerm, page, pageSize, paginated: 1 } }),
                 api.get('/brands'),
                 api.get('/groups')
             ]);
-            setParts(partsRes.data);
+            setParts(partsRes.data?.data || []);
+            setTotal(partsRes.data?.total || 0);
             setBrands(brandsRes.data);
             setGroups(groupsRes.data);
         } catch (error) {
@@ -44,7 +49,7 @@ const PartsPage = ({ user, onNavigate }) => {
         } finally {
             setLoading(false);
         }
-    }, [statusFilter, searchTerm]);
+    }, [statusFilter, searchTerm, page, pageSize]);
 
     useEffect(() => {
         const debounceTimer = setTimeout(() => {
@@ -52,6 +57,10 @@ const PartsPage = ({ user, onNavigate }) => {
         }, 300);
         return () => clearTimeout(debounceTimer);
     }, [fetchInitialData]);
+
+    useEffect(() => {
+        setPage(1);
+    }, [statusFilter, searchTerm]);
 
     const handleSave = (partData) => {
         const promise = currentPart
@@ -224,6 +233,7 @@ const PartsPage = ({ user, onNavigate }) => {
 
             <div className="bg-white p-6 rounded-xl border border-gray-200">
                 {loading ? <p>Loading...</p> : (
+                    <>
                     <div className="overflow-x-auto">
                         <table className="w-full text-left">
                             <thead>
@@ -260,6 +270,18 @@ const PartsPage = ({ user, onNavigate }) => {
                             </tbody>
                         </table>
                     </div>
+                    <PaginationControls
+                        page={page}
+                        pageSize={pageSize}
+                        total={total}
+                        onPageChange={setPage}
+                        onPageSizeChange={(value) => {
+                            setPageSize(value);
+                            setPage(1);
+                            setSelectedParts([]);
+                        }}
+                    />
+                    </>
                 )}
             </div>
             <Modal isOpen={isFormModalOpen} onClose={() => setIsFormModalOpen(false)} title={currentPart ? 'Edit Part' : 'New Part'}>

--- a/packages/web/src/pages/PartsPage.jsx
+++ b/packages/web/src/pages/PartsPage.jsx
@@ -9,10 +9,12 @@ import PartForm from '../components/forms/PartForm';
 import FilterBar from '../components/ui/FilterBar';
 import TagPopover from '../components/ui/TagPopover';
 import PaginationControls from '../components/ui/PaginationControls';
+import SortableHeader from '../components/ui/SortableHeader';
 import { useAuth } from '../contexts/AuthContext';
 import PartNumberManager from './PartNumberManager';
 import PartApplicationManager from './PartApplicationManager';
 import { formatApplicationText } from '../helpers/applicationTextHelper';
+import { sortData } from '../utils/sortData';
 
 const PartsPage = ({ user, onNavigate }) => {
     const { hasPermission } = useAuth();
@@ -31,6 +33,7 @@ const PartsPage = ({ user, onNavigate }) => {
     const [page, setPage] = useState(1);
     const [pageSize, setPageSize] = useState(25);
     const [total, setTotal] = useState(0);
+    const [sortConfig, setSortConfig] = useState({ key: 'internal_sku', direction: 'ASC' });
 
     const fetchInitialData = useCallback(async () => {
         try {
@@ -180,8 +183,9 @@ const PartsPage = ({ user, onNavigate }) => {
         }
     };
 
-    // Use parts directly to preserve MeiliSearch's relevance ranking
-    const sortedParts = parts;
+    const sortedParts = sortData(parts, sortConfig, {
+        application_text: (row) => row.applications || ''
+    });
 
     const filterTabs = [
         { key: 'active', label: 'Active' },
@@ -239,9 +243,9 @@ const PartsPage = ({ user, onNavigate }) => {
                             <thead>
                                 <tr>
                                     <th className="p-3 w-10"><input type="checkbox" onChange={handleSelectAll} checked={selectedParts.length === sortedParts.length && sortedParts.length > 0} /></th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600">SKU</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600">Item</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600">Application</th>
+                                    <SortableHeader column="internal_sku" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>SKU</SortableHeader>
+                                    <SortableHeader column="display_name" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Item</SortableHeader>
+                                    <SortableHeader column="application_text" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Application</SortableHeader>
                                     <th className="p-3 text-sm font-semibold text-gray-600 text-right">Actions</th>
                                 </tr>
                             </thead>

--- a/packages/web/src/pages/PartsPage.jsx
+++ b/packages/web/src/pages/PartsPage.jsx
@@ -34,12 +34,13 @@ const PartsPage = ({ user, onNavigate }) => {
     const [pageSize, setPageSize] = useState(25);
     const [total, setTotal] = useState(0);
     const [sortConfig, setSortConfig] = useState({ key: 'internal_sku', direction: 'ASC' });
+    const [globalSortDirection, setGlobalSortDirection] = useState('ASC');
 
     const fetchInitialData = useCallback(async () => {
         try {
             setLoading(true);
             const [partsRes, brandsRes, groupsRes] = await Promise.all([
-                api.get('/parts', { params: { status: statusFilter, search: searchTerm, page, pageSize, paginated: 1 } }),
+                api.get('/parts', { params: { status: statusFilter, search: searchTerm, page, pageSize, paginated: 1, sortBy: 'name', sortDirection: globalSortDirection } }),
                 api.get('/brands'),
                 api.get('/groups')
             ]);
@@ -52,7 +53,7 @@ const PartsPage = ({ user, onNavigate }) => {
         } finally {
             setLoading(false);
         }
-    }, [statusFilter, searchTerm, page, pageSize]);
+    }, [statusFilter, searchTerm, page, pageSize, globalSortDirection]);
 
     useEffect(() => {
         const debounceTimer = setTimeout(() => {
@@ -63,7 +64,7 @@ const PartsPage = ({ user, onNavigate }) => {
 
     useEffect(() => {
         setPage(1);
-    }, [statusFilter, searchTerm]);
+    }, [statusFilter, searchTerm, globalSortDirection]);
 
     const handleSave = (partData) => {
         const promise = currentPart
@@ -230,6 +231,18 @@ const PartsPage = ({ user, onNavigate }) => {
                             onClear={() => setSearchTerm('')}
                             placeholder="Search by detail, SKU, or part number..."
                         />
+                    </div>
+                    <div className="ml-3 flex items-center gap-2">
+                        <label htmlFor="parts-global-sort" className="text-sm text-gray-600 whitespace-nowrap">Sort all:</label>
+                        <select
+                            id="parts-global-sort"
+                            value={globalSortDirection}
+                            onChange={(e) => setGlobalSortDirection(e.target.value)}
+                            className="rounded-md border border-gray-300 px-2 py-2 text-sm"
+                        >
+                            <option value="ASC">Name (A-Z)</option>
+                            <option value="DESC">Name (Z-A)</option>
+                        </select>
                     </div>
                 </div>
             </div>

--- a/packages/web/src/pages/PartsPage.jsx
+++ b/packages/web/src/pages/PartsPage.jsx
@@ -34,13 +34,14 @@ const PartsPage = ({ user, onNavigate }) => {
     const [pageSize, setPageSize] = useState(25);
     const [total, setTotal] = useState(0);
     const [sortConfig, setSortConfig] = useState({ key: 'internal_sku', direction: 'ASC' });
+    const [globalSortBy, setGlobalSortBy] = useState('name');
     const [globalSortDirection, setGlobalSortDirection] = useState('ASC');
 
     const fetchInitialData = useCallback(async () => {
         try {
             setLoading(true);
             const [partsRes, brandsRes, groupsRes] = await Promise.all([
-                api.get('/parts', { params: { status: statusFilter, search: searchTerm, page, pageSize, paginated: 1, sortBy: 'name', sortDirection: globalSortDirection } }),
+                api.get('/parts', { params: { status: statusFilter, search: searchTerm, page, pageSize, paginated: 1, sortBy: globalSortBy, sortDirection: globalSortDirection } }),
                 api.get('/brands'),
                 api.get('/groups')
             ]);
@@ -53,7 +54,7 @@ const PartsPage = ({ user, onNavigate }) => {
         } finally {
             setLoading(false);
         }
-    }, [statusFilter, searchTerm, page, pageSize, globalSortDirection]);
+    }, [statusFilter, searchTerm, page, pageSize, globalSortBy, globalSortDirection]);
 
     useEffect(() => {
         const debounceTimer = setTimeout(() => {
@@ -64,7 +65,7 @@ const PartsPage = ({ user, onNavigate }) => {
 
     useEffect(() => {
         setPage(1);
-    }, [statusFilter, searchTerm, globalSortDirection]);
+    }, [statusFilter, searchTerm, globalSortBy, globalSortDirection]);
 
     const handleSave = (partData) => {
         const promise = currentPart
@@ -217,14 +218,14 @@ const PartsPage = ({ user, onNavigate }) => {
                 </div>
             </div>
 
-            <div className="mb-4">
-                <div className="flex justify-between items-center">
-                    <FilterBar
-                        tabs={filterTabs}
-                        activeTab={statusFilter}
-                        onTabClick={setStatusFilter}
-                    />
-                    <div className="relative w-full max-w-xs">
+            <div className="mb-4 space-y-3">
+                <FilterBar
+                    tabs={filterTabs}
+                    activeTab={statusFilter}
+                    onTabClick={setStatusFilter}
+                />
+                <div className="flex flex-wrap items-center gap-3">
+                    <div className="relative w-full max-w-md">
                         <SearchBar
                             value={searchTerm}
                             onChange={setSearchTerm}
@@ -232,16 +233,29 @@ const PartsPage = ({ user, onNavigate }) => {
                             placeholder="Search by detail, SKU, or part number..."
                         />
                     </div>
-                    <div className="ml-3 flex items-center gap-2">
-                        <label htmlFor="parts-global-sort" className="text-sm text-gray-600 whitespace-nowrap">Sort all:</label>
+                    <div className="flex items-center gap-2">
+                        <label htmlFor="parts-global-sort-by" className="text-sm text-gray-600 whitespace-nowrap">Sort all by</label>
                         <select
-                            id="parts-global-sort"
+                            id="parts-global-sort-by"
+                            value={globalSortBy}
+                            onChange={(e) => setGlobalSortBy(e.target.value)}
+                            className="rounded-md border border-gray-300 px-2 py-2 text-sm"
+                        >
+                            <option value="name">Name</option>
+                            <option value="sku">SKU</option>
+                            <option value="application">Application</option>
+                        </select>
+                    </div>
+                    <div className="flex items-center gap-2">
+                        <label htmlFor="parts-global-sort-direction" className="text-sm text-gray-600 whitespace-nowrap">Order</label>
+                        <select
+                            id="parts-global-sort-direction"
                             value={globalSortDirection}
                             onChange={(e) => setGlobalSortDirection(e.target.value)}
                             className="rounded-md border border-gray-300 px-2 py-2 text-sm"
                         >
-                            <option value="ASC">Name (A-Z)</option>
-                            <option value="DESC">Name (Z-A)</option>
+                            <option value="ASC">Ascending</option>
+                            <option value="DESC">Descending</option>
                         </select>
                     </div>
                 </div>

--- a/packages/web/src/pages/PurchaseOrderPage.jsx
+++ b/packages/web/src/pages/PurchaseOrderPage.jsx
@@ -7,7 +7,11 @@ import { useAuth } from '../contexts/AuthContext';
 // Modal removed in favor of dedicated full-page editor
 import PurchaseOrderEditorPage from './PurchaseOrderEditorPage';
 import FilterBar from '../components/ui/FilterBar';
+import PaginationControls from '../components/ui/PaginationControls';
+import SortableHeader from '../components/ui/SortableHeader';
 import { downloadFile } from '../utils/downloadFile';
+import { getPaginatedPayload } from '../utils/paginatedResponse';
+import { sortData } from '../utils/sortData';
 import { format, parseISO } from 'date-fns';
 import { toZonedTime } from 'date-fns-tz';
 
@@ -72,6 +76,10 @@ const PurchaseOrderPage = () => {
     const [isEditing, setIsEditing] = useState(false);
     const [statusFilter, setStatusFilter] = useState('Pending');
     const [expandedRows, setExpandedRows] = useState(new Set());
+    const [sortConfig, setSortConfig] = useState({ key: 'order_date', direction: 'DESC' });
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(25);
+    const [total, setTotal] = useState(0);
 
     const filterTabs = [
         { key: 'Pending', label: 'Pending' },
@@ -86,23 +94,32 @@ const PurchaseOrderPage = () => {
         if (hasPermission('purchase_orders:view')) {
             try {
                 setLoading(true);
-                const response = await api.get('/purchase-orders', { params: { status: statusFilter } });
-                setPurchaseOrders(response.data);
+                const response = await api.get('/purchase-orders', { params: { status: statusFilter, page, pageSize, paginated: 1 } });
+                const payload = getPaginatedPayload(response.data, 0);
+                setPurchaseOrders(payload.data);
+                setTotal(payload.total);
             } catch {
                 toast.error('Failed to fetch purchase orders.');
             } finally {
                 setLoading(false);
             }
         }
-    }, [hasPermission, statusFilter]);
+    }, [hasPermission, statusFilter, page, pageSize]);
 
     useEffect(() => {
         fetchPOs();
     }, [fetchPOs]);
+
+    useEffect(() => {
+        setPage(1);
+        setExpandedRows(new Set());
+    }, [statusFilter]);
     
     const showActionsColumn = useMemo(() => {
         return hasPermission('purchase_orders:edit') && purchaseOrders.some(po => po.status === 'Pending');
     }, [purchaseOrders, hasPermission]);
+
+    const sortedPurchaseOrders = useMemo(() => sortData(purchaseOrders, sortConfig), [purchaseOrders, sortConfig]);
 
 
     const exitEditor = useCallback(() => {
@@ -216,11 +233,11 @@ const PurchaseOrderPage = () => {
                         <table className="w-full text-left">
                             <thead className="border-b">
                                 <tr>
-                                    <th className="p-3 text-sm font-semibold text-gray-600">PO Number</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600">Supplier</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600">Status</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600">Order Date</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600 text-right">Total</th>
+                                    <SortableHeader column="po_number" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>PO Number</SortableHeader>
+                                    <SortableHeader column="supplier_name" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Supplier</SortableHeader>
+                                    <SortableHeader column="status" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Status</SortableHeader>
+                                    <SortableHeader column="order_date" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Order Date</SortableHeader>
+                                    <SortableHeader column="total_amount" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })} className="text-right">Total</SortableHeader>
                                     <th className="p-3 text-sm font-semibold text-gray-600 text-center">Details</th>
                                     {/* --- NEW: Download Column Header --- */}
                                     <th className="p-3 text-sm font-semibold text-gray-600 text-center">Download</th>
@@ -228,7 +245,7 @@ const PurchaseOrderPage = () => {
                                 </tr>
                             </thead>
                             <tbody>
-                                {purchaseOrders.map(po => (
+                                {sortedPurchaseOrders.map(po => (
                                         <React.Fragment key={po.po_id}>
                                         <tr className="border-b hover:bg-gray-50">
                                             <td className="p-3 text-sm font-mono">{po.po_number}</td>
@@ -287,6 +304,16 @@ const PurchaseOrderPage = () => {
                             </tbody>
                         </table>
                     </div>
+                    <PaginationControls
+                        page={page}
+                        pageSize={pageSize}
+                        total={total}
+                        onPageChange={setPage}
+                        onPageSizeChange={(value) => {
+                            setPageSize(value);
+                            setPage(1);
+                        }}
+                    />
                 )}
             </div>
 

--- a/packages/web/src/pages/PurchaseOrderPage.jsx
+++ b/packages/web/src/pages/PurchaseOrderPage.jsx
@@ -229,6 +229,7 @@ const PurchaseOrderPage = () => {
 
             <div className="bg-white p-6 rounded-xl border border-gray-200">
                 {loading ? <p>Loading...</p> : (
+                    <>
                     <div className="overflow-x-auto">
                         <table className="w-full text-left">
                             <thead className="border-b">
@@ -314,6 +315,7 @@ const PurchaseOrderPage = () => {
                             setPage(1);
                         }}
                     />
+                    </>
                 )}
             </div>
 

--- a/packages/web/src/pages/SuppliersPage.jsx
+++ b/packages/web/src/pages/SuppliersPage.jsx
@@ -7,7 +7,9 @@ import { ICONS } from '../constants';
 import SupplierForm from '../components/forms/SupplierForm';
 import FilterBar from '../components/ui/FilterBar';
 import PaginationControls from '../components/ui/PaginationControls';
+import SortableHeader from '../components/ui/SortableHeader';
 import { useAuth } from '../contexts/AuthContext'; // <-- NEW: Import useAuth
+import { sortData } from '../utils/sortData';
 
 const SuppliersPage = () => {
     const { hasPermission } = useAuth(); // <-- NEW: Use the auth context
@@ -17,6 +19,7 @@ const SuppliersPage = () => {
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [currentSupplier, setCurrentSupplier] = useState(null);
     const [statusFilter, setStatusFilter] = useState('active');
+    const [sortConfig, setSortConfig] = useState({ key: 'supplier_name', direction: 'ASC' });
     const [page, setPage] = useState(1);
     const [pageSize, setPageSize] = useState(25);
     const [total, setTotal] = useState(0);
@@ -96,6 +99,10 @@ const SuppliersPage = () => {
         });
     };
 
+    const sortedSuppliers = sortData(suppliers, sortConfig, {
+        status: (row) => (row.is_active ? 1 : 0)
+    });
+
     return (
         <div>
             <div className="flex justify-between items-center mb-6">
@@ -122,15 +129,15 @@ const SuppliersPage = () => {
                         <table className="w-full text-left">
                             <thead className="border-b">
                                 <tr>
-                                    <th className="p-3 text-sm font-semibold text-gray-600">Name</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600 hidden sm:table-cell">Contact Person</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600 hidden md:table-cell">Phone</th>
-                                    <th className="p-3 text-sm font-semibold text-gray-600 text-center">Status</th>
+                                    <SortableHeader column="supplier_name" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Name</SortableHeader>
+                                    <SortableHeader className="hidden sm:table-cell" column="contact_person" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Contact Person</SortableHeader>
+                                    <SortableHeader className="hidden md:table-cell" column="phone" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Phone</SortableHeader>
+                                    <SortableHeader className="text-center" column="status" sortConfig={sortConfig} onSort={(key, direction) => setSortConfig({ key, direction })}>Status</SortableHeader>
                                     <th className="p-3 text-sm font-semibold text-gray-600 text-right">Actions</th>
                                 </tr>
                             </thead>
                             <tbody>
-                                {suppliers.map(supplier => (
+                                {sortedSuppliers.map(supplier => (
                                     <tr key={supplier.supplier_id} className="border-b hover:bg-gray-50">
                                         <td className="p-3 text-sm font-medium text-gray-800">{supplier.supplier_name}</td>
                                         <td className="p-3 text-sm hidden sm:table-cell">{supplier.contact_person}</td>

--- a/packages/web/src/pages/SuppliersPage.jsx
+++ b/packages/web/src/pages/SuppliersPage.jsx
@@ -6,6 +6,7 @@ import Icon from '../components/ui/Icon';
 import { ICONS } from '../constants';
 import SupplierForm from '../components/forms/SupplierForm';
 import FilterBar from '../components/ui/FilterBar';
+import PaginationControls from '../components/ui/PaginationControls';
 import { useAuth } from '../contexts/AuthContext'; // <-- NEW: Import useAuth
 
 const SuppliersPage = () => {
@@ -16,6 +17,9 @@ const SuppliersPage = () => {
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [currentSupplier, setCurrentSupplier] = useState(null);
     const [statusFilter, setStatusFilter] = useState('active');
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(25);
+    const [total, setTotal] = useState(0);
 
     const filterTabs = [
         { key: 'active', label: 'Active' },
@@ -27,8 +31,9 @@ const SuppliersPage = () => {
         try {
             setError('');
             setLoading(true);
-            const response = await api.get(`/suppliers?status=${statusFilter}`);
-            setSuppliers(response.data);
+            const response = await api.get('/suppliers', { params: { status: statusFilter, page, pageSize, paginated: 1 } });
+            setSuppliers(response.data?.data || []);
+            setTotal(response.data?.total || 0);
         } catch (err) {
             setError('Failed to fetch suppliers.');
         } finally {
@@ -38,6 +43,10 @@ const SuppliersPage = () => {
 
     useEffect(() => {
         fetchSuppliers();
+    }, [statusFilter, page, pageSize]);
+
+    useEffect(() => {
+        setPage(1);
     }, [statusFilter]);
 
     const handleAdd = () => {
@@ -108,6 +117,7 @@ const SuppliersPage = () => {
                 {loading && <p>Loading suppliers...</p>}
                 {error && <p className="text-red-500">{error}</p>}
                 {!loading && !error && (
+                    <>
                     <div className="overflow-x-auto">
                         <table className="w-full text-left">
                             <thead className="border-b">
@@ -143,6 +153,17 @@ const SuppliersPage = () => {
                             </tbody>
                         </table>
                     </div>
+                    <PaginationControls
+                        page={page}
+                        pageSize={pageSize}
+                        total={total}
+                        onPageChange={setPage}
+                        onPageSizeChange={(value) => {
+                            setPageSize(value);
+                            setPage(1);
+                        }}
+                    />
+                    </>
                 )}
             </div>
             <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} title={currentSupplier ? 'Edit Supplier' : 'Add New Supplier'}>

--- a/packages/web/src/utils/paginatedResponse.js
+++ b/packages/web/src/utils/paginatedResponse.js
@@ -1,0 +1,17 @@
+export const getPaginatedPayload = (payload, fallbackTotal = 0) => {
+    if (Array.isArray(payload)) {
+        return {
+            data: payload,
+            total: fallbackTotal || payload.length,
+            page: 1,
+            pageSize: payload.length || 1
+        };
+    }
+
+    return {
+        data: payload?.data || payload?.details || [],
+        total: Number(payload?.total ?? fallbackTotal ?? 0),
+        page: Number(payload?.page ?? 1),
+        pageSize: Number(payload?.pageSize ?? (payload?.data?.length || payload?.details?.length || 1))
+    };
+};

--- a/packages/web/src/utils/sortData.js
+++ b/packages/web/src/utils/sortData.js
@@ -1,0 +1,26 @@
+export const sortData = (rows = [], sortConfig, accessors = {}) => {
+    if (!sortConfig?.key) return rows;
+    const direction = sortConfig.direction === 'DESC' ? -1 : 1;
+    const getValue = accessors[sortConfig.key] || ((row) => row?.[sortConfig.key]);
+
+    return [...rows].sort((a, b) => {
+        const aValue = getValue(a);
+        const bValue = getValue(b);
+
+        if (aValue == null && bValue == null) return 0;
+        if (aValue == null) return 1 * direction;
+        if (bValue == null) return -1 * direction;
+
+        const aDate = Date.parse(aValue);
+        const bDate = Date.parse(bValue);
+        const bothDates = !Number.isNaN(aDate) && !Number.isNaN(bDate);
+        if (bothDates) return (aDate - bDate) * direction;
+
+        const aNumber = Number(aValue);
+        const bNumber = Number(bValue);
+        const bothNumbers = !Number.isNaN(aNumber) && !Number.isNaN(bNumber);
+        if (bothNumbers) return (aNumber - bNumber) * direction;
+
+        return String(aValue).localeCompare(String(bValue), undefined, { sensitivity: 'base' }) * direction;
+    });
+};


### PR DESCRIPTION
### Motivation
- Prevent loading entire lists into the client by adding server-side pagination and small per-page controls for high-volume pages. 
- Provide a consistent, reusable pagination pattern (API + UI) that can be rolled out across other lists in later phases. 
- Preserve backward compatibility so existing callers that expect arrays continue to work unless `paginated=1` is requested.

### Description
- Added a shared API pagination helper `packages/api/helpers/pagination.js` with `parsePaginationQuery`, `paginatedResponse`, defaults (`pageSize=25`) and an upper bound (`MAX_PAGE_SIZE=100`).
- Implemented optional paginated responses in core list endpoints by honoring query params `page`, `pageSize` and `paginated=1` while keeping the original array responses when `paginated` is not set; endpoints updated include suppliers, customers (and customers/with-balances), employees, applications, goods receipts, inventory, parts, and AR endpoints (`/ar/customer-summary`, `/ar/customer-invoices/:customerId`, `/ar/drill-down-invoices`).
- Updated Meilisearch-backed routes (`/parts`, `/inventory`) to pass `limit`/`offset` to Meili when paginated and to include estimated totals when available.
- Added a reusable front-end component `PaginationControls` (`packages/web/src/components/ui/PaginationControls.jsx`) with rows-per-page options [10,25,50,100], previous/next, and range/total display.
- Wired paginated fetching + footer controls into these pages: Suppliers, Customers, Employees, Applications, Parts, Inventory, Goods Receipt History, and Accounts Receivable (customer summary and drill-down invoices). Default page size is 25 and UI resets page to 1 when filters/search change.

### Testing
- Ran lint: `npm run lint` (runs API eslint) completed successfully but returned existing warnings only. 
- Ran web lint: `npm run -w packages/web lint` completed successfully but returned existing warnings only. 
- Built the web app: `npm run -w packages/web build` completed successfully and produced the production bundle. 
- Ran unit tests: `npm test` failed in this environment because `jest` is not available (`sh: 1: jest: not found`), so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1e0fb0f68833296f3fb1d2ca2a999)