### PR TITLE
Fix brittle cheque PDF header assertion in API tests

### DIFF
--- a/packages/api/tests/chequePdf.test.js
+++ b/packages/api/tests/chequePdf.test.js
@@ -15,7 +15,7 @@ describe('createChequePdf', () => {
 
         expect(Buffer.isBuffer(pdf)).toBe(true);
         expect(pdf.length).toBeGreaterThan(100);
-        expect(pdf.toString('utf8', 0, 8)).toContain('%PDF-1.4');
+        expect(pdf.toString('utf8', 0, 8)).toMatch(/^%PDF-1\.[0-9]/);
         expect(['pdf-lib', 'fallback']).toContain(result.renderer);
     });
 


### PR DESCRIPTION
### Motivation
- The cheque PDF test asserted an exact header `%PDF-1.4` which caused CI failures when `pdf-lib` emitted other valid PDF versions such as `%PDF-1.7`.

### Description
- Relaxed the header assertion in `packages/api/tests/chequePdf.test.js` to `toMatch(/^%PDF-1\.[0-9]/)` so any valid PDF `1.x` header is accepted.

### Testing
- Reproduced the failing CI output and updated the test, then attempted to run `npm test` in `packages/api` but the run failed locally because `jest` is not available in the environment (`sh: 1: jest: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5816415408332a221abff390c7d15)