### PR TITLE
Add printer `feed_type` and letter-feed calibration for cheque PDF rendering

### DIFF
--- a/database/migrations/20260421_add_feed_type_to_printer_profiles.sql
+++ b/database/migrations/20260421_add_feed_type_to_printer_profiles.sql
@@ -1,0 +1,2 @@
+ALTER TABLE printer_profiles
+ADD COLUMN IF NOT EXISTS feed_type VARCHAR(50) NOT NULL DEFAULT 'native';

--- a/packages/api/helpers/pdf/chequePdf.js
+++ b/packages/api/helpers/pdf/chequePdf.js
@@ -150,13 +150,21 @@ async function createChequePdf({ rows, template, printerProfile = { offset_x: 0,
     const currencySettings = template?.currency_settings || { enabled: true, label: '₱' };
     const amountWordsSettings = template?.amount_words_settings || { suffix: 'pesos' };
     const textSettings = template?.text_settings || {};
-    const xOffset = Number(printerProfile.offset_x || 0);
-    const yOffset = Number(printerProfile.offset_y || 0);
     const paperSize = resolvePaperSize(template?.paper_settings);
+    const feedType = String(printerProfile?.feed_type || 'native');
+    const isLetterFeed = ['letter_center', 'letter_left', 'letter_right'].includes(feedType);
+    const baseYOffset = isLetterFeed ? (792 - paperSize.height) : 0;
+    const baseXOffset = feedType === 'letter_center'
+        ? ((612 - paperSize.width) / 2)
+        : feedType === 'letter_right'
+            ? (612 - paperSize.width)
+            : 0;
+    const finalXOffset = baseXOffset + Number(printerProfile.offset_x || 0);
+    const finalYOffset = baseYOffset + Number(printerProfile.offset_y || 0);
 
     if (!PDFDocument || !StandardFonts) {
         return {
-            buffer: createFallbackPdf({ rows, template, xOffset, yOffset, testPrint }),
+            buffer: createFallbackPdf({ rows, template, xOffset: finalXOffset, yOffset: finalYOffset, testPrint }),
             renderer: 'fallback',
             warning: 'pdf-lib unavailable; fallback renderer used'
         };
@@ -167,15 +175,16 @@ async function createChequePdf({ rows, template, printerProfile = { offset_x: 0,
         const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
 
         rows.forEach((row) => {
-            const page = pdfDoc.addPage([paperSize.width, paperSize.height]);
+            const pageDimensions = isLetterFeed ? [612, 792] : [paperSize.width, paperSize.height];
+            const page = pdfDoc.addPage(pageDimensions);
             const amountWords = amountToWords(row.amount, { suffix: amountWordsSettings?.suffix || 'pesos' });
             const words = template?.amount_format === 'upper' ? amountWords.toUpperCase() : amountWords;
             const amountWordsText = applyEndFiller(words, textSettings?.amountWordsFiller, textSettings?.amountWordsFillerEnabled);
             const payeeText = applyEndFiller(row.payee, textSettings?.payeeFiller, textSettings?.payeeFillerEnabled);
 
         const drawText = (text, cfg, fallback) => {
-            const baseX = Number(cfg?.x ?? fallback.x) + xOffset;
-            const y = Number(cfg?.y ?? fallback.y) + yOffset;
+            const baseX = Number(cfg?.x ?? fallback.x) + finalXOffset;
+            const y = Number(cfg?.y ?? fallback.y) + finalYOffset;
             const preferredSize = Number(cfg?.fontSize ?? fallback.fontSize);
             const minFontSize = Number(cfg?.minFontSize ?? fallback.minFontSize ?? 8);
             const maxWidth = Number(cfg?.maxWidth ?? fallback.maxWidth ?? NaN);
@@ -201,7 +210,7 @@ async function createChequePdf({ rows, template, printerProfile = { offset_x: 0,
 
         const drawBoxedDate = (text, cfg, fallback) => {
             const content = String(text || '').replace(/[^0-9]/g, '');
-            const y = Number(cfg?.y ?? fallback.y) + yOffset;
+            const y = Number(cfg?.y ?? fallback.y) + finalYOffset;
             const size = Number(cfg?.fontSize ?? fallback.fontSize);
             const blocks = cfg?.blocks;
 
@@ -220,13 +229,13 @@ async function createChequePdf({ rows, template, printerProfile = { offset_x: 0,
                     const spacing = Number(blockCfg.charSpacing ?? cfg?.charSpacing ?? fallback.charSpacing ?? 14);
                     if (!Number.isFinite(startX)) return;
                     value.split('').forEach((char, index) => {
-                        page.drawText(char, { x: startX + xOffset + (index * spacing), y, size, font });
+                        page.drawText(char, { x: startX + finalXOffset + (index * spacing), y, size, font });
                     });
                 });
                 return;
             }
 
-            const x = Number(cfg?.x ?? fallback.x) + xOffset;
+            const x = Number(cfg?.x ?? fallback.x) + finalXOffset;
             const spacing = Number(cfg?.charSpacing ?? fallback.charSpacing ?? 14);
             const blockSpacing = Number(cfg?.blockSpacing ?? spacing);
             

--- a/packages/api/routes/chequeRoutes.js
+++ b/packages/api/routes/chequeRoutes.js
@@ -4,6 +4,7 @@ const { protect } = require('../middleware/authMiddleware');
 const { createChequePdf } = require('../helpers/pdf/chequePdf');
 
 const router = express.Router();
+const ALLOWED_FEED_TYPES = ['native', 'letter_center', 'letter_left', 'letter_right'];
 
 function isValidDateByFormat(value, format) {
     const input = String(value || '').trim();
@@ -172,7 +173,7 @@ router.get('/cheques/history', protect, async (_req, res) => {
 router.get('/cheques/printer-profiles', protect, async (_req, res) => {
     try {
         const { rows } = await db.query(
-            `SELECT id, profile_name, offset_x, offset_y, is_default, created_at, updated_at
+            `SELECT id, profile_name, feed_type, offset_x, offset_y, is_default, created_at, updated_at
              FROM printer_profiles
              ORDER BY is_default DESC, profile_name ASC`
         );
@@ -184,9 +185,12 @@ router.get('/cheques/printer-profiles', protect, async (_req, res) => {
 });
 
 router.post('/cheques/printer-profiles', protect, async (req, res) => {
-    const { profile_name, offset_x = 0, offset_y = 0, is_default = false } = req.body;
+    const { profile_name, feed_type = 'native', offset_x = 0, offset_y = 0, is_default = false } = req.body;
     if (!profile_name || !String(profile_name).trim()) {
         return res.status(400).json({ message: 'profile_name is required' });
+    }
+    if (!ALLOWED_FEED_TYPES.includes(String(feed_type))) {
+        return res.status(400).json({ message: `feed_type must be one of: ${ALLOWED_FEED_TYPES.join(', ')}` });
     }
 
     const client = await db.getClient();
@@ -196,10 +200,10 @@ router.post('/cheques/printer-profiles', protect, async (req, res) => {
             await client.query('UPDATE printer_profiles SET is_default = FALSE WHERE is_default = TRUE');
         }
         const { rows } = await client.query(
-            `INSERT INTO printer_profiles (profile_name, offset_x, offset_y, is_default)
-             VALUES ($1, $2, $3, $4)
-             RETURNING id, profile_name, offset_x, offset_y, is_default, created_at, updated_at`,
-            [String(profile_name).trim(), Number(offset_x) || 0, Number(offset_y) || 0, Boolean(is_default)]
+            `INSERT INTO printer_profiles (profile_name, feed_type, offset_x, offset_y, is_default)
+             VALUES ($1, $2, $3, $4, $5)
+             RETURNING id, profile_name, feed_type, offset_x, offset_y, is_default, created_at, updated_at`,
+            [String(profile_name).trim(), String(feed_type), Number(offset_x) || 0, Number(offset_y) || 0, Boolean(is_default)]
         );
         await client.query('COMMIT');
         res.status(201).json(rows[0]);
@@ -214,7 +218,10 @@ router.post('/cheques/printer-profiles', protect, async (req, res) => {
 
 router.put('/cheques/printer-profiles/:id', protect, async (req, res) => {
     const { id } = req.params;
-    const { profile_name, offset_x, offset_y, is_default } = req.body;
+    const { profile_name, feed_type, offset_x, offset_y, is_default } = req.body;
+    if (feed_type !== undefined && !ALLOWED_FEED_TYPES.includes(String(feed_type))) {
+        return res.status(400).json({ message: `feed_type must be one of: ${ALLOWED_FEED_TYPES.join(', ')}` });
+    }
     const client = await db.getClient();
 
     try {
@@ -225,14 +232,16 @@ router.put('/cheques/printer-profiles/:id', protect, async (req, res) => {
         const { rows } = await client.query(
             `UPDATE printer_profiles
              SET profile_name = COALESCE($1, profile_name),
-                 offset_x = COALESCE($2, offset_x),
-                 offset_y = COALESCE($3, offset_y),
-                 is_default = COALESCE($4, is_default),
+                 feed_type = COALESCE($2, feed_type),
+                 offset_x = COALESCE($3, offset_x),
+                 offset_y = COALESCE($4, offset_y),
+                 is_default = COALESCE($5, is_default),
                  updated_at = CURRENT_TIMESTAMP
-             WHERE id = $5
-             RETURNING id, profile_name, offset_x, offset_y, is_default, created_at, updated_at`,
+             WHERE id = $6
+             RETURNING id, profile_name, feed_type, offset_x, offset_y, is_default, created_at, updated_at`,
             [
                 profile_name ? String(profile_name).trim() : null,
+                feed_type !== undefined ? String(feed_type) : null,
                 offset_x !== undefined ? Number(offset_x) || 0 : null,
                 offset_y !== undefined ? Number(offset_y) || 0 : null,
                 is_default !== undefined ? Boolean(is_default) : null,
@@ -278,10 +287,10 @@ router.post('/cheques/generate-pdf', protect, async (req, res) => {
             return res.status(404).json({ message: 'Template not found' });
         }
 
-        let profile = { offset_x: 0, offset_y: 0 };
+        let profile = { feed_type: 'native', offset_x: 0, offset_y: 0 };
         if (printer_profile_id) {
             const profileRes = await db.query(
-                `SELECT id, offset_x, offset_y
+                `SELECT id, feed_type, offset_x, offset_y
                  FROM printer_profiles
                  WHERE id = $1`,
                 [printer_profile_id]

--- a/packages/api/tests/chequePdf.test.js
+++ b/packages/api/tests/chequePdf.test.js
@@ -43,4 +43,15 @@ describe('createChequePdf', () => {
         expect(Buffer.isBuffer(pdf)).toBe(true);
         expect(pdf.length).toBeGreaterThan(100);
     });
+
+    it('uses letter canvas and feed alignment offsets when feed_type is letter_right', async () => {
+        const result = await createChequePdf({
+            rows: [{ date: '04/19/2026', payee: 'Feed Type Test', amount: '500.00', memo: '' }],
+            template: { field_positions: {}, amount_format: 'upper' },
+            printerProfile: { feed_type: 'letter_right', offset_x: 0, offset_y: 0 }
+        });
+
+        const pdfText = result.buffer.toString('latin1');
+        expect(pdfText).toContain('/MediaBox [0 0 612 792]');
+    });
 });

--- a/packages/web/src/pages/ChequePrintingPage.jsx
+++ b/packages/web/src/pages/ChequePrintingPage.jsx
@@ -48,7 +48,7 @@ const ChequePrintingPage = () => {
     const [testPrintMode, setTestPrintMode] = useState(false);
     const [historyQuery, setHistoryQuery] = useState('');
     const [historyBankFilter, setHistoryBankFilter] = useState('all');
-    const [draftProfile, setDraftProfile] = useState({ profile_name: '', offset_x: 0, offset_y: 0, is_default: false });
+    const [draftProfile, setDraftProfile] = useState({ profile_name: '', feed_type: 'native', offset_x: 0, offset_y: 0, is_default: false });
 
     const selectedTemplate = useMemo(() => templates.find((tpl) => String(tpl.id) === String(selectedTemplateId)), [templates, selectedTemplateId]);
     const selectedProfile = useMemo(() => printerProfiles.find((profile) => String(profile.id) === String(selectedProfileId)), [printerProfiles, selectedProfileId]);
@@ -74,11 +74,12 @@ const ChequePrintingPage = () => {
     useEffect(() => { loadData(); }, []);
     useEffect(() => {
         if (!selectedProfile) {
-            setDraftProfile({ profile_name: '', offset_x: 0, offset_y: 0, is_default: false });
+            setDraftProfile({ profile_name: '', feed_type: 'native', offset_x: 0, offset_y: 0, is_default: false });
             return;
         }
         setDraftProfile({
             profile_name: selectedProfile.profile_name || '',
+            feed_type: selectedProfile.feed_type || 'native',
             offset_x: Number(selectedProfile.offset_x || 0),
             offset_y: Number(selectedProfile.offset_y || 0),
             is_default: Boolean(selectedProfile.is_default)
@@ -230,6 +231,7 @@ const ChequePrintingPage = () => {
             if (!selectedProfile) {
                 const created = await api.post('/cheques/printer-profiles', {
                     profile_name: patch.profile_name || `Profile ${printerProfiles.length + 1}`,
+                    feed_type: patch.feed_type || 'native',
                     offset_x: patch.offset_x || 0,
                     offset_y: patch.offset_y || 0,
                     is_default: patch.is_default || false
@@ -626,13 +628,23 @@ const ChequePrintingPage = () => {
                                 {activeTab === 'calibration' && (
                                     <div className="space-y-3">
                                         <p className="text-gray-600">Save profile offsets to match your printer's physical output alignment.</p>
-                                        <div className="grid grid-cols-1 md:grid-cols-3 gap-2">
+                                        <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
                                             <input
                                                 className={INPUT_BASE}
                                                 placeholder="Profile name"
                                                 value={draftProfile.profile_name}
                                                 onChange={(e) => setDraftProfile((prev) => ({ ...prev, profile_name: e.target.value }))}
                                             />
+                                            <select
+                                                className={INPUT_BASE}
+                                                value={draftProfile.feed_type || 'native'}
+                                                onChange={(e) => setDraftProfile((prev) => ({ ...prev, feed_type: e.target.value }))}
+                                            >
+                                                <option value="native">Native (Custom Paper Size)</option>
+                                                <option value="letter_center">Letter Size (Center Feed)</option>
+                                                <option value="letter_left">Letter Size (Left Feed)</option>
+                                                <option value="letter_right">Letter Size (Right Feed)</option>
+                                            </select>
                                             <input
                                                 type="number"
                                                 step="0.1"
@@ -650,6 +662,7 @@ const ChequePrintingPage = () => {
                                                 onChange={(e) => setDraftProfile((prev) => ({ ...prev, offset_y: Number(e.target.value) || 0 }))}
                                             />
                                         </div>
+                                        <p className="text-xs text-gray-500">If your printer rejects custom 8x3 paper sizes, select your manual tray&apos;s feed alignment. The system will print on a Letter canvas to bypass the error.</p>
                                         <label className="flex items-center gap-2">
                                             <input
                                                 type="checkbox"
@@ -661,7 +674,7 @@ const ChequePrintingPage = () => {
                                         <div className="flex gap-2">
                                             <button className={BUTTON_PRIMARY} onClick={() => upsertProfile(draftProfile)}><Icon path={ICONS.settings} className="h-4 w-4" />{selectedProfile ? 'Save Profile' : 'Create Profile'}</button>
                                             {!selectedProfile && (
-                                                <button className={BUTTON_SECONDARY} onClick={() => setDraftProfile({ profile_name: `Profile ${printerProfiles.length + 1}`, offset_x: 0, offset_y: 0, is_default: false })}><Icon path={ICONS.edit} className="h-4 w-4" />Quick Fill</button>
+                                                <button className={BUTTON_SECONDARY} onClick={() => setDraftProfile({ profile_name: `Profile ${printerProfiles.length + 1}`, feed_type: 'native', offset_x: 0, offset_y: 0, is_default: false })}><Icon path={ICONS.edit} className="h-4 w-4" />Quick Fill</button>
                                             )}
                                         </div>
                                     </div>


### PR DESCRIPTION
### Motivation
- Some office laser printers reject custom 8"x3" paper sizes and throw a paper-size mismatch, so a Letter-size canvas workaround is required.  
- Introduce a `feed_type` on printer profiles to let the renderer emit a Letter (8.5"x11") page and translate X/Y coordinates so the 8"x3" cheque block prints at the top.  
- Provide UI and API support so feed alignment can be configured per-profile and persisted.

### Description
- Added database migration `ALTER TABLE printer_profiles ADD COLUMN IF NOT EXISTS feed_type VARCHAR(50) NOT NULL DEFAULT 'native';` to persist the new `feed_type` property.  
- Refactored `createChequePdf` in `packages/api/helpers/pdf/chequePdf.js` to read `printerProfile.feed_type`, choose Letter page dimensions for letter feeds, compute `baseX`/`baseY` translations for `letter_center`, `letter_left`, and `letter_right`, combine those with profile offsets into `finalXOffset`/`finalYOffset`, and apply them to all drawing and fallback PDF operations.  
- Updated API endpoints in `packages/api/routes/chequeRoutes.js` to include `feed_type` in list/select responses, accept and validate `feed_type` on POST/PUT (allowed values: `native`, `letter_center`, `letter_left`, `letter_right`), and return it in responses.  
- Updated the cheque printing UI `packages/web/src/pages/ChequePrintingPage.jsx` to surface a "Printer Feed Type" selector, load/save `feed_type` with profiles, and add helper text about the Letter-canvas workaround.  
- Added a test case to `packages/api/tests/chequePdf.test.js` asserting that a letter feed produces a PDF containing the Letter media box (`/MediaBox [0 0 612 792]`).

### Testing
- Added unit test in `packages/api/tests/chequePdf.test.js` that validates Letter page dimensions when `printerProfile.feed_type` is `letter_right`.  
- Attempted to run tests via `npm test -- --runInBand packages/api/tests/chequePdf.test.js`, but the run failed in this environment because `jest` is not available on the PATH in `packages/api`, so no test suite was executed here.  
- No other automated test failures were observed in this workspace while applying changes (test runner unavailable prevented execution of the new test).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2aec7707083329133ed86ea0cffcf)