### PR TITLE
Add paper and text settings to cheque templates and update PDF rendering & amount-to-words

### DIFF
--- a/database/migrations/20260420_add_paper_settings_to_cheque_templates.sql
+++ b/database/migrations/20260420_add_paper_settings_to_cheque_templates.sql
@@ -1,0 +1,44 @@
+ALTER TABLE cheque_templates
+ADD COLUMN IF NOT EXISTS paper_settings JSONB NOT NULL DEFAULT '{"widthIn": 8, "heightIn": 3, "unit": "in"}'::jsonb;
+
+UPDATE cheque_templates
+SET
+    date_format = 'MM-dd-yyyy',
+    paper_settings = COALESCE(paper_settings, '{"widthIn": 8, "heightIn": 3, "unit": "in"}'::jsonb),
+    currency_settings = CASE
+        WHEN currency_settings ? 'label'
+            THEN jsonb_set(currency_settings, '{label}', '"₱"', true)
+        ELSE currency_settings || '{"label":"₱"}'::jsonb
+    END,
+    field_positions = jsonb_set(
+        jsonb_set(
+            jsonb_set(
+                jsonb_set(
+                    jsonb_set(
+                        jsonb_set(
+                            COALESCE(field_positions, '{}'::jsonb),
+                            '{date}',
+                            '{"x":426,"y":178,"alignment":"left","fontSize":11,"mode":"boxed","charSpacing":14}'::jsonb,
+                            true
+                        ),
+                        '{payee}',
+                        '{"x":72,"y":136,"alignment":"left","fontSize":12,"maxWidth":380,"minFontSize":8}'::jsonb,
+                        true
+                    ),
+                    '{amountNumeric}',
+                    '{"x":534,"y":136,"alignment":"right","fontSize":12}'::jsonb,
+                    true
+                ),
+                '{amountWords}',
+                '{"x":72,"y":104,"alignment":"left","fontSize":11,"maxWidth":420}'::jsonb,
+                true
+            ),
+            '{memo}',
+            '{"x":72,"y":84,"alignment":"left","fontSize":10,"maxWidth":220}'::jsonb,
+            true
+        ),
+        '{currency}',
+        '{"x":474,"y":136,"alignment":"left","fontSize":11}'::jsonb,
+        true
+    )
+WHERE is_deleted = FALSE;

--- a/database/migrations/20260420_add_text_settings_to_cheque_templates.sql
+++ b/database/migrations/20260420_add_text_settings_to_cheque_templates.sql
@@ -1,0 +1,6 @@
+ALTER TABLE cheque_templates
+ADD COLUMN IF NOT EXISTS text_settings JSONB NOT NULL DEFAULT '{"amountSuffix": "pesos", "payeeFiller": "", "amountWordsFiller": ""}'::jsonb;
+
+UPDATE cheque_templates
+SET text_settings = COALESCE(text_settings, '{"amountSuffix": "pesos", "payeeFiller": "", "amountWordsFiller": ""}'::jsonb)
+WHERE is_deleted = FALSE;

--- a/packages/api/helpers/chequeAmountWords.js
+++ b/packages/api/helpers/chequeAmountWords.js
@@ -23,17 +23,19 @@ function chunkToWords(value) {
     return out.join(' ').trim();
 }
 
-function amountToWords(amount) {
+function amountToWords(amount, options = {}) {
     const numericAmount = Number(amount);
     if (Number.isNaN(numericAmount) || numericAmount < 0) {
         throw new Error('Amount must be a non-negative number');
     }
+    const suffix = String(options.suffix || 'pesos').trim();
 
     const rounded = Math.round(numericAmount * 100) / 100;
     const whole = Math.floor(rounded);
     const cents = Math.round((rounded - whole) * 100);
 
-    if (whole === 0) return `zero and ${String(cents).padStart(2, '0')}/100`;
+    if (whole === 0 && cents === 0) return suffix ? `zero ${suffix}` : 'zero';
+    if (whole === 0) return suffix ? `zero ${suffix} and ${String(cents).padStart(2, '0')}/100` : `zero and ${String(cents).padStart(2, '0')}/100`;
 
     const parts = [];
     const billions = Math.floor(whole / 1_000_000_000);
@@ -46,7 +48,9 @@ function amountToWords(amount) {
     if (thousands) parts.push(`${chunkToWords(thousands)} thousand`);
     if (remainder) parts.push(chunkToWords(remainder));
 
-    return `${parts.join(' ')} and ${String(cents).padStart(2, '0')}/100`.trim();
+    const base = suffix ? `${parts.join(' ')} ${suffix}`.trim() : parts.join(' ');
+    if (cents === 0) return base;
+    return `${base} and ${String(cents).padStart(2, '0')}/100`.trim();
 }
 
 module.exports = { amountToWords };

--- a/packages/api/helpers/pdf/chequePdf.js
+++ b/packages/api/helpers/pdf/chequePdf.js
@@ -8,7 +8,15 @@ try {
     StandardFonts = null;
 }
 
-const LETTER = { width: 612, height: 792 };
+const DEFAULT_PAPER = { width: 576, height: 216 }; // 8in x 3in @ 72 DPI
+
+function resolvePaperSize(paperSettings = {}) {
+    const widthIn = Number(paperSettings.widthIn);
+    const heightIn = Number(paperSettings.heightIn);
+    const width = Number.isFinite(widthIn) && widthIn > 0 ? widthIn * 72 : DEFAULT_PAPER.width;
+    const height = Number.isFinite(heightIn) && heightIn > 0 ? heightIn * 72 : DEFAULT_PAPER.height;
+    return { width, height };
+}
 
 function resolveAlignedX({
     text,
@@ -44,10 +52,18 @@ function fitFontSize({
 
 function createFallbackPdf({ rows, template, xOffset, yOffset, testPrint }) {
     const positions = template?.field_positions || {};
-    const currencySettings = template?.currency_settings || { enabled: true, label: 'USD' };
+    const currencySettings = template?.currency_settings || { enabled: true, label: '₱' };
+    const paperSize = resolvePaperSize(template?.paper_settings);
+    const textSettings = template?.text_settings || {};
+    const amountSuffix = String(textSettings.amountSuffix || 'pesos').trim();
+    const payeeFiller = String(textSettings.payeeFiller || '').trim();
+    const amountWordsFiller = String(textSettings.amountWordsFiller || '').trim();
+    const applyFiller = (text, filler) => (filler ? `${filler} ${text} ${filler}`.trim() : text);
     const pages = rows.map((row) => {
-        const amountWords = amountToWords(row.amount);
+        const amountWords = amountToWords(row.amount, { suffix: amountSuffix });
         const words = template?.amount_format === 'upper' ? amountWords.toUpperCase() : amountWords;
+        const renderedPayee = applyFiller(row.payee, payeeFiller);
+        const renderedWords = applyFiller(words, amountWordsFiller);
         const drawText = (text, cfg, fallback) => {
             const x = Number(cfg?.x ?? fallback.x) + xOffset;
             const y = Number(cfg?.y ?? fallback.y) + yOffset;
@@ -56,16 +72,16 @@ function createFallbackPdf({ rows, template, xOffset, yOffset, testPrint }) {
             return `BT /F1 ${size} Tf ${x} ${y} Td (${escapedText}) Tj ET`;
         };
         const lines = [
-            drawText(row.date, positions.date, { x: 430, y: 700, fontSize: 11 }),
-            drawText(row.payee, positions.payee, { x: 90, y: 655, fontSize: 12 }),
-            drawText(row.amount, positions.amountNumeric, { x: 490, y: 655, fontSize: 12 }),
-            drawText(words, positions.amountWords, { x: 90, y: 625, fontSize: 11 })
+            drawText(row.date, positions.date, { x: 426, y: 178, fontSize: 11 }),
+            drawText(renderedPayee, positions.payee, { x: 72, y: 136, fontSize: 12 }),
+            drawText(row.amount, positions.amountNumeric, { x: 534, y: 136, fontSize: 12 }),
+            drawText(renderedWords, positions.amountWords, { x: 72, y: 104, fontSize: 11 })
         ];
         if (currencySettings.enabled !== false) {
-            lines.push(drawText(currencySettings.label || 'USD', positions.currency, { x: 515, y: 655, fontSize: 11 }));
+            lines.push(drawText(currencySettings.label || '₱', positions.currency, { x: 474, y: 136, fontSize: 11 }));
         }
         if (testPrint) {
-            lines.push(drawText('*** TEST PRINT ***', { x: 220, y: 760, fontSize: 11 }, { x: 220, y: 760, fontSize: 11 }));
+            lines.push(drawText('*** TEST PRINT ***', { x: 220, y: 198, fontSize: 11 }, { x: 220, y: 198, fontSize: 11 }));
         }
         return lines;
     });
@@ -81,7 +97,7 @@ function createFallbackPdf({ rows, template, xOffset, yOffset, testPrint }) {
     for (const lines of pages) {
         const stream = lines.join('\n');
         const contentId = addObject(`<< /Length ${Buffer.byteLength(stream, 'utf8')} >>\nstream\n${stream}\nendstream`);
-        const pageId = addObject(`<< /Type /Page /Parent 2 0 R /MediaBox [0 0 ${LETTER.width} ${LETTER.height}] /Resources << /Font << /F1 3 0 R >> >> /Contents ${contentId} 0 R >>`);
+        const pageId = addObject(`<< /Type /Page /Parent 2 0 R /MediaBox [0 0 ${paperSize.width} ${paperSize.height}] /Resources << /Font << /F1 3 0 R >> >> /Contents ${contentId} 0 R >>`);
         pageIds.push(pageId);
     }
     objects.unshift({ id: 3, body: '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>' });
@@ -109,9 +125,15 @@ async function createChequePdf({ rows, template, printerProfile = { offset_x: 0,
     }
 
     const positions = template?.field_positions || {};
-    const currencySettings = template?.currency_settings || { enabled: true, label: 'USD' };
+    const currencySettings = template?.currency_settings || { enabled: true, label: '₱' };
     const xOffset = Number(printerProfile.offset_x || 0);
     const yOffset = Number(printerProfile.offset_y || 0);
+    const paperSize = resolvePaperSize(template?.paper_settings);
+    const textSettings = template?.text_settings || {};
+    const amountSuffix = String(textSettings.amountSuffix || 'pesos').trim();
+    const payeeFiller = String(textSettings.payeeFiller || '').trim();
+    const amountWordsFiller = String(textSettings.amountWordsFiller || '').trim();
+    const applyFiller = (text, filler) => (filler ? `${filler} ${text} ${filler}`.trim() : text);
 
     if (!PDFDocument || !StandardFonts) {
         return {
@@ -126,9 +148,11 @@ async function createChequePdf({ rows, template, printerProfile = { offset_x: 0,
         const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
 
         rows.forEach((row) => {
-            const page = pdfDoc.addPage([LETTER.width, LETTER.height]);
-            const amountWords = amountToWords(row.amount);
+            const page = pdfDoc.addPage([paperSize.width, paperSize.height]);
+            const amountWords = amountToWords(row.amount, { suffix: amountSuffix });
             const words = template?.amount_format === 'upper' ? amountWords.toUpperCase() : amountWords;
+            const renderedPayee = applyFiller(row.payee, payeeFiller);
+            const renderedWords = applyFiller(words, amountWordsFiller);
 
         const drawText = (text, cfg, fallback) => {
             const baseX = Number(cfg?.x ?? fallback.x) + xOffset;
@@ -156,7 +180,7 @@ async function createChequePdf({ rows, template, printerProfile = { offset_x: 0,
         };
 
         const drawBoxedDate = (text, cfg, fallback) => {
-            const content = String(text || '');
+            const content = String(text || '').replace(/[^0-9]/g, '');
             const x = Number(cfg?.x ?? fallback.x) + xOffset;
             const y = Number(cfg?.y ?? fallback.y) + yOffset;
             const size = Number(cfg?.fontSize ?? fallback.fontSize);
@@ -168,19 +192,19 @@ async function createChequePdf({ rows, template, printerProfile = { offset_x: 0,
 
         const dateCfg = positions.date || {};
         if (dateCfg.mode === 'boxed') {
-            drawBoxedDate(row.date, dateCfg, { x: 430, y: 700, fontSize: 11, charSpacing: 14 });
+            drawBoxedDate(row.date, dateCfg, { x: 426, y: 178, fontSize: 11, charSpacing: 14 });
         } else {
-            drawText(row.date, dateCfg, { x: 430, y: 700, fontSize: 11, alignment: 'left', charSpacing: 0 });
+            drawText(row.date, dateCfg, { x: 426, y: 178, fontSize: 11, alignment: 'left', charSpacing: 0 });
         }
-        drawText(row.payee, positions.payee, { x: 90, y: 655, fontSize: 12, alignment: 'left', maxWidth: 380, minFontSize: 8 });
-        drawText(row.amount, positions.amountNumeric, { x: 490, y: 655, fontSize: 12, alignment: 'right' });
-        drawText(words, positions.amountWords, { x: 90, y: 625, fontSize: 11, alignment: 'left', maxWidth: 420, minFontSize: 8 });
+        drawText(renderedPayee, positions.payee, { x: 72, y: 136, fontSize: 12, alignment: 'left', maxWidth: 380, minFontSize: 8 });
+        drawText(row.amount, positions.amountNumeric, { x: 534, y: 136, fontSize: 12, alignment: 'right' });
+        drawText(renderedWords, positions.amountWords, { x: 72, y: 104, fontSize: 11, alignment: 'left', maxWidth: 420, minFontSize: 8 });
 
         if (currencySettings.enabled !== false) {
-            drawText(currencySettings.label || 'USD', positions.currency, { x: 515, y: 655, fontSize: 11, alignment: 'left' });
+            drawText(currencySettings.label || '₱', positions.currency, { x: 474, y: 136, fontSize: 11, alignment: 'left' });
         }
         if (testPrint) {
-            page.drawText('*** TEST PRINT ***', { x: 220, y: 760, size: 11, font });
+            page.drawText('*** TEST PRINT ***', { x: 220, y: 198, size: 11, font });
         }
         });
 

--- a/packages/api/routes/chequeRoutes.js
+++ b/packages/api/routes/chequeRoutes.js
@@ -9,14 +9,16 @@ function isValidDateByFormat(value, format) {
     const input = String(value || '').trim();
     if (!input) return false;
 
-    if (format === 'MM/dd/yyyy' || format === 'dd/MM/yyyy') {
-        const match = input.match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
+    if (format === 'MM/dd/yyyy' || format === 'dd/MM/yyyy' || format === 'MM-dd-yyyy') {
+        const separator = format.includes('-') ? '-' : '/';
+        const pattern = separator === '-' ? /^(\d{2})-(\d{2})-(\d{4})$/ : /^(\d{2})\/(\d{2})\/(\d{4})$/;
+        const match = input.match(pattern);
         if (!match) return false;
         const left = Number(match[1]);
         const right = Number(match[2]);
         const year = Number(match[3]);
-        const month = format === 'MM/dd/yyyy' ? left : right;
-        const day = format === 'MM/dd/yyyy' ? right : left;
+        const month = format === 'dd/MM/yyyy' ? right : left;
+        const day = format === 'dd/MM/yyyy' ? left : right;
         const date = new Date(year, month - 1, day);
         return date.getFullYear() === year && date.getMonth() === month - 1 && date.getDate() === day;
     }
@@ -41,18 +43,21 @@ function toFileSafeSegment(value, fallback = 'cheques') {
 }
 
 const DEFAULT_TEMPLATE = {
-    date: { x: 430, y: 700, alignment: 'left', fontSize: 11 },
-    payee: { x: 90, y: 655, alignment: 'left', fontSize: 12, maxWidth: 380, minFontSize: 8 },
-    amountNumeric: { x: 490, y: 655, alignment: 'right', fontSize: 12 },
-    amountWords: { x: 90, y: 625, alignment: 'left', fontSize: 11, maxWidth: 420 },
-    memo: { x: 90, y: 585, alignment: 'left', fontSize: 10, maxWidth: 220 },
-    currency: { x: 515, y: 655, alignment: 'left', fontSize: 11 }
+    date: { x: 426, y: 178, alignment: 'left', fontSize: 11, mode: 'boxed', charSpacing: 14 },
+    payee: { x: 72, y: 136, alignment: 'left', fontSize: 12, maxWidth: 380, minFontSize: 8 },
+    amountNumeric: { x: 534, y: 136, alignment: 'right', fontSize: 12 },
+    amountWords: { x: 72, y: 104, alignment: 'left', fontSize: 11, maxWidth: 420 },
+    memo: { x: 72, y: 84, alignment: 'left', fontSize: 10, maxWidth: 220 },
+    currency: { x: 474, y: 136, alignment: 'left', fontSize: 11 }
 };
+
+const DEFAULT_PAPER_SETTINGS = { widthIn: 8, heightIn: 3, unit: 'in' };
+const DEFAULT_TEXT_SETTINGS = { amountSuffix: 'pesos', payeeFiller: '', amountWordsFiller: '' };
 
 router.get('/cheques/templates', protect, async (_req, res) => {
     try {
         const { rows } = await db.query(
-            `SELECT id, bank_name, field_positions, date_format, amount_format, currency_settings, created_at, updated_at
+            `SELECT id, bank_name, field_positions, date_format, amount_format, currency_settings, paper_settings, text_settings, created_at, updated_at
              FROM cheque_templates
              WHERE is_deleted = FALSE
              ORDER BY bank_name ASC`
@@ -68,9 +73,11 @@ router.post('/cheques/templates', protect, async (req, res) => {
     const {
         bank_name,
         field_positions = DEFAULT_TEMPLATE,
-        date_format = 'MM/dd/yyyy',
+        date_format = 'MM-dd-yyyy',
         amount_format = 'title_case',
-        currency_settings = { enabled: true, label: 'USD' }
+        currency_settings = { enabled: true, label: '₱' },
+        paper_settings = DEFAULT_PAPER_SETTINGS,
+        text_settings = DEFAULT_TEXT_SETTINGS
     } = req.body;
 
     if (!bank_name || !String(bank_name).trim()) {
@@ -79,10 +86,10 @@ router.post('/cheques/templates', protect, async (req, res) => {
 
     try {
         const { rows } = await db.query(
-            `INSERT INTO cheque_templates (bank_name, field_positions, date_format, amount_format, currency_settings)
-             VALUES ($1, $2::jsonb, $3, $4, $5::jsonb)
-             RETURNING id, bank_name, field_positions, date_format, amount_format, currency_settings, created_at, updated_at`,
-            [bank_name.trim(), JSON.stringify(field_positions), date_format, amount_format, JSON.stringify(currency_settings)]
+            `INSERT INTO cheque_templates (bank_name, field_positions, date_format, amount_format, currency_settings, paper_settings, text_settings)
+             VALUES ($1, $2::jsonb, $3, $4, $5::jsonb, $6::jsonb, $7::jsonb)
+             RETURNING id, bank_name, field_positions, date_format, amount_format, currency_settings, paper_settings, text_settings, created_at, updated_at`,
+            [bank_name.trim(), JSON.stringify(field_positions), date_format, amount_format, JSON.stringify(currency_settings), JSON.stringify(paper_settings), JSON.stringify(text_settings)]
         );
         res.status(201).json(rows[0]);
     } catch (error) {
@@ -93,7 +100,7 @@ router.post('/cheques/templates', protect, async (req, res) => {
 
 router.put('/cheques/templates/:id', protect, async (req, res) => {
     const { id } = req.params;
-    const { field_positions, date_format, amount_format, currency_settings, bank_name } = req.body;
+    const { field_positions, date_format, amount_format, currency_settings, bank_name, paper_settings, text_settings } = req.body;
 
     try {
         const { rows } = await db.query(
@@ -103,15 +110,19 @@ router.put('/cheques/templates/:id', protect, async (req, res) => {
                  date_format = COALESCE($3, date_format),
                  amount_format = COALESCE($4, amount_format),
                  currency_settings = COALESCE($5::jsonb, currency_settings),
+                 paper_settings = COALESCE($6::jsonb, paper_settings),
+                 text_settings = COALESCE($7::jsonb, text_settings),
                  updated_at = CURRENT_TIMESTAMP
-             WHERE id = $6 AND is_deleted = FALSE
-             RETURNING id, bank_name, field_positions, date_format, amount_format, currency_settings, created_at, updated_at`,
+             WHERE id = $8 AND is_deleted = FALSE
+             RETURNING id, bank_name, field_positions, date_format, amount_format, currency_settings, paper_settings, text_settings, created_at, updated_at`,
             [
                 bank_name ?? null,
                 field_positions ? JSON.stringify(field_positions) : null,
                 date_format ?? null,
                 amount_format ?? null,
                 currency_settings ? JSON.stringify(currency_settings) : null,
+                paper_settings ? JSON.stringify(paper_settings) : null,
+                text_settings ? JSON.stringify(text_settings) : null,
                 id
             ]
         );
@@ -244,7 +255,7 @@ router.post('/cheques/generate-pdf', protect, async (req, res) => {
 
     try {
         const templateRes = await db.query(
-            `SELECT id, bank_name, field_positions, date_format, amount_format, currency_settings
+            `SELECT id, bank_name, field_positions, date_format, amount_format, currency_settings, paper_settings, text_settings
              FROM cheque_templates
              WHERE id = $1 AND is_deleted = FALSE`,
             [template_id]
@@ -276,7 +287,7 @@ router.post('/cheques/generate-pdf', protect, async (req, res) => {
                 throw new Error('Amount must be numeric');
             }
             const dateValue = String(record.date || '');
-            const fmt = templateRes.rows[0].date_format || 'MM/dd/yyyy';
+            const fmt = templateRes.rows[0].date_format || 'MM-dd-yyyy';
             if (!isValidDateByFormat(dateValue, fmt)) {
                 throw new Error(`Date must follow ${fmt}`);
             }

--- a/packages/api/tests/chequeAmountWords.test.js
+++ b/packages/api/tests/chequeAmountWords.test.js
@@ -2,11 +2,19 @@ const { amountToWords } = require('../helpers/chequeAmountWords');
 
 describe('amountToWords', () => {
     it('formats whole and cent values', () => {
-        expect(amountToWords(1250.5)).toBe('one thousand two hundred fifty and 50/100');
+        expect(amountToWords(1250.5)).toBe('one thousand two hundred fifty pesos and 50/100');
     });
 
     it('handles zero whole amount', () => {
-        expect(amountToWords(0.75)).toBe('zero and 75/100');
+        expect(amountToWords(0.75)).toBe('zero pesos and 75/100');
+    });
+
+    it('omits decimal fraction when amount is whole', () => {
+        expect(amountToWords(500)).toBe('five hundred pesos');
+    });
+
+    it('supports custom suffix', () => {
+        expect(amountToWords(12.25, { suffix: 'dollars' })).toBe('twelve dollars and 25/100');
     });
 
     it('throws for negative numbers', () => {

--- a/packages/web/src/pages/ChequePrintingPage.jsx
+++ b/packages/web/src/pages/ChequePrintingPage.jsx
@@ -5,7 +5,16 @@ import api from '../api';
 
 const blankRow = () => ({ date: format(new Date(), 'yyyy-MM-dd'), payee: '', amount: '', memo: '' });
 
-const SETTINGS_TABS = ['layout', 'date', 'amount', 'currency', 'text', 'calibration'];
+const SETTINGS_TABS = ['layout', 'date', 'amount', 'currency', 'paper', 'text', 'calibration'];
+
+const FIELD_LABELS = {
+    date: 'Date',
+    payee: 'Payee',
+    amountNumeric: 'Amount in figures',
+    amountWords: 'Amount in words',
+    memo: 'Memo',
+    currency: 'Currency symbol'
+};
 
 const ChequePrintingPage = () => {
     const [templates, setTemplates] = useState([]);
@@ -92,9 +101,10 @@ const ChequePrintingPage = () => {
 
         setSaving(true);
         try {
+            const templateDateFormat = selectedTemplate.date_format || 'MM-dd-yyyy';
             const payloadRows = sourceRows.map((row) => ({
                 ...row,
-                date: format(parseISO(row.date), selectedTemplate.date_format || 'MM/dd/yyyy')
+                date: format(parseISO(row.date), templateDateFormat)
             }));
 
             const pdfResponse = await api.post('/cheques/generate-pdf', {
@@ -139,7 +149,6 @@ const ChequePrintingPage = () => {
 
     const handleReprint = async (entry) => {
         if (!selectedTemplate) return toast.error('Select a preset for reprint.');
-        const fmt = selectedTemplate.date_format || 'MM/dd/yyyy';
         await generatePdf([{
             payee: entry.payee,
             amount: Number(entry.amount).toFixed(2),
@@ -283,17 +292,29 @@ const ChequePrintingPage = () => {
                             ))}
                         </div>
                         <div className="p-4 max-h-[65vh] overflow-auto text-sm space-y-4">
-                            {activeTab === 'layout' && Object.entries(selectedTemplate.field_positions || {}).map(([field, cfg]) => (
-                                <div key={field} className="grid grid-cols-4 gap-2 items-center">
-                                    <span className="capitalize font-medium">{field}</span>
-                                    <input type="number" className="border rounded px-2 py-1" value={cfg.x ?? 0} onChange={(e) => updateTemplate({ field_positions: { ...selectedTemplate.field_positions, [field]: { ...cfg, x: Number(e.target.value) } } })} />
-                                    <input type="number" className="border rounded px-2 py-1" value={cfg.y ?? 0} onChange={(e) => updateTemplate({ field_positions: { ...selectedTemplate.field_positions, [field]: { ...cfg, y: Number(e.target.value) } } })} />
-                                    <input type="number" className="border rounded px-2 py-1" value={cfg.fontSize ?? 11} onChange={(e) => updateTemplate({ field_positions: { ...selectedTemplate.field_positions, [field]: { ...cfg, fontSize: Number(e.target.value) } } })} />
+                            {activeTab === 'layout' && (
+                                <div className="space-y-3">
+                                    <div className="grid grid-cols-4 gap-2 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                                        <span>Field</span>
+                                        <span>X Position</span>
+                                        <span>Y Position</span>
+                                        <span>Font Size</span>
+                                    </div>
+                                    {Object.entries(selectedTemplate.field_positions || {}).map(([field, cfg]) => (
+                                        <div key={field} className="grid grid-cols-4 gap-2 items-center">
+                                            <span className="font-medium">{FIELD_LABELS[field] || field}</span>
+                                            <input type="number" className="border rounded px-2 py-1" aria-label={`${field} X`} value={cfg.x ?? 0} onChange={(e) => updateTemplate({ field_positions: { ...selectedTemplate.field_positions, [field]: { ...cfg, x: Number(e.target.value) } } })} />
+                                            <input type="number" className="border rounded px-2 py-1" aria-label={`${field} Y`} value={cfg.y ?? 0} onChange={(e) => updateTemplate({ field_positions: { ...selectedTemplate.field_positions, [field]: { ...cfg, y: Number(e.target.value) } } })} />
+                                            <input type="number" className="border rounded px-2 py-1" aria-label={`${field} Font`} value={cfg.fontSize ?? 11} onChange={(e) => updateTemplate({ field_positions: { ...selectedTemplate.field_positions, [field]: { ...cfg, fontSize: Number(e.target.value) } } })} />
+                                        </div>
+                                    ))}
                                 </div>
-                            ))}
+                            )}
                             {activeTab === 'date' && (
                                 <div className="space-y-3">
-                                    <select className="border rounded px-3 py-2" value={selectedTemplate.date_format || 'MM/dd/yyyy'} onChange={(e) => updateTemplate({ date_format: e.target.value })}>
+                                    <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide">Date output format</label>
+                                    <select className="border rounded px-3 py-2" value={selectedTemplate.date_format || 'MM-dd-yyyy'} onChange={(e) => updateTemplate({ date_format: e.target.value })}>
+                                        <option value="MM-dd-yyyy">MM-DD-YYYY</option>
                                         <option value="MM/dd/yyyy">MM/dd/yyyy</option>
                                         <option value="dd/MM/yyyy">dd/MM/yyyy</option>
                                         <option value="MMM dd, yyyy">MMM dd, yyyy</option>
@@ -310,7 +331,7 @@ const ChequePrintingPage = () => {
                                             })}
                                         >
                                             <option value="single">Single-line date mode</option>
-                                            <option value="boxed">Boxed date mode</option>
+                                            <option value="boxed">Boxed date mode (MMDDYYYY without separators)</option>
                                         </select>
                                         <input
                                             type="number"
@@ -337,10 +358,90 @@ const ChequePrintingPage = () => {
                             {activeTab === 'currency' && (
                                 <div className="space-y-2">
                                     <label className="flex items-center gap-2"><input type="checkbox" checked={selectedTemplate.currency_settings?.enabled !== false} onChange={(e) => updateTemplate({ currency_settings: { ...selectedTemplate.currency_settings, enabled: e.target.checked } })} /> Show currency label</label>
+                                    <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide">Symbol outside amount box</label>
                                     <input className="border rounded px-3 py-2" value={selectedTemplate.currency_settings?.label || ''} onChange={(e) => updateTemplate({ currency_settings: { ...selectedTemplate.currency_settings, label: e.target.value } })} />
                                 </div>
                             )}
-                            {activeTab === 'text' && <p className="text-gray-600">Payee overflow mitigation uses template font size and width values; no line wrapping is applied.</p>}
+                            {activeTab === 'paper' && (
+                                <div className="space-y-3">
+                                    <p className="text-gray-600">Paper size is stored in the selected bank preset.</p>
+                                    <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+                                        <div>
+                                            <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">Width (inches)</label>
+                                            <input
+                                                type="number"
+                                                min="1"
+                                                step="0.1"
+                                                className="border rounded px-3 py-2 w-full"
+                                                value={selectedTemplate.paper_settings?.widthIn ?? 8}
+                                                onChange={(e) => updateTemplate({ paper_settings: { ...(selectedTemplate.paper_settings || {}), widthIn: Number(e.target.value) || 8, unit: 'in' } })}
+                                            />
+                                        </div>
+                                        <div>
+                                            <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">Height (inches)</label>
+                                            <input
+                                                type="number"
+                                                min="1"
+                                                step="0.1"
+                                                className="border rounded px-3 py-2 w-full"
+                                                value={selectedTemplate.paper_settings?.heightIn ?? 3}
+                                                onChange={(e) => updateTemplate({ paper_settings: { ...(selectedTemplate.paper_settings || {}), heightIn: Number(e.target.value) || 3, unit: 'in' } })}
+                                            />
+                                        </div>
+                                    </div>
+                                    <p className="text-xs text-gray-500">Recommended standardized size: 8" x 3".</p>
+                                </div>
+                            )}
+                            {activeTab === 'text' && (
+                                <div className="space-y-4">
+                                    <div className="space-y-2">
+                                        <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide">Amount suffix</label>
+                                        <input
+                                            className="border rounded px-3 py-2 w-full"
+                                            placeholder="pesos"
+                                            value={selectedTemplate.text_settings?.amountSuffix ?? 'pesos'}
+                                            onChange={(e) => updateTemplate({
+                                                text_settings: {
+                                                    ...(selectedTemplate.text_settings || {}),
+                                                    amountSuffix: e.target.value
+                                                }
+                                            })}
+                                        />
+                                        <p className="text-xs text-gray-500">Whole amounts print as "{'{amount}'} suffix". Decimal amounts print as "{'{amount}'} suffix and xx/100".</p>
+                                    </div>
+                                    <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                                        <div className="space-y-2">
+                                            <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide">Payee edge filler</label>
+                                            <input
+                                                className="border rounded px-3 py-2 w-full"
+                                                placeholder="*"
+                                                value={selectedTemplate.text_settings?.payeeFiller ?? ''}
+                                                onChange={(e) => updateTemplate({
+                                                    text_settings: {
+                                                        ...(selectedTemplate.text_settings || {}),
+                                                        payeeFiller: e.target.value
+                                                    }
+                                                })}
+                                            />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide">Amount words edge filler</label>
+                                            <input
+                                                className="border rounded px-3 py-2 w-full"
+                                                placeholder="*"
+                                                value={selectedTemplate.text_settings?.amountWordsFiller ?? ''}
+                                                onChange={(e) => updateTemplate({
+                                                    text_settings: {
+                                                        ...(selectedTemplate.text_settings || {}),
+                                                        amountWordsFiller: e.target.value
+                                                    }
+                                                })}
+                                            />
+                                        </div>
+                                    </div>
+                                    <p className="text-xs text-gray-500">Fillers are added at both ends of the rendered payee and amount-in-words text.</p>
+                                </div>
+                            )}
                             {activeTab === 'calibration' && (
                                 <div className="space-y-3">
                                     <div className="grid grid-cols-1 md:grid-cols-3 gap-2">


### PR DESCRIPTION
### Motivation
- Store per-template paper size and textual formatting options so cheque PDFs can be rendered for non-standard cheque paper and localized wording.
- Improve amount-in-words formatting to support a configurable suffix and to handle whole-zero/whole-only cases correctly.
- Standardize defaults to an 8"x3" cheque size and local currency symbol, and update field coordinates for the new layout.

### Description
- Add two DB migrations to add `paper_settings` and `text_settings` JSONB columns with defaults and update existing templates' `date_format`, `currency_settings` and `field_positions` coordinates.
- Extend `amountToWords` in `packages/api/helpers/chequeAmountWords.js` to accept `options.suffix`, omit cents when zero, and correctly render zero-only amounts with the suffix.
- Update PDF generation in `packages/api/helpers/pdf/chequePdf.js` to use `paper_settings` (via `resolvePaperSize`), apply `text_settings` (amount suffix and fillers), change default positions and currency symbol to `₱`, and sanitize boxed date input.
- Add `paper_settings` and `text_settings` handling to API routes in `packages/api/routes/chequeRoutes.js`, change default `date_format` to `MM-dd-yyyy`, and update the web UI in `packages/web/src/pages/ChequePrintingPage.jsx` to expose new "paper" and enhanced "text" settings and improved layout controls.
- Update unit tests in `packages/api/tests/chequeAmountWords.test.js` to cover suffix behavior, whole amounts, and zero handling.

### Testing
- Ran the API unit tests for the modified helper with `yarn test packages/api` and the `chequeAmountWords` tests passed. 
- Exercised PDF generation code paths (pdf-lib and fallback) locally against sample templates to verify page size, positions, currency label and boxed-date rendering (no automated failures observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e586aa3eec8332874d368ac9a8fe26)