### PR TITLE
fix: optimize parts cleanup duplicate finding and fix merge transaction safety

### DIFF
--- a/database/migrations/20260422_add_index_to_part_number.sql
+++ b/database/migrations/20260422_add_index_to_part_number.sql
@@ -1,0 +1,4 @@
+-- Index to speed up Phase 1 of Cascade Record Linkage for part deduplication
+CREATE INDEX IF NOT EXISTS idx_part_number_part_number
+ON public.part_number(part_number)
+WHERE deleted_at IS NULL;

--- a/original_duplicateFinder.js
+++ b/original_duplicateFinder.js
@@ -1,0 +1,410 @@
+/**
+ * Service for finding potential duplicate parts
+ */
+class DuplicateFinder {
+    constructor(db) {
+        this.db = db;
+    }
+
+    // Normalization helpers
+    static normalizeText(text) {
+        if (!text) return '';
+        return text
+            .toLowerCase()
+            .trim()
+            .normalize('NFD').replace(/[\u0300-\u036f]/g, '') // unaccent
+            .replace(/[^\w\s]/g, ' ') // remove punctuation
+            .replace(/\s+/g, ' ')
+            .trim();
+    }
+
+    static tokenizeAndSort(text) {
+        if (!text) return [];
+        return this.normalizeText(text)
+            .split(/\s+/)
+            .filter(word => word.length > 1) // ignore single chars
+            .sort();
+    }
+
+    static normalizePartNumber(pn) {
+        if (!pn) return '';
+        return pn.replace(/[^a-zA-Z0-9]/g, '').toUpperCase();
+    }
+
+    static extractNumericTokens(text) {
+        if (!text) return [];
+        const matches = text.match(/\b\d+\b/g) || [];
+        return matches.map(m => parseInt(m)).filter(n => !isNaN(n));
+    }
+
+    // Composite scoring for optimized finder
+    static calculateCompositeScore(part1, part2, detailSim = 0, nameSim = 0) {
+        let score = 0;
+        const reasons = [];
+
+        // Normalize fields
+        const detail1 = this.normalizeText(part1.detail || '');
+        const detail2 = this.normalizeText(part2.detail || '');
+        const name1 = this.normalizeText(part1.display_name || '');
+        const name2 = this.normalizeText(part2.display_name || '');
+
+        // Shared part numbers: +0.60
+        const pns1 = (part1.part_numbers || []).map(pn => this.normalizePartNumber(pn.part_number));
+        const pns2 = (part2.part_numbers || []).map(pn => this.normalizePartNumber(pn.part_number));
+        const sharedPns = pns1.filter(pn => pns2.includes(pn));
+        if (sharedPns.length > 0) {
+            score += 0.60;
+            reasons.push('shared_part_number');
+        }
+
+        // Detail trigram similarity: +0.25 * similarity
+        if (detailSim > 0.7) {
+            score += 0.25 * detailSim;
+            reasons.push('similar_detail');
+        }
+
+        // Name trigram similarity: +0.10 * similarity
+        if (nameSim > 0.8) {
+            score += 0.10 * nameSim;
+            reasons.push('similar_name');
+        }
+
+        // Numeric token overlap: +0.05 * (overlap / max)
+        const nums1 = this.extractNumericTokens(detail1 + ' ' + name1);
+        const nums2 = this.extractNumericTokens(detail2 + ' ' + name2);
+        const overlap = nums1.filter(n => nums2.includes(n)).length;
+        const maxLen = Math.max(nums1.length, nums2.length);
+        if (maxLen > 0) {
+            score += 0.05 * (overlap / maxLen);
+            if (overlap > 0) reasons.push('numeric_overlap');
+        }
+
+        return { score: Math.min(score, 1.0), reasons };
+    }
+
+    // Map score to confidence level
+    static getConfidenceLevel(score) {
+        if (score >= 0.85) return 'High';
+        if (score >= 0.70) return 'Medium';
+        if (score >= 0.60) return 'Low';
+        return 'Very Low';
+    }
+
+    /**
+     * Optimized duplicate finder with confidence scoring
+     */
+    async findOptimizedDuplicateGroups(options = {}) {
+        const { minScore = 0.6, limit = 50 } = options;
+
+        // Query to find candidate pairs within same brand/group
+        const queryText = `
+            SELECT p1.part_id as part1_id, p1.internal_sku as part1_sku, p1.display_name as part1_name, p1.detail as part1_detail,
+                   p1.brand_name as part1_brand, p1.group_name as part1_group,
+                   p2.part_id as part2_id, p2.internal_sku as part2_sku, p2.display_name as part2_name, p2.detail as part2_detail,
+                   p2.brand_name as part2_brand, p2.group_name as part2_group,
+                   CASE WHEN pn1.part_number IS NOT NULL AND pn2.part_number IS NOT NULL THEN 1 ELSE 0 END as shared_pn,
+                   COALESCE((SELECT json_agg(jsonb_build_object('part_number', pn.part_number)) FROM part_number pn WHERE pn.part_id = p1.part_id AND pn.deleted_at IS NULL), '[]'::json) as p1_part_numbers,
+                   COALESCE((SELECT json_agg(jsonb_build_object('part_number', pn.part_number)) FROM part_number pn WHERE pn.part_id = p2.part_id AND pn.deleted_at IS NULL), '[]'::json) as p2_part_numbers,
+                   similarity(p1.detail, p2.detail) as detail_sim,
+                   similarity(p1.display_name, p2.display_name) as name_sim
+            FROM parts_view p1
+            JOIN parts_view p2 ON p1.part_id < p2.part_id
+                AND p1.brand_name = p2.brand_name
+                AND p1.group_name = p2.group_name
+            LEFT JOIN part_number pn1 ON p1.part_id = pn1.part_id AND pn1.deleted_at IS NULL
+            LEFT JOIN part_number pn2 ON p2.part_id = pn2.part_id AND pn2.deleted_at IS NULL AND pn1.part_number = pn2.part_number
+            WHERE p1.merged_into_part_id IS NULL
+                AND p2.merged_into_part_id IS NULL
+                AND (pn1.part_number IS NOT NULL OR similarity(p1.detail, p2.detail) > 0.7 OR similarity(p1.display_name, p2.display_name) > 0.7)
+            ORDER BY (CASE WHEN pn1.part_number IS NOT NULL THEN 1 ELSE 0 END) DESC,
+                     GREATEST(similarity(p1.detail, p2.detail), similarity(p1.display_name, p2.display_name)) DESC
+            LIMIT $1
+        `;
+
+        const result = await this.db.query(queryText, [limit * 10]); // get more candidates
+
+        const groups = [];
+        const processed = new Set();
+
+        for (const row of result.rows) {
+            if (processed.has(row.part1_id) || processed.has(row.part2_id)) continue;
+
+            const part1 = {
+                part_id: row.part1_id,
+                internal_sku: row.part1_sku,
+                display_name: row.part1_name,
+                detail: row.part1_detail,
+                brand_name: row.part1_brand,
+                group_name: row.part1_group,
+                part_numbers: row.p1_part_numbers
+            };
+            const part2 = {
+                part_id: row.part2_id,
+                internal_sku: row.part2_sku,
+                display_name: row.part2_name,
+                detail: row.part2_detail,
+                brand_name: row.part2_brand,
+                group_name: row.part2_group,
+                part_numbers: row.p2_part_numbers
+            };
+
+            const { score, reasons } = this.constructor.calculateCompositeScore(part1, part2, row.detail_sim, row.name_sim);
+
+            if (score >= minScore) {
+                const group = {
+                    groupId: `opt_${row.part1_id}_${row.part2_id}`,
+                    score,
+                    confidence: this.constructor.getConfidenceLevel(score),
+                    reasons,
+                    parts: [this.formatPartData(part1), this.formatPartData(part2)]
+                };
+                groups.push(group);
+                processed.add(row.part1_id);
+                processed.add(row.part2_id);
+            }
+        }
+
+        return groups.slice(0, limit);
+    }
+
+    /**
+     * Find groups of potentially duplicate parts
+     * @param {Object} options - Search options
+     * @param {string} options.query - Optional search query to filter parts
+     * @param {number} options.limit - Maximum number of groups to return
+     * @param {number} options.offset - Offset for pagination
+     * @param {string} options.strategy - Detection strategy ('auto', 'strict', 'loose')
+     * @returns {Array} Array of duplicate groups
+     */
+    async findDuplicateGroups(options = {}) {
+        const { query = '', limit = 50, offset = 0, strategy = 'auto' } = options;
+
+        const duplicateGroups = [];
+
+        // Strategy 1: Exact SKU matches (different parts with same SKU - shouldn't happen but might)
+        const skuDuplicates = await this.findSkuDuplicates(query, limit, offset);
+        duplicateGroups.push(...skuDuplicates);
+
+        // Strategy 2: Exact part number overlaps
+        const partNumberDuplicates = await this.findPartNumberDuplicates(query, limit, offset);
+        duplicateGroups.push(...partNumberDuplicates);
+
+        // Strategy 3: Similar names within same brand/group
+        const nameDuplicates = await this.findSimilarNameDuplicates(query, limit, offset, strategy);
+        duplicateGroups.push(...nameDuplicates);
+
+        // Strategy 4: Very similar display names (trigram similarity)
+        if (strategy === 'auto' || strategy === 'loose') {
+            const trigramDuplicates = await this.findTrigramSimilarDuplicates(query, limit, offset);
+            duplicateGroups.push(...trigramDuplicates);
+        }
+
+        // Deduplicate and sort by confidence score
+        const uniqueGroups = this.deduplicateGroups(duplicateGroups);
+        return uniqueGroups.sort((a, b) => b.score - a.score).slice(0, limit);
+    }
+
+    async findSkuDuplicates(query, limit, offset) {
+        const queryText = `
+            SELECT p1.part_id, p1.internal_sku, p1.display_name, p1.brand_name, p1.group_name,
+                   p1.tags, p1.created_at, p1.modified_at
+            FROM parts_view p1
+            JOIN parts_view p2 ON p1.internal_sku = p2.internal_sku
+                AND p1.part_id != p2.part_id
+            WHERE p1.merged_into_part_id IS NULL
+                AND p2.merged_into_part_id IS NULL
+                AND ($1 = '' OR p1.display_name ILIKE $1 OR p1.internal_sku ILIKE $1)
+            ORDER BY p1.internal_sku, p1.part_id
+            LIMIT $2 OFFSET $3
+        `;
+
+        const params = [`%${query}%`, limit * 2, offset];
+        const result = await this.db.query(queryText, params);
+
+        return this.groupPartsByKey(result.rows, 'internal_sku', 'exact_sku', 1.0);
+    }
+
+    async findPartNumberDuplicates(query, limit, offset) {
+        const queryText = `
+            SELECT DISTINCT p1.part_id, p1.internal_sku, p1.display_name, p1.brand_name, p1.group_name,
+                   p1.tags, p1.created_at, p1.modified_at, pn1.part_number
+            FROM parts_view p1
+            JOIN part_number pn1 ON p1.part_id = pn1.part_id
+            JOIN part_number pn2 ON pn1.part_number = pn2.part_number
+                AND pn1.part_id != pn2.part_id
+            JOIN parts_view p2 ON pn2.part_id = p2.part_id
+            WHERE p1.merged_into_part_id IS NULL
+                AND p2.merged_into_part_id IS NULL
+                AND ($1 = '' OR p1.display_name ILIKE $1 OR p1.internal_sku ILIKE $1)
+            ORDER BY pn1.part_number, p1.part_id
+            LIMIT $2 OFFSET $3
+        `;
+
+        const params = [`%${query}%`, limit * 2, offset];
+        const result = await this.db.query(queryText, params);
+
+        return this.groupPartsByKey(result.rows, 'part_number', 'shared_part_number', 0.9);
+    }
+
+    async findSimilarNameDuplicates(query, limit, offset, strategy) {
+        const similarityThreshold = strategy === 'strict' ? 0.9 : 0.8;
+
+        const queryText = `
+            SELECT p1.part_id, p1.internal_sku, p1.display_name, p1.brand_name, p1.group_name,
+                   p1.tags, p1.created_at, p1.modified_at,
+                   similarity(p1.display_name, p2.display_name) as name_similarity
+            FROM parts_view p1
+            JOIN parts_view p2 ON p1.part_id < p2.part_id
+                AND p1.brand_name = p2.brand_name
+                AND p1.group_name = p2.group_name
+                AND similarity(p1.display_name, p2.display_name) > $4
+            WHERE p1.merged_into_part_id IS NULL
+                AND p2.merged_into_part_id IS NULL
+                AND ($1 = '' OR p1.display_name ILIKE $1 OR p1.internal_sku ILIKE $1)
+            ORDER BY name_similarity DESC, p1.part_id
+            LIMIT $2 OFFSET $3
+        `;
+
+        const params = [`%${query}%`, limit * 2, offset, similarityThreshold];
+
+        try {
+            const result = await this.db.query(queryText, params);
+            return this.groupSimilarParts(result.rows, 'similar_name_brand_group', 0.8);
+        } catch (error) {
+            console.warn('Trigram similarity not available, skipping similar name detection:', error.message);
+            return [];
+        }
+    }
+
+    async findTrigramSimilarDuplicates(query, limit, offset) {
+        const queryText = `
+            SELECT p1.part_id, p1.internal_sku, p1.display_name, p1.brand_name, p1.group_name,
+                   p1.tags, p1.created_at, p1.modified_at,
+                   similarity(p1.display_name, p2.display_name) as name_similarity
+            FROM parts_view p1
+            JOIN parts_view p2 ON p1.part_id < p2.part_id
+                AND similarity(p1.display_name, p2.display_name) > 0.7
+            WHERE p1.merged_into_part_id IS NULL
+                AND p2.merged_into_part_id IS NULL
+                AND ($1 = '' OR p1.display_name ILIKE $1 OR p1.internal_sku ILIKE $1)
+            ORDER BY name_similarity DESC, p1.part_id
+            LIMIT $2 OFFSET $3
+        `;
+
+        const params = [`%${query}%`, limit * 2, offset];
+
+        try {
+            const result = await this.db.query(queryText, params);
+            return this.groupSimilarParts(result.rows, 'similar_name_trigram', 0.7);
+        } catch (error) {
+            console.warn('Trigram similarity not available, skipping trigram detection:', error.message);
+            return [];
+        }
+    }
+
+    groupPartsByKey(rows, keyField, reason, score) {
+        const groups = new Map();
+
+        for (const row of rows) {
+            const key = row[keyField];
+            if (!groups.has(key)) {
+                groups.set(key, {
+                    groupId: `${reason}_${key}`,
+                    score,
+                    reasons: [reason],
+                    parts: []
+                });
+            }
+            groups.get(key).parts.push(this.formatPartData(row));
+        }
+
+        return Array.from(groups.values()).filter(group => group.parts.length > 1);
+    }
+
+    groupSimilarParts(rows, reason, score) {
+        const groups = [];
+        const processed = new Set();
+
+        for (const row of rows) {
+            if (processed.has(row.part_id)) continue;
+
+            const group = {
+                groupId: `${reason}_${row.part_id}`,
+                score: Math.min(score, row.name_similarity || score),
+                reasons: [reason],
+                parts: [this.formatPartData(row)]
+            };
+
+            // Find all similar parts for this group
+            for (const otherRow of rows) {
+                if (otherRow.part_id !== row.part_id &&
+                    !processed.has(otherRow.part_id) &&
+                    (otherRow.name_similarity || 0) >= score) {
+                    group.parts.push(this.formatPartData(otherRow));
+                    processed.add(otherRow.part_id);
+                }
+            }
+
+            if (group.parts.length > 1) {
+                groups.push(group);
+                processed.add(row.part_id);
+            }
+        }
+
+        return groups;
+    }
+
+    formatPartData(row) {
+        return {
+            part_id: row.part_id,
+            internal_sku: row.internal_sku,
+            display_name: row.display_name,
+            brand_name: row.brand_name,
+            group_name: row.group_name,
+            tags: row.tags,
+            created_at: row.created_at,
+            modified_at: row.modified_at
+        };
+    }
+
+    deduplicateGroups(groups) {
+        const seen = new Set();
+        const unique = [];
+
+        for (const group of groups) {
+            const partIds = group.parts.map(p => p.part_id).sort().join(',');
+            if (!seen.has(partIds)) {
+                seen.add(partIds);
+                unique.push(group);
+            }
+        }
+
+        return unique;
+    }
+
+    /**
+     * Search for parts that could be manually selected for merging
+     * @param {string} searchTerm - Search term
+     * @param {number} limit - Max results
+     * @returns {Array} Array of parts
+     */
+    async searchPartsForMerge(searchTerm, limit = 20) {
+        const queryText = `
+            SELECT part_id, internal_sku, display_name, brand_name, group_name,
+                   tags, created_at, modified_at
+            FROM parts_view
+            WHERE merged_into_part_id IS NULL
+                AND (display_name ILIKE $1 OR internal_sku ILIKE $1 OR detail ILIKE $1)
+            ORDER BY
+                CASE WHEN internal_sku ILIKE $1 THEN 1 ELSE 2 END,
+                CASE WHEN display_name ILIKE $1 THEN 1 ELSE 2 END,
+                modified_at DESC
+            LIMIT $2
+        `;
+
+        const result = await this.db.query(queryText, [`%${searchTerm}%`, limit]);
+        return result.rows.map(row => this.formatPartData(row));
+    }
+}
+
+module.exports = DuplicateFinder;

--- a/packages/api/routes/partMergeRoutes.js
+++ b/packages/api/routes/partMergeRoutes.js
@@ -197,10 +197,15 @@ router.post('/parts/merge/merge', protect, hasPermission('parts:merge'), async (
             });
         }
 
+        const finalRules = {
+            ...conflictResolutions,
+            preserveAliases
+        };
+
         const result = await partMergeService.executeMerge({
             keepPartId: targetPartIdInt,
             mergePartIds: sourcePartIdsInt,
-            rules: conflictResolutions
+            rules: finalRules
         }, req.user.employee_id);
 
         res.json({

--- a/packages/api/services/duplicateFinder.js
+++ b/packages/api/services/duplicateFinder.js
@@ -118,7 +118,8 @@ class DuplicateFinder {
     }
 
     async findOptimizedDuplicateGroups(options = {}) {
-        const { query = '', limit = 50, minScore = 0.50 } = options;
+        const { query = '', limit = 50 } = options;
+        const minScore = options.minScore !== undefined ? options.minScore : (options.minSimilarity !== undefined ? options.minSimilarity : 0.50);
 
         const duplicateGroups = [];
         const processedPairs = new Set();
@@ -242,7 +243,7 @@ class DuplicateFinder {
                 GROUP BY part_number
                 HAVING COUNT(DISTINCT part_id) > 1
             )
-            SELECT DISTINCT p.*,
+            SELECT p.*,
                    COALESCE(
                        (SELECT json_agg(jsonb_build_object('part_number', pn_inner.part_number))
                         FROM part_number pn_inner
@@ -306,7 +307,6 @@ class DuplicateFinder {
 
             const searchRes = await index.search(searchQuery, {
                 limit: 5,
-                filter: ['merged_into_part_id IS NULL'],
                 attributesToRetrieve: ['part_id']
             });
 

--- a/packages/api/services/duplicateFinder.js
+++ b/packages/api/services/duplicateFinder.js
@@ -63,6 +63,22 @@ class DuplicateFinder {
 
         const sharedPns = pns1.filter(pn => pns2.includes(pn));
 
+        const normalizeBrandName = (brand) => {
+            if (typeof brand !== 'string') return '';
+            return brand.trim().toLowerCase();
+        };
+
+        const normalizedBrand1 = normalizeBrandName(part1.brand_name);
+        const normalizedBrand2 = normalizeBrandName(part2.brand_name);
+
+        // Strict Brand Disqualification Rule:
+        // If both parts have explicitly defined brand names and they conflict,
+        // immediately disqualify the pair regardless of deterministic/fuzzy base score.
+        if (normalizedBrand1 && normalizedBrand2 && normalizedBrand1 !== normalizedBrand2) {
+            score = -1.0;
+            reasons.push('different_brands_disqualification');
+        }
+
         // Massive Penalty/Disqualification: Candidates have *different*, explicitly defined part numbers
         // Only penalize if BOTH have defined part numbers and they DO NOT share any.
         if (pns1.length > 0 && pns2.length > 0 && sharedPns.length === 0) {
@@ -76,8 +92,8 @@ class DuplicateFinder {
         }
 
         // Boost: Candidates share the same `brand` and `group`. (+0.30)
-        if (part1.brand_name && part2.brand_name && part1.group_name && part2.group_name) {
-            if (part1.brand_name === part2.brand_name && part1.group_name === part2.group_name) {
+        if (normalizedBrand1 && normalizedBrand2 && part1.group_name && part2.group_name) {
+            if (normalizedBrand1 === normalizedBrand2 && part1.group_name === part2.group_name) {
                 score += 0.30;
                 reasons.push('same_brand_and_group');
             }

--- a/packages/api/services/duplicateFinder.js
+++ b/packages/api/services/duplicateFinder.js
@@ -121,7 +121,9 @@ class DuplicateFinder {
         const { query = '', limit = 50 } = options;
         const minScore = options.minScore !== undefined ? options.minScore : (options.minSimilarity !== undefined ? options.minSimilarity : 0.50);
 
-        const duplicateGroups = [];
+        const adjacency = new Map();
+        const partById = new Map();
+        const edgeDetails = new Map();
         const processedPairs = new Set();
         
         // Helper to generate a unique pair ID regardless of order
@@ -130,32 +132,39 @@ class DuplicateFinder {
             return `${a}_${b}`;
         };
 
+        const addEdge = (pair, baseScore) => {
+            const part1Id = parseInt(pair.part1.part_id);
+            const part2Id = parseInt(pair.part2.part_id);
+            const pairId = getPairId(part1Id, part2Id);
+
+            if (processedPairs.has(pairId)) return;
+            processedPairs.add(pairId);
+
+            const { score, reasons } = this.constructor.calculateCompositeScore(pair.part1, pair.part2, baseScore);
+            if (score < minScore) return;
+
+            partById.set(part1Id, pair.part1);
+            partById.set(part2Id, pair.part2);
+
+            if (!adjacency.has(part1Id)) adjacency.set(part1Id, new Set());
+            if (!adjacency.has(part2Id)) adjacency.set(part2Id, new Set());
+            adjacency.get(part1Id).add(part2Id);
+            adjacency.get(part2Id).add(part1Id);
+
+            edgeDetails.set(pairId, {
+                score,
+                reasons: [...(pair.reasons || []), ...reasons]
+            });
+        };
+
         // Phase 1: Deterministic Blocking (The Fast Net)
         // Group items that share exact, distinct identifiers (internal_sku or part_number)
         const deterministicPairs = await this.findDeterministicPairs(query, limit);
         
         for (const pair of deterministicPairs) {
-            const pairId = getPairId(pair.part1.part_id, pair.part2.part_id);
-            if (!processedPairs.has(pairId)) {
-                processedPairs.add(pairId);
-
-                // Phase 3: Hierarchical Penalty & Boost Scoring
-                // Start with a high base score (0.80) because they are deterministic matches.
-                // The prompt says "Items matching in this phase should be immediately flagged as 'High Confidence'"
-                // If they share part number but have different brands, etc., it could drop, or boost to 1.0.
-                const baseScore = 0.80;
-                const { score, reasons } = this.constructor.calculateCompositeScore(pair.part1, pair.part2, baseScore);
-
-                if (score >= minScore) {
-                    duplicateGroups.push({
-                        groupId: `deterministic_${pairId}`,
-                        score,
-                        confidence: this.constructor.getConfidenceLevel(score),
-                        reasons: [...pair.reasons, ...reasons],
-                        parts: [pair.part1, pair.part2]
-                    });
-                }
-            }
+            // Phase 3: Hierarchical Penalty & Boost Scoring
+            // Start with a high base score (0.80) because they are deterministic matches.
+            addEdge(pair, 0.80);
         }
 
         // Phase 2: Semantic/Fuzzy Blocking (The Wide Net) using Meilisearch
@@ -163,33 +172,73 @@ class DuplicateFinder {
             const fuzzyPairs = await this.findFuzzyMeilisearchPairs(query, limit);
 
             for (const pair of fuzzyPairs) {
-                const pairId = getPairId(pair.part1.part_id, pair.part2.part_id);
-                if (!processedPairs.has(pairId)) {
-                    processedPairs.add(pairId);
-
-                    // Phase 3: Hierarchical Penalty & Boost Scoring
-                    // Base score for a Meilisearch fuzzy match.
-                    const baseScore = 0.40;
-                    const { score, reasons } = this.constructor.calculateCompositeScore(pair.part1, pair.part2, baseScore);
-
-                    if (score >= minScore) {
-                        duplicateGroups.push({
-                            groupId: `fuzzy_${pairId}`,
-                            score,
-                            confidence: this.constructor.getConfidenceLevel(score),
-                            reasons: [...pair.reasons, ...reasons],
-                            parts: [pair.part1, pair.part2]
-                        });
-                    }
-                }
+                // Phase 3: Hierarchical Penalty & Boost Scoring
+                // Base score for a Meilisearch fuzzy match.
+                addEdge(pair, 0.40);
             }
         } catch (error) {
             console.error('Meilisearch fuzzy blocking failed, falling back/skipping:', error);
         }
 
-        // Deduplicate and sort by confidence score
-        const uniqueGroups = this.deduplicateGroups(duplicateGroups);
-        return uniqueGroups.sort((a, b) => b.score - a.score).slice(0, limit);
+        // Extract connected components (O(V+E))
+        const duplicateGroups = [];
+        const visited = new Set();
+
+        for (const partId of adjacency.keys()) {
+            if (visited.has(partId)) continue;
+
+            const stack = [partId];
+            const componentIds = [];
+            visited.add(partId);
+
+            while (stack.length > 0) {
+                const current = stack.pop();
+                componentIds.push(current);
+
+                for (const neighbor of adjacency.get(current) || []) {
+                    if (!visited.has(neighbor)) {
+                        visited.add(neighbor);
+                        stack.push(neighbor);
+                    }
+                }
+            }
+
+            if (componentIds.length <= 1) continue;
+
+            const componentSet = new Set(componentIds);
+            const componentParts = componentIds
+                .map(id => partById.get(id))
+                .filter(Boolean);
+
+            const componentScores = [];
+            const componentReasons = new Set();
+
+            for (const edgeId of edgeDetails.keys()) {
+                const [aStr, bStr] = edgeId.split('_');
+                const a = parseInt(aStr);
+                const b = parseInt(bStr);
+                if (!componentSet.has(a) || !componentSet.has(b)) continue;
+
+                const edge = edgeDetails.get(edgeId);
+                componentScores.push(edge.score);
+                for (const reason of edge.reasons) componentReasons.add(reason);
+            }
+
+            if (componentScores.length === 0) continue;
+
+            const averageScore = componentScores.reduce((sum, val) => sum + val, 0) / componentScores.length;
+            const normalizedIds = [...componentIds].sort((a, b) => a - b).join('_');
+
+            duplicateGroups.push({
+                groupId: `component_${normalizedIds}`,
+                score: averageScore,
+                confidence: this.constructor.getConfidenceLevel(averageScore),
+                reasons: Array.from(componentReasons),
+                parts: componentParts
+            });
+        }
+
+        return duplicateGroups.sort((a, b) => b.score - a.score).slice(0, limit);
     }
 
     async findDeterministicPairs(query, limit) {

--- a/packages/api/services/duplicateFinder.js
+++ b/packages/api/services/duplicateFinder.js
@@ -1,5 +1,10 @@
+const { meiliClient } = require('../meilisearch');
+
 /**
- * Service for finding potential duplicate parts
+ * Service for finding potential duplicate parts using Cascade Record Linkage
+ * Phase 1: Deterministic Blocking (SQL)
+ * Phase 2: Semantic/Fuzzy Blocking (Meilisearch)
+ * Phase 3: Hierarchical Penalty & Boost Scoring
  */
 class DuplicateFinder {
     constructor(db) {
@@ -18,14 +23,6 @@ class DuplicateFinder {
             .trim();
     }
 
-    static tokenizeAndSort(text) {
-        if (!text) return [];
-        return this.normalizeText(text)
-            .split(/\s+/)
-            .filter(word => word.length > 1) // ignore single chars
-            .sort();
-    }
-
     static normalizePartNumber(pn) {
         if (!pn) return '';
         return pn.replace(/[^a-zA-Z0-9]/g, '').toUpperCase();
@@ -37,9 +34,11 @@ class DuplicateFinder {
         return matches.map(m => parseInt(m)).filter(n => !isNaN(n));
     }
 
-    // Composite scoring for optimized finder
-    static calculateCompositeScore(part1, part2, detailSim = 0, nameSim = 0) {
-        let score = 0;
+    /**
+     * Phase 3: Hierarchical Penalty & Boost Scoring
+     */
+    static calculateCompositeScore(part1, part2, baseScore = 0) {
+        let score = baseScore;
         const reasons = [];
 
         // Normalize fields
@@ -48,261 +47,314 @@ class DuplicateFinder {
         const name1 = this.normalizeText(part1.display_name || '');
         const name2 = this.normalizeText(part2.display_name || '');
 
-        // Shared part numbers: +0.60
-        const pns1 = (part1.part_numbers || []).map(pn => this.normalizePartNumber(pn.part_number));
-        const pns2 = (part2.part_numbers || []).map(pn => this.normalizePartNumber(pn.part_number));
+        // Ensure part numbers are mapped as strings, handling both formats
+        const getPns = (part) => {
+            const pns = part.part_numbers || part.part_numbers_array || [];
+            if (!Array.isArray(pns)) return [];
+            return pns.map(p => {
+                if (typeof p === 'string') return p;
+                if (p && p.part_number) return p.part_number;
+                return '';
+            }).filter(Boolean);
+        };
+
+        const pns1 = getPns(part1).map(pn => this.normalizePartNumber(pn));
+        const pns2 = getPns(part2).map(pn => this.normalizePartNumber(pn));
+
         const sharedPns = pns1.filter(pn => pns2.includes(pn));
-        if (sharedPns.length > 0) {
-            score += 0.60;
-            reasons.push('shared_part_number');
+
+        // Massive Penalty/Disqualification: Candidates have *different*, explicitly defined part numbers
+        // Only penalize if BOTH have defined part numbers and they DO NOT share any.
+        if (pns1.length > 0 && pns2.length > 0 && sharedPns.length === 0) {
+            score -= 0.80;
+            reasons.push('different_part_numbers_penalty');
+        } else if (sharedPns.length > 0) {
+            // Give a boost if they share part numbers but only if it's not already accounted for
+            // We'll give a small boost for shared part numbers to maintain logic,
+            // though phase 1 might have already found it.
+            score += 0.10;
         }
 
-        // Detail trigram similarity: +0.25 * similarity
-        if (detailSim > 0.7) {
-            score += 0.25 * detailSim;
-            reasons.push('similar_detail');
+        // Boost: Candidates share the same `brand` and `group`. (+0.30)
+        if (part1.brand_name && part2.brand_name && part1.group_name && part2.group_name) {
+            if (part1.brand_name === part2.brand_name && part1.group_name === part2.group_name) {
+                score += 0.30;
+                reasons.push('same_brand_and_group');
+            }
         }
 
-        // Name trigram similarity: +0.10 * similarity
-        if (nameSim > 0.8) {
-            score += 0.10 * nameSim;
-            reasons.push('similar_name');
-        }
-
-        // Numeric token overlap: +0.05 * (overlap / max)
+        // Boost: Extracted numeric tokens match exactly (+0.20)
         const nums1 = this.extractNumericTokens(detail1 + ' ' + name1);
         const nums2 = this.extractNumericTokens(detail2 + ' ' + name2);
-        const overlap = nums1.filter(n => nums2.includes(n)).length;
-        const maxLen = Math.max(nums1.length, nums2.length);
-        if (maxLen > 0) {
-            score += 0.05 * (overlap / maxLen);
-            if (overlap > 0) reasons.push('numeric_overlap');
+        if (nums1.length > 0 && nums2.length > 0) {
+            const sortedNums1 = [...nums1].sort().join(',');
+            const sortedNums2 = [...nums2].sort().join(',');
+            if (sortedNums1 === sortedNums2) {
+                score += 0.20;
+                reasons.push('numeric_tokens_match');
+            }
         }
 
-        return { score: Math.min(score, 1.0), reasons };
+        return { score: Math.max(-1.0, Math.min(score, 1.0)), reasons };
     }
 
     // Map score to confidence level
     static getConfidenceLevel(score) {
         if (score >= 0.85) return 'High';
         if (score >= 0.70) return 'Medium';
-        if (score >= 0.60) return 'Low';
+        if (score >= 0.50) return 'Low';
         return 'Very Low';
     }
 
     /**
-     * Optimized duplicate finder with confidence scoring
-     */
-    async findOptimizedDuplicateGroups(options = {}) {
-        const { minScore = 0.6, limit = 50 } = options;
-
-        // Query to find candidate pairs within same brand/group
-        const queryText = `
-            SELECT p1.part_id as part1_id, p1.internal_sku as part1_sku, p1.display_name as part1_name, p1.detail as part1_detail,
-                   p1.brand_name as part1_brand, p1.group_name as part1_group,
-                   p2.part_id as part2_id, p2.internal_sku as part2_sku, p2.display_name as part2_name, p2.detail as part2_detail,
-                   p2.brand_name as part2_brand, p2.group_name as part2_group,
-                   CASE WHEN pn1.part_number IS NOT NULL AND pn2.part_number IS NOT NULL THEN 1 ELSE 0 END as shared_pn,
-                   COALESCE((SELECT json_agg(jsonb_build_object('part_number', pn.part_number)) FROM part_number pn WHERE pn.part_id = p1.part_id AND pn.deleted_at IS NULL), '[]'::json) as p1_part_numbers,
-                   COALESCE((SELECT json_agg(jsonb_build_object('part_number', pn.part_number)) FROM part_number pn WHERE pn.part_id = p2.part_id AND pn.deleted_at IS NULL), '[]'::json) as p2_part_numbers,
-                   similarity(p1.detail, p2.detail) as detail_sim,
-                   similarity(p1.display_name, p2.display_name) as name_sim
-            FROM parts_view p1
-            JOIN parts_view p2 ON p1.part_id < p2.part_id 
-                AND p1.brand_name = p2.brand_name 
-                AND p1.group_name = p2.group_name
-            LEFT JOIN part_number pn1 ON p1.part_id = pn1.part_id AND pn1.deleted_at IS NULL
-            LEFT JOIN part_number pn2 ON p2.part_id = pn2.part_id AND pn2.deleted_at IS NULL AND pn1.part_number = pn2.part_number
-            WHERE p1.merged_into_part_id IS NULL 
-                AND p2.merged_into_part_id IS NULL
-                AND (pn1.part_number IS NOT NULL OR similarity(p1.detail, p2.detail) > 0.7 OR similarity(p1.display_name, p2.display_name) > 0.7)
-            ORDER BY (CASE WHEN pn1.part_number IS NOT NULL THEN 1 ELSE 0 END) DESC, 
-                     GREATEST(similarity(p1.detail, p2.detail), similarity(p1.display_name, p2.display_name)) DESC
-            LIMIT $1
-        `;
-
-        const result = await this.db.query(queryText, [limit * 10]); // get more candidates
-
-        const groups = [];
-        const processed = new Set();
-
-        for (const row of result.rows) {
-            if (processed.has(row.part1_id) || processed.has(row.part2_id)) continue;
-
-            const part1 = {
-                part_id: row.part1_id,
-                internal_sku: row.part1_sku,
-                display_name: row.part1_name,
-                detail: row.part1_detail,
-                brand_name: row.part1_brand,
-                group_name: row.part1_group,
-                part_numbers: row.p1_part_numbers
-            };
-            const part2 = {
-                part_id: row.part2_id,
-                internal_sku: row.part2_sku,
-                display_name: row.part2_name,
-                detail: row.part2_detail,
-                brand_name: row.part2_brand,
-                group_name: row.part2_group,
-                part_numbers: row.p2_part_numbers
-            };
-
-            const { score, reasons } = this.constructor.calculateCompositeScore(part1, part2, row.detail_sim, row.name_sim);
-
-            if (score >= minScore) {
-                const group = {
-                    groupId: `opt_${row.part1_id}_${row.part2_id}`,
-                    score,
-                    confidence: this.constructor.getConfidenceLevel(score),
-                    reasons,
-                    parts: [this.formatPartData(part1), this.formatPartData(part2)]
-                };
-                groups.push(group);
-                processed.add(row.part1_id);
-                processed.add(row.part2_id);
-            }
-        }
-
-        return groups.slice(0, limit);
-    }
-
-    /**
-     * Find groups of potentially duplicate parts
+     * Find groups of potentially duplicate parts using the cascade strategy
      * @param {Object} options - Search options
      * @param {string} options.query - Optional search query to filter parts
      * @param {number} options.limit - Maximum number of groups to return
-     * @param {number} options.offset - Offset for pagination
-     * @param {string} options.strategy - Detection strategy ('auto', 'strict', 'loose')
      * @returns {Array} Array of duplicate groups
      */
     async findDuplicateGroups(options = {}) {
-        const { query = '', limit = 50, offset = 0, strategy = 'auto' } = options;
-        
+        return this.findOptimizedDuplicateGroups(options);
+    }
+
+    async findOptimizedDuplicateGroups(options = {}) {
+        const { query = '', limit = 50, minScore = 0.50 } = options;
+
         const duplicateGroups = [];
+        const processedPairs = new Set();
         
-        // Strategy 1: Exact SKU matches (different parts with same SKU - shouldn't happen but might)
-        const skuDuplicates = await this.findSkuDuplicates(query, limit, offset);
-        duplicateGroups.push(...skuDuplicates);
+        // Helper to generate a unique pair ID regardless of order
+        const getPairId = (id1, id2) => {
+            const [a, b] = [parseInt(id1), parseInt(id2)].sort((x, y) => x - y);
+            return `${a}_${b}`;
+        };
+
+        // Phase 1: Deterministic Blocking (The Fast Net)
+        // Group items that share exact, distinct identifiers (internal_sku or part_number)
+        const deterministicPairs = await this.findDeterministicPairs(query, limit);
         
-        // Strategy 2: Exact part number overlaps
-        const partNumberDuplicates = await this.findPartNumberDuplicates(query, limit, offset);
-        duplicateGroups.push(...partNumberDuplicates);
-        
-        // Strategy 3: Similar names within same brand/group
-        const nameDuplicates = await this.findSimilarNameDuplicates(query, limit, offset, strategy);
-        duplicateGroups.push(...nameDuplicates);
-        
-        // Strategy 4: Very similar display names (trigram similarity)
-        if (strategy === 'auto' || strategy === 'loose') {
-            const trigramDuplicates = await this.findTrigramSimilarDuplicates(query, limit, offset);
-            duplicateGroups.push(...trigramDuplicates);
+        for (const pair of deterministicPairs) {
+            const pairId = getPairId(pair.part1.part_id, pair.part2.part_id);
+            if (!processedPairs.has(pairId)) {
+                processedPairs.add(pairId);
+
+                // Phase 3: Hierarchical Penalty & Boost Scoring
+                // Start with a high base score (0.80) because they are deterministic matches.
+                // The prompt says "Items matching in this phase should be immediately flagged as 'High Confidence'"
+                // If they share part number but have different brands, etc., it could drop, or boost to 1.0.
+                const baseScore = 0.80;
+                const { score, reasons } = this.constructor.calculateCompositeScore(pair.part1, pair.part2, baseScore);
+
+                if (score >= minScore) {
+                    duplicateGroups.push({
+                        groupId: `deterministic_${pairId}`,
+                        score,
+                        confidence: this.constructor.getConfidenceLevel(score),
+                        reasons: [...pair.reasons, ...reasons],
+                        parts: [pair.part1, pair.part2]
+                    });
+                }
+            }
         }
-        
+
+        // Phase 2: Semantic/Fuzzy Blocking (The Wide Net) using Meilisearch
+        try {
+            const fuzzyPairs = await this.findFuzzyMeilisearchPairs(query, limit);
+
+            for (const pair of fuzzyPairs) {
+                const pairId = getPairId(pair.part1.part_id, pair.part2.part_id);
+                if (!processedPairs.has(pairId)) {
+                    processedPairs.add(pairId);
+
+                    // Phase 3: Hierarchical Penalty & Boost Scoring
+                    // Base score for a Meilisearch fuzzy match.
+                    const baseScore = 0.40;
+                    const { score, reasons } = this.constructor.calculateCompositeScore(pair.part1, pair.part2, baseScore);
+
+                    if (score >= minScore) {
+                        duplicateGroups.push({
+                            groupId: `fuzzy_${pairId}`,
+                            score,
+                            confidence: this.constructor.getConfidenceLevel(score),
+                            reasons: [...pair.reasons, ...reasons],
+                            parts: [pair.part1, pair.part2]
+                        });
+                    }
+                }
+            }
+        } catch (error) {
+            console.error('Meilisearch fuzzy blocking failed, falling back/skipping:', error);
+        }
+
         // Deduplicate and sort by confidence score
         const uniqueGroups = this.deduplicateGroups(duplicateGroups);
         return uniqueGroups.sort((a, b) => b.score - a.score).slice(0, limit);
     }
 
-    async findSkuDuplicates(query, limit, offset) {
-        const queryText = `
-            SELECT p1.part_id, p1.internal_sku, p1.display_name, p1.brand_name, p1.group_name,
-                   p1.tags, p1.created_at, p1.modified_at
-            FROM parts_view p1
-            JOIN parts_view p2 ON p1.internal_sku = p2.internal_sku 
-                AND p1.part_id != p2.part_id
-            WHERE p1.merged_into_part_id IS NULL 
-                AND p2.merged_into_part_id IS NULL
-                AND ($1 = '' OR p1.display_name ILIKE $1 OR p1.internal_sku ILIKE $1)
-            ORDER BY p1.internal_sku, p1.part_id
-            LIMIT $2 OFFSET $3
+    async findDeterministicPairs(query, limit) {
+        const pairs = [];
+        
+        // Deterministic by internal_sku
+        const skuQueryText = `
+            WITH duplicated_skus AS (
+                SELECT internal_sku
+                FROM part
+                WHERE merged_into_part_id IS NULL AND internal_sku IS NOT NULL AND internal_sku != ''
+                GROUP BY internal_sku
+                HAVING COUNT(*) > 1
+            )
+            SELECT p.*,
+                   COALESCE(
+                       (SELECT json_agg(jsonb_build_object('part_number', pn.part_number))
+                        FROM part_number pn
+                        WHERE pn.part_id = p.part_id AND pn.deleted_at IS NULL),
+                   '[]'::json) as part_numbers_array
+            FROM parts_view p
+            JOIN duplicated_skus ds ON p.internal_sku = ds.internal_sku
+            WHERE p.merged_into_part_id IS NULL
+              AND ($1 = '' OR p.display_name ILIKE $1 OR p.internal_sku ILIKE $1)
+            ORDER BY p.internal_sku, p.part_id
+            LIMIT $2
         `;
         
-        const params = [`%${query}%`, limit * 2, offset];
-        const result = await this.db.query(queryText, params);
+        const skuResult = await this.db.query(skuQueryText, [`%${query}%`, limit * 5]);
+        const skuGroups = this.groupPartsByKey(skuResult.rows, 'internal_sku', 'exact_internal_sku');
         
-        return this.groupPartsByKey(result.rows, 'internal_sku', 'exact_sku', 1.0);
-    }
-
-    async findPartNumberDuplicates(query, limit, offset) {
-        const queryText = `
-            SELECT DISTINCT p1.part_id, p1.internal_sku, p1.display_name, p1.brand_name, p1.group_name,
-                   p1.tags, p1.created_at, p1.modified_at, pn1.part_number
-            FROM parts_view p1
-            JOIN part_number pn1 ON p1.part_id = pn1.part_id
-            JOIN part_number pn2 ON pn1.part_number = pn2.part_number 
-                AND pn1.part_id != pn2.part_id
-            JOIN parts_view p2 ON pn2.part_id = p2.part_id
-            WHERE p1.merged_into_part_id IS NULL 
-                AND p2.merged_into_part_id IS NULL
-                AND ($1 = '' OR p1.display_name ILIKE $1 OR p1.internal_sku ILIKE $1)
-            ORDER BY pn1.part_number, p1.part_id
-            LIMIT $2 OFFSET $3
-        `;
-        
-        const params = [`%${query}%`, limit * 2, offset];
-        const result = await this.db.query(queryText, params);
-        
-        return this.groupPartsByKey(result.rows, 'part_number', 'shared_part_number', 0.9);
-    }
-
-    async findSimilarNameDuplicates(query, limit, offset, strategy) {
-        const similarityThreshold = strategy === 'strict' ? 0.9 : 0.8;
-        
-        const queryText = `
-            SELECT p1.part_id, p1.internal_sku, p1.display_name, p1.brand_name, p1.group_name,
-                   p1.tags, p1.created_at, p1.modified_at,
-                   similarity(p1.display_name, p2.display_name) as name_similarity
-            FROM parts_view p1
-            JOIN parts_view p2 ON p1.part_id < p2.part_id 
-                AND p1.brand_name = p2.brand_name 
-                AND p1.group_name = p2.group_name
-                AND similarity(p1.display_name, p2.display_name) > $4
-            WHERE p1.merged_into_part_id IS NULL 
-                AND p2.merged_into_part_id IS NULL
-                AND ($1 = '' OR p1.display_name ILIKE $1 OR p1.internal_sku ILIKE $1)
-            ORDER BY name_similarity DESC, p1.part_id
-            LIMIT $2 OFFSET $3
-        `;
-        
-        const params = [`%${query}%`, limit * 2, offset, similarityThreshold];
-        
-        try {
-            const result = await this.db.query(queryText, params);
-            return this.groupSimilarParts(result.rows, 'similar_name_brand_group', 0.8);
-        } catch (error) {
-            console.warn('Trigram similarity not available, skipping similar name detection:', error.message);
-            return [];
+        for (const group of skuGroups) {
+            const parts = group.parts;
+            for (let i = 0; i < parts.length; i++) {
+                for (let j = i + 1; j < parts.length; j++) {
+                    pairs.push({
+                        part1: parts[i],
+                        part2: parts[j],
+                        reasons: ['exact_internal_sku']
+                    });
+                }
+            }
         }
-    }
 
-    async findTrigramSimilarDuplicates(query, limit, offset) {
-        const queryText = `
-            SELECT p1.part_id, p1.internal_sku, p1.display_name, p1.brand_name, p1.group_name,
-                   p1.tags, p1.created_at, p1.modified_at,
-                   similarity(p1.display_name, p2.display_name) as name_similarity
-            FROM parts_view p1
-            JOIN parts_view p2 ON p1.part_id < p2.part_id 
-                AND similarity(p1.display_name, p2.display_name) > 0.7
-            WHERE p1.merged_into_part_id IS NULL 
-                AND p2.merged_into_part_id IS NULL
-                AND ($1 = '' OR p1.display_name ILIKE $1 OR p1.internal_sku ILIKE $1)
-            ORDER BY name_similarity DESC, p1.part_id
-            LIMIT $2 OFFSET $3
+        // Deterministic by part_number
+        const pnQueryText = `
+            WITH duplicated_pns AS (
+                SELECT part_number
+                FROM part_number
+                WHERE deleted_at IS NULL AND part_number IS NOT NULL AND part_number != ''
+                GROUP BY part_number
+                HAVING COUNT(DISTINCT part_id) > 1
+            )
+            SELECT DISTINCT p.*,
+                   COALESCE(
+                       (SELECT json_agg(jsonb_build_object('part_number', pn_inner.part_number))
+                        FROM part_number pn_inner
+                        WHERE pn_inner.part_id = p.part_id AND pn_inner.deleted_at IS NULL),
+                   '[]'::json) as part_numbers_array,
+                   dpn.part_number as matching_part_number
+            FROM parts_view p
+            JOIN part_number pn ON p.part_id = pn.part_id AND pn.deleted_at IS NULL
+            JOIN duplicated_pns dpn ON pn.part_number = dpn.part_number
+            WHERE p.merged_into_part_id IS NULL
+              AND ($1 = '' OR p.display_name ILIKE $1 OR p.internal_sku ILIKE $1)
+            ORDER BY dpn.part_number, p.part_id
+            LIMIT $2
         `;
         
-        const params = [`%${query}%`, limit * 2, offset];
+        const pnResult = await this.db.query(pnQueryText, [`%${query}%`, limit * 5]);
+        const pnGroups = this.groupPartsByKey(pnResult.rows, 'matching_part_number', 'exact_part_number');
         
-        try {
-            const result = await this.db.query(queryText, params);
-            return this.groupSimilarParts(result.rows, 'similar_name_trigram', 0.7);
-        } catch (error) {
-            console.warn('Trigram similarity not available, skipping trigram detection:', error.message);
-            return [];
+        for (const group of pnGroups) {
+            const parts = group.parts;
+            for (let i = 0; i < parts.length; i++) {
+                for (let j = i + 1; j < parts.length; j++) {
+                    pairs.push({
+                        part1: parts[i],
+                        part2: parts[j],
+                        reasons: ['exact_part_number']
+                    });
+                }
+            }
         }
+
+        return pairs;
     }
 
-    groupPartsByKey(rows, keyField, reason, score) {
+    async findFuzzyMeilisearchPairs(query, limit) {
+        const baseQueryText = `
+            SELECT p.*,
+                   COALESCE(
+                       (SELECT json_agg(jsonb_build_object('part_number', pn.part_number))
+                        FROM part_number pn
+                        WHERE pn.part_id = p.part_id AND pn.deleted_at IS NULL),
+                   '[]'::json) as part_numbers_array
+            FROM parts_view p
+            WHERE p.merged_into_part_id IS NULL
+              AND ($1 = '' OR p.display_name ILIKE $1 OR p.internal_sku ILIKE $1 OR p.detail ILIKE $1)
+            ORDER BY p.modified_at DESC
+            LIMIT $2
+        `;
+        
+        const baseResult = await this.db.query(baseQueryText, [`%${query}%`, limit]);
+        const candidates = baseResult.rows;
+        
+        const pairs = [];
+        const index = meiliClient.index('parts');
+        const rawHitsByCandidate = [];
+        const allHitIds = new Set();
+
+        for (const candidate of candidates) {
+            const searchQuery = candidate.display_name || candidate.internal_sku || '';
+            if (!searchQuery) continue;
+
+            const searchRes = await index.search(searchQuery, {
+                limit: 5,
+                filter: ['merged_into_part_id IS NULL'],
+                attributesToRetrieve: ['part_id']
+            });
+
+            const hitIds = searchRes.hits.map(h => h.part_id).filter(id => id !== candidate.part_id);
+            if (hitIds.length > 0) {
+                rawHitsByCandidate.push({ candidate, hitIds });
+                hitIds.forEach(id => allHitIds.add(id));
+            }
+        }
+
+        // Proactive Edge Case Handling: Fetch up-to-date data from DB for all Meilisearch hits
+        // This ensures we don't present stale data (e.g. recently merged parts) if Meili sync is lagging.
+        const upToDateHits = new Map();
+        if (allHitIds.size > 0) {
+            const idsArray = Array.from(allHitIds);
+            const hitsQuery = `
+                SELECT p.*,
+                       COALESCE(
+                           (SELECT json_agg(jsonb_build_object('part_number', pn.part_number))
+                            FROM part_number pn
+                            WHERE pn.part_id = p.part_id AND pn.deleted_at IS NULL),
+                       '[]'::json) as part_numbers_array
+                FROM parts_view p
+                WHERE p.part_id = ANY($1) AND p.merged_into_part_id IS NULL
+            `;
+            const hitsResult = await this.db.query(hitsQuery, [idsArray]);
+            for (const row of hitsResult.rows) {
+                upToDateHits.set(row.part_id, row);
+            }
+        }
+
+        for (const { candidate, hitIds } of rawHitsByCandidate) {
+            for (const hitId of hitIds) {
+                const freshHit = upToDateHits.get(hitId);
+                if (freshHit) {
+                    pairs.push({
+                        part1: this.formatPartData(candidate),
+                        part2: this.formatPartData(freshHit),
+                        reasons: ['meilisearch_fuzzy_match']
+                    });
+                }
+            }
+        }
+
+        return pairs;
+    }
+
+    groupPartsByKey(rows, keyField, reason) {
         const groups = new Map();
         
         for (const row of rows) {
@@ -310,7 +362,6 @@ class DuplicateFinder {
             if (!groups.has(key)) {
                 groups.set(key, {
                     groupId: `${reason}_${key}`,
-                    score,
                     reasons: [reason],
                     parts: []
                 });
@@ -321,49 +372,18 @@ class DuplicateFinder {
         return Array.from(groups.values()).filter(group => group.parts.length > 1);
     }
 
-    groupSimilarParts(rows, reason, score) {
-        const groups = [];
-        const processed = new Set();
-        
-        for (const row of rows) {
-            if (processed.has(row.part_id)) continue;
-            
-            const group = {
-                groupId: `${reason}_${row.part_id}`,
-                score: Math.min(score, row.name_similarity || score),
-                reasons: [reason],
-                parts: [this.formatPartData(row)]
-            };
-            
-            // Find all similar parts for this group
-            for (const otherRow of rows) {
-                if (otherRow.part_id !== row.part_id && 
-                    !processed.has(otherRow.part_id) &&
-                    (otherRow.name_similarity || 0) >= score) {
-                    group.parts.push(this.formatPartData(otherRow));
-                    processed.add(otherRow.part_id);
-                }
-            }
-            
-            if (group.parts.length > 1) {
-                groups.push(group);
-                processed.add(row.part_id);
-            }
-        }
-        
-        return groups;
-    }
-
     formatPartData(row) {
         return {
             part_id: row.part_id,
             internal_sku: row.internal_sku,
             display_name: row.display_name,
+            detail: row.detail,
             brand_name: row.brand_name,
             group_name: row.group_name,
-            tags: row.tags,
-            created_at: row.created_at,
-            modified_at: row.modified_at
+            tags: row.tags || '',
+            created_at: row.created_at || row.date_created,
+            modified_at: row.modified_at || row.date_modified,
+            part_numbers: row.part_numbers_array || row.part_numbers || []
         };
     }
 
@@ -372,7 +392,7 @@ class DuplicateFinder {
         const unique = [];
         
         for (const group of groups) {
-            const partIds = group.parts.map(p => p.part_id).sort().join(',');
+            const partIds = group.parts.map(p => parseInt(p.part_id)).sort((a,b) => a-b).join(',');
             if (!seen.has(partIds)) {
                 seen.add(partIds);
                 unique.push(group);
@@ -390,8 +410,8 @@ class DuplicateFinder {
      */
     async searchPartsForMerge(searchTerm, limit = 20) {
         const queryText = `
-            SELECT part_id, internal_sku, display_name, brand_name, group_name, 
-                   tags, created_at, modified_at
+            SELECT part_id, internal_sku, display_name, brand_name, group_name, detail,
+                   date_created as created_at, date_modified as modified_at
             FROM parts_view
             WHERE merged_into_part_id IS NULL
                 AND (display_name ILIKE $1 OR internal_sku ILIKE $1 OR detail ILIKE $1)

--- a/packages/api/services/duplicateFinder.js
+++ b/packages/api/services/duplicateFinder.js
@@ -103,6 +103,8 @@ class DuplicateFinder {
                    p2.part_id as part2_id, p2.internal_sku as part2_sku, p2.display_name as part2_name, p2.detail as part2_detail,
                    p2.brand_name as part2_brand, p2.group_name as part2_group,
                    CASE WHEN pn1.part_number IS NOT NULL AND pn2.part_number IS NOT NULL THEN 1 ELSE 0 END as shared_pn,
+                   COALESCE((SELECT json_agg(jsonb_build_object('part_number', pn.part_number)) FROM part_number pn WHERE pn.part_id = p1.part_id AND pn.deleted_at IS NULL), '[]'::json) as p1_part_numbers,
+                   COALESCE((SELECT json_agg(jsonb_build_object('part_number', pn.part_number)) FROM part_number pn WHERE pn.part_id = p2.part_id AND pn.deleted_at IS NULL), '[]'::json) as p2_part_numbers,
                    similarity(p1.detail, p2.detail) as detail_sim,
                    similarity(p1.display_name, p2.display_name) as name_sim
             FROM parts_view p1
@@ -134,7 +136,7 @@ class DuplicateFinder {
                 detail: row.part1_detail,
                 brand_name: row.part1_brand,
                 group_name: row.part1_group,
-                part_numbers: [] // placeholder, need to fetch
+                part_numbers: row.p1_part_numbers
             };
             const part2 = {
                 part_id: row.part2_id,
@@ -143,16 +145,8 @@ class DuplicateFinder {
                 detail: row.part2_detail,
                 brand_name: row.part2_brand,
                 group_name: row.part2_group,
-                part_numbers: [] // placeholder
+                part_numbers: row.p2_part_numbers
             };
-
-            // Fetch part numbers for scoring
-            const pnQuery = `SELECT part_id, part_number FROM part_number WHERE part_id IN ($1, $2) AND deleted_at IS NULL`;
-            const pnResult = await this.db.query(pnQuery, [row.part1_id, row.part2_id]);
-            pnResult.rows.forEach(pn => {
-                if (pn.part_id === row.part1_id) part1.part_numbers.push({ part_number: pn.part_number });
-                else part2.part_numbers.push({ part_number: pn.part_number });
-            });
 
             const { score, reasons } = this.constructor.calculateCompositeScore(part1, part2, row.detail_sim, row.name_sim);
 

--- a/packages/api/services/partMergeService.js
+++ b/packages/api/services/partMergeService.js
@@ -77,7 +77,7 @@ class PartMergeService {
             const resolvedPart = this.calculateResolvedPart(keepPart, mergeParts, rules);
             
             // Update the keep part with merged data
-            await this.updateKeepPart(client, keepPartId, resolvedPart, rules);
+            await this.updateKeepPart(client, keepPartId, keepPart, mergeParts, rules);
             
             // Merge child records (part_numbers, applications, etc.)
             const childUpdateCounts = await this.mergeChildRecords(client, keepPartId, mergePartIds, rules);
@@ -89,7 +89,9 @@ class PartMergeService {
             const inventoryUpdateCounts = await this.consolidateInventory(client, keepPartId, mergePartIds);
             
             // Create aliases for old SKUs/part numbers
-            await this.createAliases(client, keepPartId, mergeParts, rules);
+            if (rules.preserveAliases !== false) {
+                await this.createAliases(client, keepPartId, mergeParts, rules);
+            }
             
             // Mark source parts as merged
             await this.markPartsAsMerged(client, mergePartIds, keepPartId);
@@ -357,7 +359,7 @@ class PartMergeService {
         );
     }
 
-    async updateKeepPart(client, keepPartId, resolvedPart, rules) {
+    async updateKeepPart(client, keepPartId, keepPart, mergeParts, rules) {
         const updateFields = [];
         const params = [keepPartId];
         let paramIndex = 2;
@@ -372,16 +374,34 @@ class PartMergeService {
                 brand_id: 'brand_id',
                 group_id: 'group_id',
                 is_active: 'is_active',
+                is_service: 'is_service',
                 cost_price: 'last_cost',
                 sale_price: 'last_sale_price',
                 internal_sku: 'internal_sku',
                 tax_rate_id: 'tax_rate_id'
             };
+            // Ensure field overrides actually match a part being merged
             for (const [field, value] of Object.entries(rules.fieldOverrides)) {
                 if (fieldMap[field]) {
-                    updateFields.push(`${fieldMap[field]} = $${paramIndex}`);
-                    params.push(value);
-                    paramIndex++;
+                    // Make sure the value actually exists on keepPart or mergeParts
+                    // Special case for boolean overrides since they aren't part-specific ID swaps
+                    let isValueValid = false;
+                    if (typeof value === 'boolean') {
+                        isValueValid = true;
+                    } else if (field === 'brand_id' || field === 'group_id' || field === 'tax_rate_id') {
+                        // For IDs, check if any of the merged parts or the keep part has this value
+                        isValueValid = (keepPart[fieldMap[field]] === value) ||
+                            mergeParts.some(p => p[fieldMap[field]] === value);
+                    } else {
+                        // For other fields like string and numbers
+                        isValueValid = true;
+                    }
+
+                    if (isValueValid) {
+                        updateFields.push(`${fieldMap[field]} = $${paramIndex}`);
+                        params.push(value);
+                        paramIndex++;
+                    }
                 }
             }
         }
@@ -414,12 +434,14 @@ class PartMergeService {
             counts.part_numbers = result.rowCount;
             // Remove duplicates after reassignment using unique(part_id, part_number)
             await client.query(`
-                DELETE FROM part_number pn
-                USING part_number pn2
+                UPDATE part_number pn
+                SET deleted_at = NOW()
+                FROM part_number pn2
                 WHERE pn.part_id = $1
                   AND pn.part_id = pn2.part_id
                   AND pn.part_number = pn2.part_number
                   AND pn.part_number_id > pn2.part_number_id
+                  AND pn.deleted_at IS NULL
             `, [keepPartId]);
         }
         
@@ -463,24 +485,54 @@ class PartMergeService {
         const counts = {};
         
         for (const table of tables) {
-            try {
-                const result = await client.query(
-                    `UPDATE ${table} SET part_id = $1 WHERE part_id = ANY($2)`,
-                    [keepPartId, mergePartIds]
-                );
-                counts[table] = result.rowCount;
-            } catch (error) {
-                console.warn(`Error updating ${table}:`, error.message);
-                counts[table] = 0;
-            }
+            const result = await client.query(
+                `UPDATE ${table} SET part_id = $1 WHERE part_id = ANY($2)`,
+                [keepPartId, mergePartIds]
+            );
+            counts[table] = result.rowCount;
         }
         
         return counts;
     }
 
-    async consolidateInventory(_client, _keepPartId, _mergePartIds) {
-        // No inventory_locations table; consolidation is achieved by FK reassignment on inventory_transaction
-        return { inventory_consolidated: 0 };
+    async consolidateInventory(client, keepPartId, mergePartIds) {
+        const allPartIds = [keepPartId, ...mergePartIds];
+
+        // Safely calculate new total quantities and WAC values in one pass
+        const wacQuery = `
+            WITH stock_qty AS (
+                SELECT part_id, COALESCE(SUM(quantity), 0) as stock_on_hand
+                FROM inventory_transaction
+                WHERE part_id = ANY($1)
+                GROUP BY part_id
+            )
+            SELECT p.part_id, COALESCE(p.wac_cost, 0) as wac_cost, COALESCE(sq.stock_on_hand, 0) as qty
+            FROM part p
+            LEFT JOIN stock_qty sq ON p.part_id = sq.part_id
+            WHERE p.part_id = ANY($1)
+        `;
+        const wacResult = await client.query(wacQuery, [allPartIds]);
+
+        let totalValue = 0;
+        let totalQty = 0;
+
+        for (const row of wacResult.rows) {
+            const qty = Number(row.qty);
+            const wac = Number(row.wac_cost);
+            if (qty > 0) {
+                totalValue += (qty * wac);
+                totalQty += qty;
+            }
+        }
+
+        const newWac = totalQty > 0 ? (totalValue / totalQty) : 0;
+
+        // Explicitly set the correctly weighted WAC for the master part
+        await client.query(`
+            UPDATE part SET wac_cost = $1 WHERE part_id = $2
+        `, [newWac, keepPartId]);
+
+        return { inventory_consolidated: totalQty, new_wac: newWac };
     }
 
     async createAliases(client, keepPartId, mergeParts, _rules) {
@@ -540,10 +592,9 @@ class PartMergeService {
             UPDATE part 
             SET merged_into_part_id = $1, 
                 is_active = false,
-                internal_sku = internal_sku || '-merged-' || $2,
                 date_modified = NOW()
-            WHERE part_id = ANY($3)
-        `, [keepPartId, keepPartId.toString(), mergePartIds]);
+            WHERE part_id = ANY($2)
+        `, [keepPartId, mergePartIds]);
         
         // Mark part_number records of merged parts as deleted
         await client.query(`

--- a/packages/api/test_sql.js
+++ b/packages/api/test_sql.js
@@ -1,0 +1,59 @@
+const db = require('./db');
+async function run() {
+    try {
+        console.log("Testing query 1...");
+        await db.query(`
+            WITH duplicated_skus AS (
+                SELECT internal_sku
+                FROM part
+                WHERE merged_into_part_id IS NULL AND internal_sku IS NOT NULL AND internal_sku != ''
+                GROUP BY internal_sku
+                HAVING COUNT(*) > 1
+            )
+            SELECT p.*,
+                   COALESCE(
+                       (SELECT json_agg(jsonb_build_object('part_number', pn.part_number))
+                        FROM part_number pn
+                        WHERE pn.part_id = p.part_id AND pn.deleted_at IS NULL),
+                   '[]'::json) as part_numbers_array
+            FROM parts_view p
+            JOIN duplicated_skus ds ON p.internal_sku = ds.internal_sku
+            WHERE p.merged_into_part_id IS NULL
+              AND ($1 = '' OR p.display_name ILIKE $1 OR p.internal_sku ILIKE $1)
+            ORDER BY p.internal_sku, p.part_id
+            LIMIT $2
+        `, ['%%', 250]);
+        console.log("Query 1 passed");
+
+        console.log("Testing query 2...");
+        await db.query(`
+            WITH duplicated_pns AS (
+                SELECT part_number
+                FROM part_number
+                WHERE deleted_at IS NULL AND part_number IS NOT NULL AND part_number != ''
+                GROUP BY part_number
+                HAVING COUNT(DISTINCT part_id) > 1
+            )
+            SELECT DISTINCT p.*,
+                   COALESCE(
+                       (SELECT json_agg(jsonb_build_object('part_number', pn_inner.part_number))
+                        FROM part_number pn_inner
+                        WHERE pn_inner.part_id = p.part_id AND pn_inner.deleted_at IS NULL),
+                   '[]'::json) as part_numbers_array,
+                   dpn.part_number as matching_part_number
+            FROM parts_view p
+            JOIN part_number pn ON p.part_id = pn.part_id AND pn.deleted_at IS NULL
+            JOIN duplicated_pns dpn ON pn.part_number = dpn.part_number
+            WHERE p.merged_into_part_id IS NULL
+              AND ($1 = '' OR p.display_name ILIKE $1 OR p.internal_sku ILIKE $1)
+            ORDER BY dpn.part_number, p.part_id
+            LIMIT $2
+        `, ['%%', 250]);
+        console.log("Query 2 passed");
+        process.exit(0);
+    } catch(err) {
+        console.error(err);
+        process.exit(1);
+    }
+}
+run();

--- a/test_db_queries.js
+++ b/test_db_queries.js
@@ -1,0 +1,64 @@
+const { Pool } = require('pg');
+const DuplicateFinder = require('./packages/api/services/duplicateFinder');
+
+const pool = new Pool({
+  host: process.env.PGHOST || 'localhost',
+  user: process.env.PGUSER || 'postgres',
+  password: process.env.PGPASSWORD || 'postgres',
+  database: process.env.PGDATABASE || 'forson',
+  port: process.env.PGPORT || 5432,
+});
+
+async function run() {
+    console.log("Connecting to DB...");
+    const result = await pool.query(`
+            WITH duplicated_skus AS (
+                SELECT internal_sku
+                FROM part
+                WHERE merged_into_part_id IS NULL AND internal_sku IS NOT NULL AND internal_sku != ''
+                GROUP BY internal_sku
+                HAVING COUNT(*) > 1
+            )
+            SELECT p.*,
+                   COALESCE(
+                       (SELECT json_agg(jsonb_build_object('part_number', pn.part_number))
+                        FROM part_number pn
+                        WHERE pn.part_id = p.part_id AND pn.deleted_at IS NULL),
+                   '[]'::json) as part_numbers_array
+            FROM parts_view p
+            JOIN duplicated_skus ds ON p.internal_sku = ds.internal_sku
+            WHERE p.merged_into_part_id IS NULL
+              AND ($1 = '' OR p.display_name ILIKE $1 OR p.internal_sku ILIKE $1)
+            ORDER BY p.internal_sku, p.part_id
+            LIMIT $2
+    `, ['%%', 250]);
+    console.log("Query 1 success, rows:", result.rows.length);
+
+    const result2 = await pool.query(`
+            WITH duplicated_pns AS (
+                SELECT part_number
+                FROM part_number
+                WHERE deleted_at IS NULL AND part_number IS NOT NULL AND part_number != ''
+                GROUP BY part_number
+                HAVING COUNT(DISTINCT part_id) > 1
+            )
+            SELECT DISTINCT p.*,
+                   COALESCE(
+                       (SELECT json_agg(jsonb_build_object('part_number', pn_inner.part_number))
+                        FROM part_number pn_inner
+                        WHERE pn_inner.part_id = p.part_id AND pn_inner.deleted_at IS NULL),
+                   '[]'::json) as part_numbers_array,
+                   dpn.part_number as matching_part_number
+            FROM parts_view p
+            JOIN part_number pn ON p.part_id = pn.part_id AND pn.deleted_at IS NULL
+            JOIN duplicated_pns dpn ON pn.part_number = dpn.part_number
+            WHERE p.merged_into_part_id IS NULL
+              AND ($1 = '' OR p.display_name ILIKE $1 OR p.internal_sku ILIKE $1)
+            ORDER BY dpn.part_number, p.part_id
+            LIMIT $2
+    `, ['%%', 250]);
+    console.log("Query 2 success, rows:", result2.rows.length);
+
+    pool.end();
+}
+run().catch(console.error);

--- a/test_duplicate_error.js
+++ b/test_duplicate_error.js
@@ -1,0 +1,27 @@
+const { Pool } = require('pg');
+const DuplicateFinder = require('./packages/api/services/duplicateFinder');
+
+const pool = new Pool({
+  host: process.env.PGHOST || 'localhost',
+  user: process.env.PGUSER || 'postgres',
+  password: process.env.PGPASSWORD || 'postgres',
+  database: process.env.PGDATABASE || 'forson',
+  port: process.env.PGPORT || 5432,
+});
+
+async function run() {
+  const duplicateFinder = new DuplicateFinder(pool);
+  try {
+    await duplicateFinder.findDuplicateGroups({
+        minSimilarity: 0.8,
+        limit: 50,
+        excludeMerged: true
+    });
+    console.log("Success");
+  } catch (err) {
+    console.error("Error:", err);
+  } finally {
+    pool.end();
+  }
+}
+run();

--- a/test_duplicate_mock.js
+++ b/test_duplicate_mock.js
@@ -1,0 +1,18 @@
+const DuplicateFinder = require('./packages/api/services/duplicateFinder');
+
+const mockPool = {
+    query: async (text, params) => {
+        return { rows: [] };
+    }
+};
+
+async function run() {
+    const df = new DuplicateFinder(mockPool);
+    try {
+        await df.findDuplicateGroups({ minSimilarity: 0.8, limit: 50, excludeMerged: true });
+        console.log("Success");
+    } catch(err) {
+        console.error("Error:", err);
+    }
+}
+run();

--- a/test_duplicate_refactor.js
+++ b/test_duplicate_refactor.js
@@ -1,0 +1,2 @@
+const { DuplicateFinder } = require('./packages/api/services/duplicateFinder');
+// just seeing if we can instantiate it and check syntax

--- a/test_duplicate_refactor_syntax.js
+++ b/test_duplicate_refactor_syntax.js
@@ -1,0 +1,1 @@
+const DuplicateFinder = require('./packages/api/services/duplicateFinder');


### PR DESCRIPTION
### Summary of Changes

1. **Performance (N+1 Query Fix):** In `duplicateFinder.js`, fetching part numbers during the duplicate scanning process was happening inside a loop (N+1 vulnerability). This was rewritten to use PostgreSQL's `json_agg` natively inside the primary query, dramatically improving performance on large catalogs.
2. **ACID Compliance & Transaction Safety:** In `partMergeService.js`, the `reassignForeignKeys` method contained a `try-catch` block that suppressed update errors. This broke ACID compliance because a failure on one table (e.g., `invoice_line`) would still allow the overall transaction to commit, leaving orphaned rows. The catch block was removed so errors correctly propagate and trigger the transaction `ROLLBACK`.
3. **Data Integrity (WAC & Soft Deletes):**
    *   **WAC Recalculation:** Inventory consolidation now securely queries the aggregate `wac_cost` and quantity across all merged parts in a single pass to properly recalculate and apply the new Weighted Average Cost.
    *   **Soft Deletes:** `part_number` duplication cleanup now correctly uses `UPDATE ... SET deleted_at = NOW()` instead of a hard `DELETE`, maintaining referential integrity for old receipts.
4. **Security & Input Validation:** The backend now validates `rules.fieldOverrides` (e.g., `brand_id`) by verifying that the requested override value actually matches the value from the primary part or one of the duplicate parts. This prevents users from blindly assigning a part to a random/unauthorized brand or tax group.
5. **Logic Fixes:** Added missing `is_service` field mapping, hooked up the unused `preserveAliases` parameter, and removed redundant internal SKU string mutations.

---
*PR created automatically by Jules for task [4058067495848775395](https://jules.google.com/task/4058067495848775395) started by @kent1l*