### PR TITLE
fix(api): resolve lint failures in cheque PDF and search repair

### DIFF
--- a/packages/api/helpers/pdf/chequePdf.js
+++ b/packages/api/helpers/pdf/chequePdf.js
@@ -3,7 +3,7 @@ let PDFDocument;
 let StandardFonts;
 try {
     ({ PDFDocument, StandardFonts } = require('pdf-lib'));
-} catch (_error) {
+} catch {
     PDFDocument = null;
     StandardFonts = null;
 }
@@ -63,12 +63,12 @@ function toPdfLibSafeText(text, font) {
     try {
         font.encodeText(content);
         return content;
-    } catch (_error) {
+    } catch {
         return Array.from(content).map((char) => {
             try {
                 font.encodeText(char);
                 return char;
-            } catch (_innerError) {
+            } catch {
                 return '?';
             }
         }).join('');
@@ -272,7 +272,7 @@ async function createChequePdf({ rows, template, printerProfile = { offset_x: 0,
         return { buffer: Buffer.from(bytes), renderer: 'pdf-lib', warning: null };
     } catch (error) {
         return {
-            buffer: createFallbackPdf({ rows, template, xOffset, yOffset, testPrint }),
+            buffer: createFallbackPdf({ rows, template, xOffset: finalXOffset, yOffset: finalYOffset, testPrint }),
             renderer: 'fallback',
             warning: `pdf-lib failed (${error.message || 'unknown error'}); fallback renderer used`
         };

--- a/packages/api/routes/dataUtilsRoutes.js
+++ b/packages/api/routes/dataUtilsRoutes.js
@@ -6,8 +6,6 @@ const db = require('../db');
 const { protect, isAdmin } = require('../middleware/authMiddleware');
 const { generateUniqueCode } = require('../helpers/codeGenerator');
 const { syncPartWithMeili } = require('../meilisearch');
-const { setupMeiliSearch } = require('../meilisearch-setup');
-const { getPartDataForMeili } = require('./partRoutes');
 const { constructDisplayName } = require('../helpers/displayNameHelper');
 const router = express.Router();
 

--- a/packages/api/search-repair-worker.js
+++ b/packages/api/search-repair-worker.js
@@ -238,7 +238,7 @@ const processRepairJob = async (job, config) => {
           payload.push(doc);
           success += 1;
         }
-      } catch (error) {
+      } catch {
         failed += 1;
       }
 
@@ -301,7 +301,7 @@ const runNightlyReconciliation = async (config = DEFAULTS) => {
   for (const partId of sampleIds) {
     try {
       await meiliClient.index('parts').getDocument(partId);
-    } catch (_error) {
+    } catch {
       missingFromIndex += 1;
     }
   }

--- a/packages/api/tests/chequePdf.test.js
+++ b/packages/api/tests/chequePdf.test.js
@@ -55,3 +55,30 @@ describe('createChequePdf', () => {
         expect(pdfText).toContain('/MediaBox [0 0 612 792]');
     });
 });
+
+
+describe('createChequePdf fallback renderer offsets', () => {
+    afterEach(() => {
+        jest.resetModules();
+        jest.dontMock('pdf-lib');
+    });
+
+    it('applies final printer offsets in fallback path when pdf-lib is unavailable', async () => {
+        jest.resetModules();
+        jest.doMock('pdf-lib', () => {
+            throw new Error('Simulated missing pdf-lib');
+        });
+
+        const { createChequePdf: createWithFallback } = require('../helpers/pdf/chequePdf');
+
+        const result = await createWithFallback({
+            rows: [{ date: '04/19/2026', payee: 'Offset Check', amount: '123.45', memo: '' }],
+            template: { field_positions: {} },
+            printerProfile: { offset_x: 10, offset_y: 20 }
+        });
+
+        expect(result.renderer).toBe('fallback');
+        const pdfText = result.buffer.toString('latin1');
+        expect(pdfText).toContain('436 198 Td');
+    });
+});


### PR DESCRIPTION
### Motivation
- Fix the CI-blocking ESLint `no-undef` error in `packages/api/helpers/pdf/chequePdf.js` where `xOffset`/`yOffset` were referenced but not defined in the fallback path. 
- Remove lint noise from `no-unused-vars` warnings introduced by unused catch bindings and unused imports in the `api` package. 
- Ensure the fallback PDF renderer applies the same printer offsets as the primary `pdf-lib` renderer so printed output stays consistent. 

### Description
- Pass the computed offsets into the fallback renderer by changing the catch fallback call to `createFallbackPdf({ rows, template, xOffset: finalXOffset, yOffset: finalYOffset, testPrint })` in `packages/api/helpers/pdf/chequePdf.js`. 
- Ensure `createFallbackPdf` accepts and uses `xOffset` and `yOffset` when rendering the fallback PDF. 
- Remove unused Meilisearch-related imports `setupMeiliSearch` and `getPartDataForMeili` from `packages/api/routes/dataUtilsRoutes.js`. 
- Replace unused catch-binding patterns like `catch (_error)` / `catch (_innerError)` and `catch (error)` (when the binding was unused) with bare `catch` blocks in `chequePdf.js` and `search-repair-worker.js` to satisfy lint rules. 

### Testing
- Ran `npm run lint` in `packages/api` and confirmed ESLint completed without errors. 
- The changes were validated locally by re-running the lint step after edits and observing a clean lint pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f347e849048332b0a888d4365d1e22)