### PR TITLE
Sync merged parts to Meilisearch after duplicate merge

### DIFF
--- a/packages/api/services/partMergeService.js
+++ b/packages/api/services/partMergeService.js
@@ -630,18 +630,22 @@ class PartMergeService {
     }
 
     async syncMeilisearch(keepPartId, mergePartIds) {
+        const { syncPartWithMeili } = require('../meilisearch');
+
         try {
-            const { syncPartWithMeili } = require('../meilisearch');
-            
-            // Sync the keep part
             const keepPart = await this.getPartDetails(keepPartId);
             await syncPartWithMeili(keepPart);
-            
-            // Remove merged parts from Meilisearch
-            // This would depend on your Meilisearch setup
-            console.log(`Synced part ${keepPartId} with Meilisearch, removed parts ${mergePartIds.join(', ')}`);
         } catch (error) {
-            console.error('Error syncing with Meilisearch:', error);
+            console.error(`Error syncing keep part ${keepPartId} with Meilisearch:`, error);
+        }
+
+        for (const mergedPartId of mergePartIds) {
+            try {
+                const mergedPart = await this.getPartDetails(mergedPartId);
+                await syncPartWithMeili(mergedPart);
+            } catch (error) {
+                console.error(`Error syncing merged part ${mergedPartId} with Meilisearch:`, error);
+            }
         }
     }
 

--- a/packages/api/services/partMergeService.js
+++ b/packages/api/services/partMergeService.js
@@ -630,7 +630,14 @@ class PartMergeService {
     }
 
     async syncMeilisearch(keepPartId, mergePartIds) {
-        const { syncPartWithMeili } = require('../meilisearch');
+        let syncPartWithMeili;
+
+        try {
+            ({ syncPartWithMeili } = require('../meilisearch'));
+        } catch (error) {
+            console.error('Error loading Meilisearch module during part merge sync:', error);
+            return;
+        }
 
         try {
             const keepPart = await this.getPartDetails(keepPartId);


### PR DESCRIPTION
### Motivation
- After a duplicate merge the merged parts were not updated in Meilisearch and continued to appear in active search results because the code only synced the canonical part and left merged parts untouched.
- The merged parts must be updated (not deleted) in the index to reflect `is_active = false` and `merged_into_part_id` so they disappear from active views but remain findable in inactive searches.

### Description
- Refactored `syncMeilisearch(keepPartId, mergePartIds)` in `packages/api/services/partMergeService.js` to call `syncPartWithMeili` for the canonical part and for each `mergedPartId` after reloading each part via `getPartDetails`.
- Added per-item try/catch logging so failures syncing one merged part do not abort syncing remaining parts or the post-merge flow.
- Preserved the behavior of not deleting merged parts from Meilisearch and instead writing the updated part records so their `is_active`/`merged_into_part_id` state is indexed.

### Testing
- No automated tests were executed as part of this change (no unit/CI runs were performed in this rollout).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feaa287cb883328c109634c5cbc007)