### PR TITLE
fix(api): resolve 500 error on parts sorting and pagination

### DIFF
--- a/packages/api/meilisearch-setup.js
+++ b/packages/api/meilisearch-setup.js
@@ -193,6 +193,9 @@ const setupMeiliSearch = async () => {
             'part_numbers', 
             'normalized_part_numbers'
           ]
+        },
+        pagination: {
+          maxTotalHits: 20000
         }
       };
 
@@ -237,6 +240,9 @@ const setupMeiliSearch = async () => {
           'automatic': ['auto', 'at'],
           'transmission': ['trans', 'tranny'],
           'engine': ['eng', 'motor']
+        },
+        pagination: {
+          maxTotalHits: 20000
         }
       };
 

--- a/packages/api/routes/partRoutes.js
+++ b/packages/api/routes/partRoutes.js
@@ -170,7 +170,7 @@ router.get('/parts', protect, hasPermission('parts:view'), async (req, res) => {
             if (sortBy === 'sku') {
                 orderByClause = `ORDER BY LOWER(COALESCE(p.internal_sku, '')) ${sortDirection}, p.part_id ${sortDirection}`;
             } else if (sortBy === 'application') {
-                orderByClause = `ORDER BY LOWER(COALESCE(applications, '')) ${sortDirection}, p.part_id ${sortDirection}`;
+                orderByClause = `ORDER BY applications ${sortDirection}, p.part_id ${sortDirection}`;
             } else {
                 orderByClause = `ORDER BY LOWER(COALESCE(g.group_name, '') || ' ' || COALESCE(b.brand_name, '') || ' ' || COALESCE(p.detail, '')) ${sortDirection}, p.part_id ${sortDirection}`;
             }


### PR DESCRIPTION
Resolves a 500 Internal Server error in the parts list endpoint in production. The root causes were twofold:
1. When doing global sorts combined with deep pagination limits (`totalHits` up to 20,000 requests), Meilisearch restricts pagination up to 1,000 entries by default via `maxTotalHits`. I configured the index to allow pagination limits to match the application's required bounds.
2. In the fallback SQL query for global sorts like `application`, there was a bug where the Postgres query attempted to order by `LOWER(COALESCE(applications, ''))`. Since `applications` is defined as a scalar subquery `SELECT` alias, wrapping it with an expression in `ORDER BY` causes a SQL syntax error (`column "applications" does not exist`). I fixed it to reference the alias directly.

---
*PR created automatically by Jules for task [14373085516886164345](https://jules.google.com/task/14373085516886164345) started by @kent1l*