### PR TITLE
Optimize dashboard data flow and standardize activity card layout

### DIFF
--- a/packages/api/routes/dashboardRoutes.js
+++ b/packages/api/routes/dashboardRoutes.js
@@ -152,11 +152,12 @@ router.get('/dashboard/stats', async (req, res) => {
 // GET /dashboard/sales-chart - Data for the last 30 days sales chart (now calculates NET sales)
 router.get('/dashboard/sales-chart', async (req, res) => {
     try {
-        const timeRange = req.query.days || 30;
+        const parsedDays = Number.parseInt(req.query.days, 10);
+        const timeRange = Number.isFinite(parsedDays) ? Math.min(Math.max(parsedDays, 7), 365) : 30;
         const query = `
             WITH all_days AS (
                 SELECT generate_series(
-                    CURRENT_DATE - INTERVAL '${parseInt(timeRange) - 1} days',
+                    CURRENT_DATE - (($1::int - 1) * INTERVAL '1 day'),
                     CURRENT_DATE,
                     '1 day'
                 )::date AS day
@@ -172,7 +173,7 @@ router.get('/dashboard/sales-chart', async (req, res) => {
             GROUP BY d.day
             ORDER BY d.day;
         `;
-        const { rows } = await db.query(query);
+        const { rows } = await db.query(query, [timeRange]);
         res.json(rows);
     } catch (err) {
         console.error(err.message);
@@ -194,11 +195,11 @@ router.get('/dashboard/enhanced-stats', async (req, res) => {
         ] = await Promise.all([
             // Today's revenue
             db.query(`
-                SELECT COALESCE(SUM(total_amount), 0) as today_revenue,
-                       COALESCE(SUM(CASE WHEN invoice_date >= CURRENT_DATE - INTERVAL '1 day' AND invoice_date < CURRENT_DATE THEN total_amount ELSE 0 END), 0) as yesterday_revenue
+                SELECT
+                    COALESCE(SUM(total_amount) FILTER (WHERE invoice_date::date = CURRENT_DATE), 0) as today_revenue,
+                    COALESCE(SUM(total_amount) FILTER (WHERE invoice_date::date = CURRENT_DATE - INTERVAL '1 day'), 0) as yesterday_revenue
                 FROM invoice 
-                WHERE invoice_date::date >= CURRENT_DATE - INTERVAL '1 day'
-                AND status IN ('Paid', 'Partially Paid')
+                WHERE status IN ('Paid', 'Partially Paid')
             `),
             
             // Outstanding A/R
@@ -222,14 +223,17 @@ router.get('/dashboard/enhanced-stats', async (req, res) => {
             
             // Low stock count
             db.query(`
+                WITH stock_totals AS (
+                    SELECT part_id, SUM(quantity) as quantity
+                    FROM inventory_transaction
+                    GROUP BY part_id
+                )
                 SELECT COUNT(*) as low_stock_count
                 FROM part p
+                LEFT JOIN stock_totals st ON st.part_id = p.part_id
                 WHERE p.low_stock_warning = TRUE 
-                AND (
-                    SELECT COALESCE(SUM(it.quantity), 0) 
-                    FROM inventory_transaction it 
-                    WHERE it.part_id = p.part_id
-                ) <= p.warning_quantity
+                AND COALESCE(st.quantity, 0) <= p.warning_quantity
+                AND p.is_active = TRUE
             `),
             
             // Recent sales (last 5)

--- a/packages/web/src/components/dashboard/EnhancedKPICard.jsx
+++ b/packages/web/src/components/dashboard/EnhancedKPICard.jsx
@@ -63,7 +63,8 @@ const EnhancedKPICard = ({
     urgent = false,
     loading = false,
     onClick,
-    subtitle
+    subtitle,
+    isMonetary = false
 }) => {
     const colors = colorVariants[color];
     
@@ -73,18 +74,27 @@ const EnhancedKPICard = ({
         bg-white p-6 rounded-xl border ${colors.accent} shadow-sm hover:shadow-md transition-shadow duration-200
     `;
 
+    const compactFormatter = new Intl.NumberFormat('en-US', {
+        notation: 'compact',
+        compactDisplay: 'short',
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 3
+    });
+
+    const decimalFormatter = new Intl.NumberFormat('en-US', {
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 3
+    });
+
     const formatValue = (val) => {
-        if (typeof val === 'number') {
-            if (val >= 1000000) {
-                return `₱${(val / 1000000).toFixed(1)}M`;
-            } else if (val >= 1000) {
-                return `₱${(val / 1000).toFixed(0)}K`;
-            } else if (val < 1000 && val > 0 && icon === 'currency') {
-                return `₱${val.toLocaleString()}`;
-            }
-            return val.toLocaleString();
-        }
-        return val;
+        if (typeof val !== 'number') return val;
+
+        const absoluteValue = Math.abs(val);
+        const formattedNumber = absoluteValue >= 1000
+            ? compactFormatter.format(val)
+            : decimalFormatter.format(val);
+
+        return isMonetary ? `₱${formattedNumber}` : formattedNumber;
     };
 
     return (

--- a/packages/web/src/components/dashboard/RecentActivityFeed.jsx
+++ b/packages/web/src/components/dashboard/RecentActivityFeed.jsx
@@ -23,7 +23,7 @@ export const RecentSalesPanel = ({ data = [], loading = false, onViewAll }) => {
     const { hasPermission } = useAuth();
     
     return (
-        <div className="bg-white p-6 rounded-xl border border-gray-200">
+        <div className="bg-white p-6 rounded-xl border border-gray-200 h-[420px] flex flex-col">
             <div className="flex justify-between items-center mb-4">
                 <div className="flex items-center space-x-2">
                     <FileText className="h-5 w-5 text-gray-600" />
@@ -41,7 +41,7 @@ export const RecentSalesPanel = ({ data = [], loading = false, onViewAll }) => {
             </div>
             
             {loading ? (
-                <div className="space-y-3">
+                <div className="space-y-3 overflow-y-auto pr-1 flex-1">
                     {[...Array(5)].map((_, i) => (
                         <div key={i} className="animate-pulse flex justify-between items-center p-3 bg-gray-50 rounded-lg">
                             <div className="flex-1">
@@ -56,12 +56,12 @@ export const RecentSalesPanel = ({ data = [], loading = false, onViewAll }) => {
                     ))}
                 </div>
             ) : data.length === 0 ? (
-                <div className="text-center py-8 text-gray-500">
+                <div className="text-center py-8 text-gray-500 flex-1 flex flex-col justify-center">
                     <FileText className="h-12 w-12 mx-auto mb-3 text-gray-300" />
                     <p>No recent sales found</p>
                 </div>
             ) : (
-                <div className="space-y-3">
+                <div className="space-y-3 overflow-y-auto pr-1 flex-1">
                     {data.map((sale, index) => (
                         <div key={sale.invoice_number || index} 
                              className="flex justify-between items-center p-3 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors cursor-pointer">
@@ -91,7 +91,7 @@ export const LowStockAlertsPanel = ({ data = [], loading = false, onManageStock 
     const { hasPermission } = useAuth();
     
     return (
-        <div className="bg-white p-6 rounded-xl border border-gray-200">
+        <div className="bg-white p-6 rounded-xl border border-gray-200 h-[420px] flex flex-col">
             <div className="flex justify-between items-center mb-4">
                 <div className="flex items-center space-x-2">
                     <AlertTriangle className="h-5 w-5 text-orange-600" />
@@ -109,7 +109,7 @@ export const LowStockAlertsPanel = ({ data = [], loading = false, onManageStock 
             </div>
             
             {loading ? (
-                <div className="space-y-3">
+                <div className="space-y-3 overflow-y-auto pr-1 flex-1">
                     {[...Array(5)].map((_, i) => (
                         <div key={i} className="animate-pulse flex justify-between items-center p-3 bg-orange-50 rounded-lg">
                             <div className="flex-1">
@@ -124,13 +124,13 @@ export const LowStockAlertsPanel = ({ data = [], loading = false, onManageStock 
                     ))}
                 </div>
             ) : data.length === 0 ? (
-                <div className="text-center py-8 text-gray-500">
+                <div className="text-center py-8 text-gray-500 flex-1 flex flex-col justify-center">
                     <Package className="h-12 w-12 mx-auto mb-3 text-green-300" />
                     <p>All stock levels are healthy</p>
                     <p className="text-sm text-gray-400 mt-1">No low stock alerts</p>
                 </div>
             ) : (
-                <div className="space-y-3">
+                <div className="space-y-3 overflow-y-auto pr-1 flex-1">
                     {data.map((item, index) => (
                         <div key={item.part_id || index} 
                              className="flex justify-between items-center p-3 bg-orange-50 rounded-lg border-l-4 border-orange-400 hover:bg-orange-100 transition-colors cursor-pointer">

--- a/packages/web/src/pages/Dashboard.jsx
+++ b/packages/web/src/pages/Dashboard.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import api from '../api';
 import { RefreshCw, Activity } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
@@ -10,6 +10,7 @@ import { RecentActivityFeed } from '../components/dashboard/RecentActivityFeed';
 const Dashboard = ({ onNavigate }) => {
     const { hasPermission } = useAuth();
     const [loading, setLoading] = useState(true);
+    const [refreshing, setRefreshing] = useState(false);
     const [autoRefresh, setAutoRefresh] = useState(false);
     const [lastUpdated, setLastUpdated] = useState(new Date());
     const [error, setError] = useState('');
@@ -28,10 +29,15 @@ const Dashboard = ({ onNavigate }) => {
     });
     const [chartData, setChartData] = useState([]);
     const [lowStockItems, setLowStockItems] = useState([]);
+    const hasLoadedRef = useRef(false);
 
-    const fetchDashboardData = useCallback(async () => {
+    const fetchDashboardData = useCallback(async ({ silent = false } = {}) => {
         try {
-            setLoading(true);
+            if (silent) {
+                setRefreshing(true);
+            } else {
+                setLoading(true);
+            }
             setError('');
             
             const [enhancedRes, chartRes, lowStockRes] = await Promise.all([
@@ -48,12 +54,17 @@ const Dashboard = ({ onNavigate }) => {
             setError('Failed to load dashboard data.');
             console.error('Dashboard data fetch error:', err);
         } finally {
-            setLoading(false);
+            if (silent) {
+                setRefreshing(false);
+            } else {
+                setLoading(false);
+            }
         }
     }, [timeRange]);
 
     useEffect(() => {
-        fetchDashboardData();
+        fetchDashboardData({ silent: hasLoadedRef.current });
+        hasLoadedRef.current = true;
     }, [fetchDashboardData]);
 
     // Auto-refresh functionality
@@ -61,7 +72,7 @@ const Dashboard = ({ onNavigate }) => {
         let interval;
         if (autoRefresh) {
             interval = setInterval(() => {
-                fetchDashboardData();
+                fetchDashboardData({ silent: true });
             }, 30000); // Refresh every 30 seconds
         }
         return () => {
@@ -76,7 +87,7 @@ const Dashboard = ({ onNavigate }) => {
     };
 
     const handleRefresh = () => {
-        fetchDashboardData();
+        fetchDashboardData({ silent: true });
     };
 
     const formatLastUpdated = () => {
@@ -130,11 +141,11 @@ const Dashboard = ({ onNavigate }) => {
                         
                         <button
                             onClick={handleRefresh}
-                            disabled={loading}
+                            disabled={loading || refreshing}
                             className="flex items-center space-x-2 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 text-white px-4 py-2 rounded-lg transition-colors"
                         >
-                            <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
-                            <span>Refresh</span>
+                            <RefreshCw className={`h-4 w-4 ${(loading || refreshing) ? 'animate-spin' : ''}`} />
+                            <span>{refreshing ? 'Refreshing...' : 'Refresh'}</span>
                         </button>
                     </div>
                 </div>

--- a/packages/web/src/pages/Dashboard.jsx
+++ b/packages/web/src/pages/Dashboard.jsx
@@ -162,6 +162,7 @@ const Dashboard = ({ onNavigate }) => {
                             color="green"
                             loading={loading}
                             onClick={() => handleNavigation('sales_history')}
+                            isMonetary
                         />
                     )}
                     {hasPermission('ar:view') && (
@@ -173,6 +174,7 @@ const Dashboard = ({ onNavigate }) => {
                             loading={loading}
                             onClick={() => handleNavigation('ar')}
                             subtitle="Unpaid invoices"
+                            isMonetary
                         />
                     )}
                     {hasPermission('inventory:view') && (
@@ -184,6 +186,7 @@ const Dashboard = ({ onNavigate }) => {
                             loading={loading}
                             onClick={() => handleNavigation('inventory')}
                             subtitle="Total stock value"
+                            isMonetary
                         />
                     )}
                     {hasPermission('inventory:view') && (


### PR DESCRIPTION
### Motivation
- Ensure dashboard cards keep consistent size and avoid pushing layout when lists grow by making activity panels scroll internally.
- Improve perceived performance by avoiding full-skeleton reloads on manual/auto/time-range refreshes and instead perform silent refreshes that preserve displayed data.
- Harden dashboard API inputs and queries to prevent SQL injection/poor performance and to make KPI calculations more correct and efficient.

### Description
- UI: Standardized `Recent Sales` and `Stock Alerts` cards to a fixed height and moved their list areas into internal scroll containers, centering empty/loading states; changes in `packages/web/src/components/dashboard/RecentActivityFeed.jsx`.
- UX: Split initial load vs silent refresh in the dashboard loader and added a `refreshing` state so `fetchDashboardData` can be called with `{ silent: true }`; changes in `packages/web/src/pages/Dashboard.jsx` (added `refreshing`, `hasLoadedRef`, and adjusted auto-refresh/manual refresh behavior).
- API: Parameterized and clamped the `days` input for `/dashboard/sales-chart` to use a safe bound and a positional SQL parameter instead of string interpolation, avoiding extreme ranges and unsafe SQL; changes in `packages/api/routes/dashboardRoutes.js`.
- API: Fixed `today_revenue` vs `yesterday_revenue` calculation to use date-filtered aggregates and replaced the correlated low-stock subquery with a pre-aggregated CTE join plus `is_active` filtering for the low-stock count query in `packages/api/routes/dashboardRoutes.js`.

### Testing
- Ran `npm run lint` which completed successfully in the workspace (API lint run as part of that command succeeded with unrelated warnings). 
- Ran `npm run -w packages/api lint` which completed successfully with only lint warnings unrelated to these changes. 
- Ran `npm run -w packages/web lint` which completed successfully (the workspace has pre-existing warnings in unrelated files that did not block the run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4cdf4a78883329248af6f0fdff2c5)