### PR TITLE
Cheque: configurable amount suffix and customizable fillers; omit decimals for whole amounts

### DIFF
--- a/database/migrations/20260420_add_amount_word_and_text_settings_to_cheque_templates.sql
+++ b/database/migrations/20260420_add_amount_word_and_text_settings_to_cheque_templates.sql
@@ -1,0 +1,8 @@
+ALTER TABLE cheque_templates
+ADD COLUMN IF NOT EXISTS amount_words_settings JSONB NOT NULL DEFAULT '{"suffix":"pesos"}'::jsonb,
+ADD COLUMN IF NOT EXISTS text_settings JSONB NOT NULL DEFAULT '{"payeeFillerEnabled":false,"payeeFiller":"***","amountWordsFillerEnabled":false,"amountWordsFiller":"***"}'::jsonb;
+
+UPDATE cheque_templates
+SET amount_words_settings = COALESCE(amount_words_settings, '{"suffix":"pesos"}'::jsonb),
+    text_settings = COALESCE(text_settings, '{"payeeFillerEnabled":false,"payeeFiller":"***","amountWordsFillerEnabled":false,"amountWordsFiller":"***"}'::jsonb)
+WHERE amount_words_settings IS NULL OR text_settings IS NULL;

--- a/packages/api/helpers/chequeAmountWords.js
+++ b/packages/api/helpers/chequeAmountWords.js
@@ -23,7 +23,8 @@ function chunkToWords(value) {
     return out.join(' ').trim();
 }
 
-function amountToWords(amount) {
+function amountToWords(amount, options = {}) {
+    const suffix = String(options.suffix || 'pesos').trim() || 'pesos';
     const numericAmount = Number(amount);
     if (Number.isNaN(numericAmount) || numericAmount < 0) {
         throw new Error('Amount must be a non-negative number');
@@ -33,7 +34,10 @@ function amountToWords(amount) {
     const whole = Math.floor(rounded);
     const cents = Math.round((rounded - whole) * 100);
 
-    if (whole === 0) return `zero and ${String(cents).padStart(2, '0')}/100`;
+    if (whole === 0) {
+        if (cents === 0) return `zero ${suffix} only`;
+        return `zero ${suffix} and ${String(cents).padStart(2, '0')}/100`;
+    }
 
     const parts = [];
     const billions = Math.floor(whole / 1_000_000_000);
@@ -46,7 +50,11 @@ function amountToWords(amount) {
     if (thousands) parts.push(`${chunkToWords(thousands)} thousand`);
     if (remainder) parts.push(chunkToWords(remainder));
 
-    return `${parts.join(' ')} and ${String(cents).padStart(2, '0')}/100`.trim();
+    if (cents === 0) {
+        return `${parts.join(' ')} ${suffix} only`.trim();
+    }
+
+    return `${parts.join(' ')} ${suffix} and ${String(cents).padStart(2, '0')}/100`.trim();
 }
 
 module.exports = { amountToWords };

--- a/packages/api/helpers/pdf/chequePdf.js
+++ b/packages/api/helpers/pdf/chequePdf.js
@@ -10,6 +10,14 @@ try {
 
 const DEFAULT_PAPER = { width: 576, height: 216 }; // 8in x 3in @ 72 DPI
 
+function applyEndFiller(text, filler, enabled) {
+    const content = String(text || '').trim();
+    if (!enabled) return content;
+    const token = String(filler || '').trim();
+    if (!token || !content) return content;
+    return `${token} ${content} ${token}`;
+}
+
 function resolvePaperSize(paperSettings = {}) {
     const widthIn = Number(paperSettings.widthIn);
     const heightIn = Number(paperSettings.heightIn);
@@ -53,10 +61,14 @@ function fitFontSize({
 function createFallbackPdf({ rows, template, xOffset, yOffset, testPrint }) {
     const positions = template?.field_positions || {};
     const currencySettings = template?.currency_settings || { enabled: true, label: '₱' };
+    const amountWordsSettings = template?.amount_words_settings || { suffix: 'pesos' };
+    const textSettings = template?.text_settings || {};
     const paperSize = resolvePaperSize(template?.paper_settings);
     const pages = rows.map((row) => {
-        const amountWords = amountToWords(row.amount);
+        const amountWords = amountToWords(row.amount, { suffix: amountWordsSettings?.suffix || 'pesos' });
         const words = template?.amount_format === 'upper' ? amountWords.toUpperCase() : amountWords;
+        const amountWordsText = applyEndFiller(words, textSettings?.amountWordsFiller, textSettings?.amountWordsFillerEnabled);
+        const payeeText = applyEndFiller(row.payee, textSettings?.payeeFiller, textSettings?.payeeFillerEnabled);
         const drawText = (text, cfg, fallback) => {
             const x = Number(cfg?.x ?? fallback.x) + xOffset;
             const y = Number(cfg?.y ?? fallback.y) + yOffset;
@@ -66,9 +78,9 @@ function createFallbackPdf({ rows, template, xOffset, yOffset, testPrint }) {
         };
         const lines = [
             drawText(row.date, positions.date, { x: 426, y: 178, fontSize: 11 }),
-            drawText(row.payee, positions.payee, { x: 72, y: 136, fontSize: 12 }),
+            drawText(payeeText, positions.payee, { x: 72, y: 136, fontSize: 12 }),
             drawText(row.amount, positions.amountNumeric, { x: 534, y: 136, fontSize: 12 }),
-            drawText(words, positions.amountWords, { x: 72, y: 104, fontSize: 11 })
+            drawText(amountWordsText, positions.amountWords, { x: 72, y: 104, fontSize: 11 })
         ];
         if (currencySettings.enabled !== false) {
             lines.push(drawText(currencySettings.label || '₱', positions.currency, { x: 474, y: 136, fontSize: 11 }));
@@ -119,6 +131,8 @@ async function createChequePdf({ rows, template, printerProfile = { offset_x: 0,
 
     const positions = template?.field_positions || {};
     const currencySettings = template?.currency_settings || { enabled: true, label: '₱' };
+    const amountWordsSettings = template?.amount_words_settings || { suffix: 'pesos' };
+    const textSettings = template?.text_settings || {};
     const xOffset = Number(printerProfile.offset_x || 0);
     const yOffset = Number(printerProfile.offset_y || 0);
     const paperSize = resolvePaperSize(template?.paper_settings);
@@ -137,8 +151,10 @@ async function createChequePdf({ rows, template, printerProfile = { offset_x: 0,
 
         rows.forEach((row) => {
             const page = pdfDoc.addPage([paperSize.width, paperSize.height]);
-            const amountWords = amountToWords(row.amount);
+            const amountWords = amountToWords(row.amount, { suffix: amountWordsSettings?.suffix || 'pesos' });
             const words = template?.amount_format === 'upper' ? amountWords.toUpperCase() : amountWords;
+            const amountWordsText = applyEndFiller(words, textSettings?.amountWordsFiller, textSettings?.amountWordsFillerEnabled);
+            const payeeText = applyEndFiller(row.payee, textSettings?.payeeFiller, textSettings?.payeeFillerEnabled);
 
         const drawText = (text, cfg, fallback) => {
             const baseX = Number(cfg?.x ?? fallback.x) + xOffset;
@@ -182,9 +198,9 @@ async function createChequePdf({ rows, template, printerProfile = { offset_x: 0,
         } else {
             drawText(row.date, dateCfg, { x: 426, y: 178, fontSize: 11, alignment: 'left', charSpacing: 0 });
         }
-        drawText(row.payee, positions.payee, { x: 72, y: 136, fontSize: 12, alignment: 'left', maxWidth: 380, minFontSize: 8 });
+        drawText(payeeText, positions.payee, { x: 72, y: 136, fontSize: 12, alignment: 'left', maxWidth: 380, minFontSize: 8 });
         drawText(row.amount, positions.amountNumeric, { x: 534, y: 136, fontSize: 12, alignment: 'right' });
-        drawText(words, positions.amountWords, { x: 72, y: 104, fontSize: 11, alignment: 'left', maxWidth: 420, minFontSize: 8 });
+        drawText(amountWordsText, positions.amountWords, { x: 72, y: 104, fontSize: 11, alignment: 'left', maxWidth: 420, minFontSize: 8 });
 
         if (currencySettings.enabled !== false) {
             drawText(currencySettings.label || '₱', positions.currency, { x: 474, y: 136, fontSize: 11, alignment: 'left' });

--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -19,6 +19,7 @@
         "multer": "^1.4.5-lts.1",
         "mustache": "^4.2.0",
         "papaparse": "^5.4.1",
+        "pdf-lib": "^1.17.1",
         "pg": "^8.16.3",
         "puppeteer": "^23.6.0",
         "yargs": "^17.7.2"
@@ -1051,6 +1052,24 @@
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.10"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -5226,6 +5245,12 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/papaparse": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
@@ -5330,6 +5355,24 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
+    },
+    "node_modules/pdf-lib": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "pako": "^1.0.11",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/pdf-lib/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/pend": {
       "version": "1.2.0",

--- a/packages/api/routes/chequeRoutes.js
+++ b/packages/api/routes/chequeRoutes.js
@@ -264,7 +264,7 @@ router.post('/cheques/generate-pdf', protect, async (req, res) => {
 
     try {
         const templateRes = await db.query(
-            `SELECT id, bank_name, field_positions, date_format, amount_format, currency_settings, paper_settings
+            `SELECT id, bank_name, field_positions, date_format, amount_format, currency_settings, paper_settings, amount_words_settings, text_settings
              FROM cheque_templates
              WHERE id = $1 AND is_deleted = FALSE`,
             [template_id]

--- a/packages/api/routes/chequeRoutes.js
+++ b/packages/api/routes/chequeRoutes.js
@@ -52,11 +52,18 @@ const DEFAULT_TEMPLATE = {
 };
 
 const DEFAULT_PAPER_SETTINGS = { widthIn: 8, heightIn: 3, unit: 'in' };
+const DEFAULT_AMOUNT_WORDS_SETTINGS = { suffix: 'pesos' };
+const DEFAULT_TEXT_SETTINGS = {
+    payeeFillerEnabled: false,
+    payeeFiller: '***',
+    amountWordsFillerEnabled: false,
+    amountWordsFiller: '***'
+};
 
 router.get('/cheques/templates', protect, async (_req, res) => {
     try {
         const { rows } = await db.query(
-            `SELECT id, bank_name, field_positions, date_format, amount_format, currency_settings, paper_settings, created_at, updated_at
+            `SELECT id, bank_name, field_positions, date_format, amount_format, currency_settings, paper_settings, amount_words_settings, text_settings, created_at, updated_at
              FROM cheque_templates
              WHERE is_deleted = FALSE
              ORDER BY bank_name ASC`
@@ -75,7 +82,9 @@ router.post('/cheques/templates', protect, async (req, res) => {
         date_format = 'MM-dd-yyyy',
         amount_format = 'title_case',
         currency_settings = { enabled: true, label: '₱' },
-        paper_settings = DEFAULT_PAPER_SETTINGS
+        paper_settings = DEFAULT_PAPER_SETTINGS,
+        amount_words_settings = DEFAULT_AMOUNT_WORDS_SETTINGS,
+        text_settings = DEFAULT_TEXT_SETTINGS
     } = req.body;
 
     if (!bank_name || !String(bank_name).trim()) {
@@ -84,10 +93,10 @@ router.post('/cheques/templates', protect, async (req, res) => {
 
     try {
         const { rows } = await db.query(
-            `INSERT INTO cheque_templates (bank_name, field_positions, date_format, amount_format, currency_settings, paper_settings)
-             VALUES ($1, $2::jsonb, $3, $4, $5::jsonb, $6::jsonb)
-             RETURNING id, bank_name, field_positions, date_format, amount_format, currency_settings, paper_settings, created_at, updated_at`,
-            [bank_name.trim(), JSON.stringify(field_positions), date_format, amount_format, JSON.stringify(currency_settings), JSON.stringify(paper_settings)]
+            `INSERT INTO cheque_templates (bank_name, field_positions, date_format, amount_format, currency_settings, paper_settings, amount_words_settings, text_settings)
+             VALUES ($1, $2::jsonb, $3, $4, $5::jsonb, $6::jsonb, $7::jsonb, $8::jsonb)
+             RETURNING id, bank_name, field_positions, date_format, amount_format, currency_settings, paper_settings, amount_words_settings, text_settings, created_at, updated_at`,
+            [bank_name.trim(), JSON.stringify(field_positions), date_format, amount_format, JSON.stringify(currency_settings), JSON.stringify(paper_settings), JSON.stringify(amount_words_settings), JSON.stringify(text_settings)]
         );
         res.status(201).json(rows[0]);
     } catch (error) {
@@ -98,7 +107,7 @@ router.post('/cheques/templates', protect, async (req, res) => {
 
 router.put('/cheques/templates/:id', protect, async (req, res) => {
     const { id } = req.params;
-    const { field_positions, date_format, amount_format, currency_settings, bank_name, paper_settings } = req.body;
+    const { field_positions, date_format, amount_format, currency_settings, bank_name, paper_settings, amount_words_settings, text_settings } = req.body;
 
     try {
         const { rows } = await db.query(
@@ -109,9 +118,11 @@ router.put('/cheques/templates/:id', protect, async (req, res) => {
                  amount_format = COALESCE($4, amount_format),
                  currency_settings = COALESCE($5::jsonb, currency_settings),
                  paper_settings = COALESCE($6::jsonb, paper_settings),
+                 amount_words_settings = COALESCE($7::jsonb, amount_words_settings),
+                 text_settings = COALESCE($8::jsonb, text_settings),
                  updated_at = CURRENT_TIMESTAMP
-             WHERE id = $7 AND is_deleted = FALSE
-             RETURNING id, bank_name, field_positions, date_format, amount_format, currency_settings, paper_settings, created_at, updated_at`,
+             WHERE id = $9 AND is_deleted = FALSE
+             RETURNING id, bank_name, field_positions, date_format, amount_format, currency_settings, paper_settings, amount_words_settings, text_settings, created_at, updated_at`,
             [
                 bank_name ?? null,
                 field_positions ? JSON.stringify(field_positions) : null,
@@ -119,6 +130,8 @@ router.put('/cheques/templates/:id', protect, async (req, res) => {
                 amount_format ?? null,
                 currency_settings ? JSON.stringify(currency_settings) : null,
                 paper_settings ? JSON.stringify(paper_settings) : null,
+                amount_words_settings ? JSON.stringify(amount_words_settings) : null,
+                text_settings ? JSON.stringify(text_settings) : null,
                 id
             ]
         );

--- a/packages/api/tests/chequeAmountWords.test.js
+++ b/packages/api/tests/chequeAmountWords.test.js
@@ -1,12 +1,20 @@
 const { amountToWords } = require('../helpers/chequeAmountWords');
 
 describe('amountToWords', () => {
-    it('formats whole and cent values', () => {
-        expect(amountToWords(1250.5)).toBe('one thousand two hundred fifty and 50/100');
+    it('formats decimal values using default suffix', () => {
+        expect(amountToWords(1250.5)).toBe('one thousand two hundred fifty pesos and 50/100');
     });
 
-    it('handles zero whole amount', () => {
-        expect(amountToWords(0.75)).toBe('zero and 75/100');
+    it('omits fraction for whole numbers', () => {
+        expect(amountToWords(500)).toBe('five hundred pesos only');
+    });
+
+    it('supports custom suffix values', () => {
+        expect(amountToWords(77.25, { suffix: 'dollars' })).toBe('seventy seven dollars and 25/100');
+    });
+
+    it('handles zero whole amount with decimal', () => {
+        expect(amountToWords(0.75)).toBe('zero pesos and 75/100');
     });
 
     it('throws for negative numbers', () => {

--- a/packages/api/tests/chequePdf.test.js
+++ b/packages/api/tests/chequePdf.test.js
@@ -7,7 +7,9 @@ describe('createChequePdf', () => {
             template: {
                 field_positions: {},
                 amount_format: 'title_case',
-                currency_settings: { enabled: true, label: 'USD' }
+                currency_settings: { enabled: true, label: 'USD' },
+                amount_words_settings: { suffix: 'pesos' },
+                text_settings: { payeeFillerEnabled: true, payeeFiller: '***', amountWordsFillerEnabled: true, amountWordsFiller: '--' }
             },
             printerProfile: { offset_x: 0, offset_y: 0 }
         });

--- a/packages/web/src/pages/ChequePrintingPage.jsx
+++ b/packages/web/src/pages/ChequePrintingPage.jsx
@@ -87,7 +87,7 @@ const ChequePrintingPage = () => {
 
     const activeRows = rows.filter((row) => row.payee || row.amount || row.memo).map((row) => ({
         ...row,
-        amount: (Math.round(Number(row.amount || 0) * 100) / 100).toFixed(2)
+        amount: String(Math.round(Number(row.amount || 0) * 100) / 100)
     }));
 
     const generatePdf = async (sourceRows = activeRows, persist = persistRecords) => {
@@ -350,10 +350,30 @@ const ChequePrintingPage = () => {
                                 </div>
                             )}
                             {activeTab === 'amount' && (
-                                <select className="border rounded px-3 py-2" value={selectedTemplate.amount_format || 'title_case'} onChange={(e) => updateTemplate({ amount_format: e.target.value })}>
-                                    <option value="title_case">Title Case</option>
-                                    <option value="upper">UPPER CASE</option>
-                                </select>
+                                <div className="space-y-3">
+                                    <div>
+                                        <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">Amount words casing</label>
+                                        <select className="border rounded px-3 py-2" value={selectedTemplate.amount_format || 'title_case'} onChange={(e) => updateTemplate({ amount_format: e.target.value })}>
+                                            <option value="title_case">Title Case</option>
+                                            <option value="upper">UPPER CASE</option>
+                                        </select>
+                                    </div>
+                                    <div>
+                                        <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">Amount suffix</label>
+                                        <input
+                                            className="border rounded px-3 py-2 w-full"
+                                            placeholder="pesos"
+                                            value={selectedTemplate.amount_words_settings?.suffix || 'pesos'}
+                                            onChange={(e) => updateTemplate({
+                                                amount_words_settings: {
+                                                    ...(selectedTemplate.amount_words_settings || {}),
+                                                    suffix: e.target.value
+                                                }
+                                            })}
+                                        />
+                                        <p className="text-xs text-gray-500 mt-1">Whole numbers render as “&lt;amount&gt; suffix only”. Decimal amounts render as “&lt;amount&gt; suffix and xx/100”.</p>
+                                    </div>
+                                </div>
                             )}
                             {activeTab === 'currency' && (
                                 <div className="space-y-2">
@@ -392,7 +412,63 @@ const ChequePrintingPage = () => {
                                     <p className="text-xs text-gray-500">Recommended standardized size: 8" x 3".</p>
                                 </div>
                             )}
-                            {activeTab === 'text' && <p className="text-gray-600">Payee overflow mitigation uses template font size and width values; no line wrapping is applied.</p>}
+                            {activeTab === 'text' && (
+                                <div className="space-y-3">
+                                    <p className="text-gray-600">Payee overflow mitigation uses template font size and width values; no line wrapping is applied.</p>
+                                    <div className="border rounded-lg p-3 space-y-2">
+                                        <label className="flex items-center gap-2">
+                                            <input
+                                                type="checkbox"
+                                                checked={Boolean(selectedTemplate.text_settings?.payeeFillerEnabled)}
+                                                onChange={(e) => updateTemplate({
+                                                    text_settings: {
+                                                        ...(selectedTemplate.text_settings || {}),
+                                                        payeeFillerEnabled: e.target.checked
+                                                    }
+                                                })}
+                                            />
+                                            Add filler at both ends of payee text
+                                        </label>
+                                        <input
+                                            className="border rounded px-3 py-2 w-full"
+                                            placeholder="***"
+                                            value={selectedTemplate.text_settings?.payeeFiller || '***'}
+                                            onChange={(e) => updateTemplate({
+                                                text_settings: {
+                                                    ...(selectedTemplate.text_settings || {}),
+                                                    payeeFiller: e.target.value
+                                                }
+                                            })}
+                                        />
+                                    </div>
+                                    <div className="border rounded-lg p-3 space-y-2">
+                                        <label className="flex items-center gap-2">
+                                            <input
+                                                type="checkbox"
+                                                checked={Boolean(selectedTemplate.text_settings?.amountWordsFillerEnabled)}
+                                                onChange={(e) => updateTemplate({
+                                                    text_settings: {
+                                                        ...(selectedTemplate.text_settings || {}),
+                                                        amountWordsFillerEnabled: e.target.checked
+                                                    }
+                                                })}
+                                            />
+                                            Add filler at both ends of amount-in-words
+                                        </label>
+                                        <input
+                                            className="border rounded px-3 py-2 w-full"
+                                            placeholder="***"
+                                            value={selectedTemplate.text_settings?.amountWordsFiller || '***'}
+                                            onChange={(e) => updateTemplate({
+                                                text_settings: {
+                                                    ...(selectedTemplate.text_settings || {}),
+                                                    amountWordsFiller: e.target.value
+                                                }
+                                            })}
+                                        />
+                                    </div>
+                                </div>
+                            )}
                             {activeTab === 'calibration' && (
                                 <div className="space-y-3">
                                     <div className="grid grid-cols-1 md:grid-cols-3 gap-2">


### PR DESCRIPTION
### Motivation
- The cheque writer must omit the decimal fraction when the amount is a whole number and render whole amounts as "<amount> <suffix> only" to match local wording preferences.
- Provide a template-level option to customize the amount suffix (default `pesos`) so different currencies/labels can be used.
- Allow adding configurable filler characters at both ends of the payee and amount-in-words fields to support visual alignment/formatting needs.

### Description
- Updated `amountToWords` to accept `options` (suffix) and to render whole amounts as `"... <suffix> only"` and decimal amounts as `"... <suffix> and xx/100"` (file: `packages/api/helpers/chequeAmountWords.js`).
- Applied suffix and optional end-fillers to both PDF renderers (pdf-lib and fallback) via `amount_words_settings` and `text_settings` template properties and an `applyEndFiller` helper (file: `packages/api/helpers/pdf/chequePdf.js`).
- Extended cheque template API to persist and return `amount_words_settings` and `text_settings` with sane defaults, and wired these into the create/update/get endpoints (file: `packages/api/routes/chequeRoutes.js`).
- Added a DB migration that adds `amount_words_settings` and `text_settings` JSONB columns with defaults and backfill (file: `database/migrations/20260420_add_amount_word_and_text_settings_to_cheque_templates.sql`).
- Updated the web settings UI to expose an Amount suffix input and toggles/inputs for payee and amount-in-words fillers, and adjusted client-side amount formatting so whole amounts can be sent without forced `xx` decimals (file: `packages/web/src/pages/ChequePrintingPage.jsx`).
- Updated unit tests to cover the new wording behavior and template payload usage (`packages/api/tests/chequeAmountWords.test.js`, `packages/api/tests/chequePdf.test.js`).

### Testing
- Updated/added unit tests: `packages/api/tests/chequeAmountWords.test.js` and `packages/api/tests/chequePdf.test.js` were updated to assert the new suffix and whole-number wording behaviors.
- Attempted to run the tests with `npm run -w packages/api test -- chequeAmountWords.test.js chequePdf.test.js` but the environment failed with `jest: not found`, so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e59be2000883328879da9f71f7e923)