### PR TITLE
Fix test failures and noisy logs

### DIFF
--- a/packages/api/helpers/partNumberSoftDelete.js
+++ b/packages/api/helpers/partNumberSoftDelete.js
@@ -7,9 +7,13 @@ let hasDeletedAtColumn = false;
     const sql = `SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='part_number' AND column_name='deleted_at'`;
     const res = await db.query(sql);
     hasDeletedAtColumn = res.rowCount > 0;
-    if (!hasDeletedAtColumn) console.warn('[part_number] deleted_at column not found - soft delete disabled until migration runs.');
+    if (!hasDeletedAtColumn && process.env.NODE_ENV !== 'test') {
+      console.warn('[part_number] deleted_at column not found - soft delete disabled until migration runs.');
+    }
   } catch (e) {
-    console.error('Failed checking part_number.deleted_at existence', e.message);
+    if (process.env.NODE_ENV !== 'test') {
+      console.error('Failed checking part_number.deleted_at existence', e.message);
+    }
   }
 })();
 

--- a/packages/api/routes/partRoutes.js
+++ b/packages/api/routes/partRoutes.js
@@ -55,9 +55,7 @@ const getPartDataForMeili = async (client, partId) => {
 
 // Helper function to handle tag logic
 const manageTags = async (client, tags, partId) => {
-    console.log('[DEBUG] manageTags - Starting with:', { tags, partId });
     if (!Array.isArray(tags)) {
-        console.log('[DEBUG] manageTags - Tags is not an array:', tags);
         return; // Skip tag processing if tags is not an array
     }
 

--- a/packages/api/tests/chequePdf.test.js
+++ b/packages/api/tests/chequePdf.test.js
@@ -51,8 +51,18 @@ describe('createChequePdf', () => {
             printerProfile: { feed_type: 'letter_right', offset_x: 0, offset_y: 0 }
         });
 
-        const pdfText = result.buffer.toString('latin1');
-        expect(pdfText).toContain('/MediaBox [0 0 612 792]');
+        if (result.renderer === 'pdf-lib') {
+            const { PDFDocument } = require('pdf-lib');
+            const pdfDoc = await PDFDocument.load(result.buffer);
+            const pages = pdfDoc.getPages();
+            expect(pages.length).toBeGreaterThan(0);
+            const { width, height } = pages[0].getSize();
+            expect(width).toBeCloseTo(612, 0);
+            expect(height).toBeCloseTo(792, 0);
+        } else {
+            const pdfText = result.buffer.toString('latin1');
+            expect(pdfText).toContain('/MediaBox [0 0 612 792]');
+        }
     });
 });
 

--- a/packages/api/tests/taxCalculationService.test.js
+++ b/packages/api/tests/taxCalculationService.test.js
@@ -10,6 +10,11 @@ const db = require('../db');
 describe('Tax Calculation Service', () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        console.error.mockRestore();
     });
 
     describe('calculateLineTax', () => {
@@ -166,6 +171,14 @@ describe('Tax Calculation Service', () => {
 
 // Integration test for database interactions
 describe('Tax Calculation Integration', () => {
+    beforeEach(() => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        console.error.mockRestore();
+    });
+
     test('should handle database errors gracefully', async () => {
         db.query.mockRejectedValue(new Error('Database connection failed'));
 


### PR DESCRIPTION
Fixes the failing `npm test` by correcting how `chequePdf.test.js` asserts the dimensions of generated PDFs and suppresses unwanted logs during test execution.

---
*PR created automatically by Jules for task [9137261697826473442](https://jules.google.com/task/9137261697826473442) started by @kent1l*