### PR TITLE
Fix cheque PDF lint failure from undefined fallback offsets

### DIFF
--- a/packages/api/helpers/pdf/chequePdf.js
+++ b/packages/api/helpers/pdf/chequePdf.js
@@ -272,7 +272,7 @@ async function createChequePdf({ rows, template, printerProfile = { offset_x: 0,
         return { buffer: Buffer.from(bytes), renderer: 'pdf-lib', warning: null };
     } catch (error) {
         return {
-            buffer: createFallbackPdf({ rows, template, xOffset, yOffset, testPrint }),
+            buffer: createFallbackPdf({ rows, template, xOffset: finalXOffset, yOffset: finalYOffset, testPrint }),
             renderer: 'fallback',
             warning: `pdf-lib failed (${error.message || 'unknown error'}); fallback renderer used`
         };


### PR DESCRIPTION
### Motivation
- Address an ESLint `no-undef` error caused by passing undefined `xOffset`/`yOffset` into the fallback PDF renderer from the `createChequePdf` `catch` block by using the already-computed offsets.

### Description
- Update `packages/api/helpers/pdf/chequePdf.js` to call `createFallbackPdf` with `xOffset: finalXOffset` and `yOffset: finalYOffset` in the `catch` fallback instead of the undefined `xOffset`/`yOffset` variables.

### Testing
- Ran `npm run lint` in `packages/api` and lint now completes with warnings only and no errors (previous `no-undef` errors resolved).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f33a789d908332875e8550fec432da)