### PR TITLE
Normalize API responses to arrays and add empty-state / error handling for reports and parts list

### DIFF
--- a/packages/web/src/components/reports/InventoryMovementReport.jsx
+++ b/packages/web/src/components/reports/InventoryMovementReport.jsx
@@ -9,6 +9,8 @@ import { sortData } from '../../utils/sortData';
 import { format, parseISO } from 'date-fns';
 import { toZonedTime } from 'date-fns-tz';
 
+const asArray = (value) => (Array.isArray(value) ? value : []);
+
 const InventoryMovementReport = () => {
     const [reportData, setReportData] = useState([]);
     const [parts, setParts] = useState([]);
@@ -28,10 +30,10 @@ const InventoryMovementReport = () => {
     });
 
     useEffect(() => {
-        api.get('/parts?status=all').then(res => setParts(res.data));
+        api.get('/parts?status=all').then(res => setParts(asArray(res.data?.data ?? res.data)));
     }, []);
     
-    const partOptions = parts.map(p => ({ value: p.part_id, label: p.display_name }));
+    const partOptions = asArray(parts).map(p => ({ value: p.part_id, label: p.display_name }));
 
     const handleFilterChange = (name, value) => {
         setFilters(prev => ({ ...prev, [name]: value }));
@@ -57,7 +59,7 @@ const InventoryMovementReport = () => {
                 toast.success('Report exported successfully!');
             } else {
                 const paginated = getPaginatedPayload(response.data);
-                setReportData(paginated.data);
+                setReportData(asArray(paginated.data));
                 setTotal(paginated.total);
             }
         } catch {
@@ -128,6 +130,11 @@ const InventoryMovementReport = () => {
                                         <td className="p-3 text-sm">{row.employee_name}</td>
                                     </tr>
                                 ))}
+                                {sortedReportData.length === 0 && (
+                                    <tr>
+                                        <td colSpan="6" className="p-4 text-center text-gray-500">No data to display.</td>
+                                    </tr>
+                                )}
                             </tbody>
                     </table>
                 </div>

--- a/packages/web/src/components/reports/ProfitabilityReport.jsx
+++ b/packages/web/src/components/reports/ProfitabilityReport.jsx
@@ -10,6 +10,8 @@ import { sortData } from '../../utils/sortData';
 import { format } from 'date-fns';
 import { toZonedTime } from 'date-fns-tz';
 
+const asArray = (value) => (Array.isArray(value) ? value : []);
+
 const ProfitabilityReport = () => {
     const { settings } = useSettings();
     const [reportData, setReportData] = useState([]);
@@ -32,12 +34,12 @@ const ProfitabilityReport = () => {
     });
 
     useEffect(() => {
-        api.get('/brands').then(res => setBrands(res.data));
-        api.get('/groups').then(res => setGroups(res.data));
+        api.get('/brands').then(res => setBrands(asArray(res.data?.data ?? res.data)));
+        api.get('/groups').then(res => setGroups(asArray(res.data?.data ?? res.data)));
     }, []);
     
-    const brandOptions = brands.map(b => ({ value: b.brand_id, label: b.brand_name }));
-    const groupOptions = groups.map(g => ({ value: g.group_id, label: g.group_name }));
+    const brandOptions = asArray(brands).map(b => ({ value: b.brand_id, label: b.brand_name }));
+    const groupOptions = asArray(groups).map(g => ({ value: g.group_id, label: g.group_name }));
 
     const handleFilterChange = (name, value) => {
         setFilters(prev => ({ ...prev, [name]: value }));
@@ -63,7 +65,7 @@ const ProfitabilityReport = () => {
                 toast.success('Report exported successfully!');
             } else {
                 const paginated = getPaginatedPayload(response.data);
-                setReportData(paginated.data);
+                setReportData(asArray(paginated.data));
                 setTotal(paginated.total);
             }
         } catch {
@@ -140,6 +142,11 @@ const ProfitabilityReport = () => {
                                         <td className="p-3 text-sm text-right font-mono font-bold text-blue-600">{settings?.DEFAULT_CURRENCY_SYMBOL || '₱'}{parseFloat(row.total_profit).toFixed(2)}</td>
                                     </tr>
                                 ))}
+                                {sortedReportData.length === 0 && (
+                                    <tr>
+                                        <td colSpan="4" className="p-4 text-center text-gray-500">No data to display.</td>
+                                    </tr>
+                                )}
                             </tbody>
                     </table>
                 </div>

--- a/packages/web/src/components/reports/SalesByCustomerReport.jsx
+++ b/packages/web/src/components/reports/SalesByCustomerReport.jsx
@@ -10,6 +10,8 @@ import { sortData } from '../../utils/sortData';
 import { format } from 'date-fns';
 import { toZonedTime } from 'date-fns-tz';
 
+const asArray = (value) => (Array.isArray(value) ? value : []);
+
 const SalesByCustomerReport = () => {
     const { settings } = useSettings();
     const [reportData, setReportData] = useState([]);
@@ -30,10 +32,10 @@ const SalesByCustomerReport = () => {
     });
 
     useEffect(() => {
-        api.get('/customers').then(res => setCustomers(res.data));
+        api.get('/customers').then(res => setCustomers(asArray(res.data?.data ?? res.data)));
     }, []);
 
-    const customerOptions = customers.map(c => ({ value: c.customer_id, label: `${c.first_name} ${c.last_name}` }));
+    const customerOptions = asArray(customers).map(c => ({ value: c.customer_id, label: `${c.first_name} ${c.last_name}` }));
 
     const handleFilterChange = (name, value) => {
         setFilters(prev => ({ ...prev, [name]: value }));
@@ -59,7 +61,7 @@ const SalesByCustomerReport = () => {
                 toast.success('Report exported successfully!');
             } else {
                 const paginated = getPaginatedPayload(response.data);
-                setReportData(paginated.data);
+                setReportData(asArray(paginated.data));
                 setTotal(paginated.total);
             }
         } catch {
@@ -127,6 +129,11 @@ const SalesByCustomerReport = () => {
                                         <td className="p-3 text-sm text-right font-mono">{settings?.DEFAULT_CURRENCY_SYMBOL || '₱'}{parseFloat(row.total_sales).toFixed(2)}</td>
                                     </tr>
                                 ))}
+                                {sortedReportData.length === 0 && (
+                                    <tr>
+                                        <td colSpan="3" className="p-4 text-center text-gray-500">No data to display.</td>
+                                    </tr>
+                                )}
                             </tbody>
                     </table>
                 </div>

--- a/packages/web/src/pages/PartsPage.jsx
+++ b/packages/web/src/pages/PartsPage.jsx
@@ -16,12 +16,15 @@ import PartApplicationManager from './PartApplicationManager';
 import { formatApplicationText } from '../helpers/applicationTextHelper';
 import { sortData } from '../utils/sortData';
 
+const asArray = (value) => (Array.isArray(value) ? value : []);
+
 const PartsPage = ({ user, onNavigate }) => {
     const { hasPermission } = useAuth();
     const [parts, setParts] = useState([]);
     const [brands, setBrands] = useState([]);
     const [groups, setGroups] = useState([]);
     const [loading, setLoading] = useState(true);
+    const [listError, setListError] = useState('');
     const [isFormModalOpen, setIsFormModalOpen] = useState(false);
     const [isNumberModalOpen, setIsNumberModalOpen] = useState(false);
     const [isAppModalOpen, setIsAppModalOpen] = useState(false);
@@ -40,16 +43,20 @@ const PartsPage = ({ user, onNavigate }) => {
     const fetchInitialData = useCallback(async () => {
         try {
             setLoading(true);
+            setListError('');
             const [partsRes, brandsRes, groupsRes] = await Promise.all([
                 api.get('/parts', { params: { status: statusFilter, search: searchTerm, page, pageSize, paginated: 1, sortBy: globalSortBy, sortDirection: globalSortDirection } }),
                 api.get('/brands'),
                 api.get('/groups')
             ]);
-            setParts(partsRes.data?.data || []);
+            setParts(asArray(partsRes.data?.data));
             setTotal(partsRes.data?.total || 0);
-            setBrands(brandsRes.data);
-            setGroups(groupsRes.data);
+            setBrands(asArray(brandsRes.data?.data ?? brandsRes.data));
+            setGroups(asArray(groupsRes.data?.data ?? groupsRes.data));
         } catch (error) {
+            setParts([]);
+            setTotal(0);
+            setListError(error.response?.data?.message || 'Unable to load parts right now.');
             toast.error("Failed to load data: " + (error.response?.data?.message || error.message));
         } finally {
             setLoading(false);
@@ -265,6 +272,11 @@ const PartsPage = ({ user, onNavigate }) => {
             <div className="bg-white p-6 rounded-xl border border-gray-200">
                 {loading ? <p>Loading...</p> : (
                     <>
+                    {listError && (
+                        <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+                            {listError}
+                        </div>
+                    )}
                     <div className="overflow-x-auto">
                         <table className="w-full text-left">
                             <thead>
@@ -298,6 +310,11 @@ const PartsPage = ({ user, onNavigate }) => {
                                         </td>
                                     </tr>
                                 ))}
+                                {sortedParts.length === 0 && (
+                                    <tr>
+                                        <td colSpan="5" className="p-4 text-center text-gray-500">No data to display.</td>
+                                    </tr>
+                                )}
                             </tbody>
                         </table>
                     </div>


### PR DESCRIPTION
### Motivation
- Prevent runtime errors caused by inconsistent API payload shapes (sometimes an array, sometimes nested under `data`) when mapping response values. 
- Improve UX by showing a clear empty-state message when a report or parts list has no rows. 
- Surface loading failures on the parts list so users know when data couldn't be retrieved.

### Description
- Introduced a small `asArray` helper (`const asArray = (value) => (Array.isArray(value) ? value : []);`) in `InventoryMovementReport.jsx`, `ProfitabilityReport.jsx`, `SalesByCustomerReport.jsx`, and `PartsPage.jsx` and used it to normalize API responses (`res.data?.data ?? res.data`) before setting state. 
- Replaced direct mappings with `asArray(...)` when building option lists and when calling `setReportData` to ensure state is always an array. 
- Added empty-state table rows in the three report components and in `PartsPage.jsx` that render "No data to display." when the datasets are empty. 
- Added `listError` state to `PartsPage.jsx`, cleared at fetch start and populated on error, and render a visible error banner when loading the parts list fails; also clear `parts` and `total` on error to keep UI consistent.

### Testing
- Ran local linting with `npm run lint` and unit tests with `npm test`; both succeeded. 
- Manually exercised the reports and parts list flows locally to verify empty-state rows and the parts error banner render as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4ae669d7c83329ebadeab5cdbf28b)