### PR TITLE
Fix Cycle Count currency, unassigned search, and display_name usage

### DIFF
--- a/packages/api/routes/cycleCountRoutes.js
+++ b/packages/api/routes/cycleCountRoutes.js
@@ -9,10 +9,15 @@ router.get('/inventory/cycle-count/my-tasks', protect, hasPermission('cycle_coun
     try {
         const { employee_id } = req.user;
         const query = `
-            SELECT l.*, p.detail, p.internal_sku
+            SELECT
+                l.*,
+                p.detail,
+                p.internal_sku,
+                COALESCE(pv.display_name, p.internal_sku, p.detail) AS display_name
             FROM cycle_count_line l
             JOIN cycle_count_batch b ON l.batch_id = b.batch_id
             JOIN part p ON l.part_id = p.part_id
+            LEFT JOIN parts_view pv ON pv.part_id = p.part_id
             WHERE b.employee_id = $1 AND b.status IN ('PENDING', 'IN_PROGRESS')
             AND l.status = 'PENDING'
             ORDER BY b.created_at ASC;
@@ -119,8 +124,15 @@ router.post('/inventory/cycle-count/unassigned-find', protect, hasPermission('cy
         await client.query('BEGIN');
 
         // 1. Ensure part exists and snapshot qty
-        const partResult = await client.query('SELECT stock_on_hand FROM part WHERE part_id = $1 FOR SHARE', [part_id]);
-        if (partResult.rows.length === 0) {
+        const partResult = await client.query(`
+            SELECT
+                COUNT(p.part_id) AS part_exists,
+                COALESCE(SUM(it.quantity), 0) AS stock_on_hand
+            FROM part p
+            LEFT JOIN inventory_transaction it ON it.part_id = p.part_id
+            WHERE p.part_id = $1
+        `, [part_id]);
+        if (partResult.rows.length === 0 || Number(partResult.rows[0].part_exists) === 0) {
             await client.query('ROLLBACK');
             return res.status(404).json({ message: 'Part not found' });
         }
@@ -186,7 +198,8 @@ router.get('/inventory/cycle-count/manager/review', protect, hasPermission('cycl
             SELECT 
                 l.*, 
                 p.detail, 
-                p.internal_sku, 
+                p.internal_sku,
+                COALESCE(pv.display_name, p.internal_sku, p.detail) AS display_name,
                 p.wac_cost,
                 b.employee_id,
                 (l.counted_qty - l.system_qty_snapshot) AS variance_qty,
@@ -194,6 +207,7 @@ router.get('/inventory/cycle-count/manager/review', protect, hasPermission('cycl
             FROM cycle_count_line l
             JOIN cycle_count_batch b ON l.batch_id = b.batch_id
             JOIN part p ON l.part_id = p.part_id
+            LEFT JOIN parts_view pv ON pv.part_id = p.part_id
             WHERE l.status = 'PENDING_MANAGER_REVIEW'
             ORDER BY l.counted_at DESC;
         `;

--- a/packages/web/src/components/cycleCount/ManagerReviewDesk.jsx
+++ b/packages/web/src/components/cycleCount/ManagerReviewDesk.jsx
@@ -2,8 +2,12 @@ import React, { useState, useEffect } from 'react';
 import api from '../../api';
 import toast from 'react-hot-toast';
 import EmployeePerformanceTab from './EmployeePerformanceTab';
+import { useSettings } from '../../contexts/SettingsContext';
+import { formatCurrency } from '../../utils/currency';
 
 export default function ManagerReviewDesk() {
+    const { settings } = useSettings();
+    const currencySymbol = settings?.DEFAULT_CURRENCY_SYMBOL || '₱';
     const [activeTab, setActiveTab] = useState('pending_reviews');
     const [lines, setLines] = useState([]);
     const [loading, setLoading] = useState(true);
@@ -29,7 +33,7 @@ export default function ManagerReviewDesk() {
 
     const handleApprove = async (lineId) => {
         try {
-            const response = await api.post(`/inventory/cycle-count/lines/${lineId}/approve`);
+            await api.post(`/inventory/cycle-count/lines/${lineId}/approve`);
             toast.success('Adjustment approved successfully.');
             setLines(prev => prev.filter(line => line.line_id !== lineId));
         } catch (error) {
@@ -89,7 +93,7 @@ export default function ManagerReviewDesk() {
 
                                     return (
                                         <tr key={line.line_id} className="text-center hover:bg-gray-50">
-                                            <td className="py-2 px-4 border-b text-left">{line.detail}</td>
+                                            <td className="py-2 px-4 border-b text-left whitespace-normal break-words">{line.display_name || line.detail}</td>
                                             <td className="py-2 px-4 border-b text-left">{line.internal_sku}</td>
                                             <td className="py-2 px-4 border-b">{line.system_qty_snapshot}</td>
                                             <td className="py-2 px-4 border-b font-medium">{line.counted_qty}</td>
@@ -97,7 +101,7 @@ export default function ManagerReviewDesk() {
                                                 {isPositive ? `+${varianceQty}` : varianceQty}
                                             </td>
                                             <td className={`py-2 px-4 border-b font-bold ${colorClass}`}>
-                                                ${financialImpact.toFixed(2)}
+                                                {formatCurrency(financialImpact, currencySymbol)}
                                             </td>
                                             <td className="py-2 px-4 border-b">
                                                 <button

--- a/packages/web/src/components/cycleCount/MobileCounter.jsx
+++ b/packages/web/src/components/cycleCount/MobileCounter.jsx
@@ -1,6 +1,10 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { X, Check, Search } from 'lucide-react';
 import api from '../../api';
+import toast from 'react-hot-toast';
+
+const getPartDisplayName = (part) => part?.display_name || part?.detail || part?.internal_sku || part?.part_number || 'Unnamed item';
+const getPartSecondaryLabel = (part) => part?.internal_sku || part?.part_number || '';
 
 const MobileCounter = ({ task, onSubmit, onCancel, itemNumber, totalItems, isUnassigned = false }) => {
     const [inputValue, setInputValue] = useState('');
@@ -18,25 +22,46 @@ const MobileCounter = ({ task, onSubmit, onCancel, itemNumber, totalItems, isUna
         }
     }, [isUnassigned]);
 
-    const handleSearch = async (e) => {
-        const query = e.target.value;
-        setSearchQuery(query);
+    useEffect(() => {
+        if (!isUnassigned || selectedPart) return undefined;
 
-        if (query.length < 3) {
+        const query = searchQuery.trim();
+        if (query.length < 2) {
             setSearchResults([]);
-            return;
+            setSearching(false);
+            return undefined;
         }
 
-        setSearching(true);
-        try {
-            // Re-using the parts search endpoint
-            const res = await api.get(`/parts?search=${encodeURIComponent(query)}&limit=10`);
-            setSearchResults(res.data.data || []);
-        } catch (err) {
-            console.error('Search failed', err);
-        } finally {
-            setSearching(false);
-        }
+        const controller = new AbortController();
+        const debounceTimer = setTimeout(async () => {
+            setSearching(true);
+            try {
+                const res = await api.get('/power-search/parts', {
+                    params: { keyword: query, status: 'active' },
+                    signal: controller.signal,
+                });
+                const results = Array.isArray(res.data) ? res.data : (res.data?.data || []);
+                setSearchResults(results);
+            } catch (err) {
+                if (err.name === 'CanceledError' || err.code === 'ERR_CANCELED') return;
+                console.error('Search failed', err);
+                setSearchResults([]);
+                toast.error('Unable to search parts. Please try again.');
+            } finally {
+                if (!controller.signal.aborted) {
+                    setSearching(false);
+                }
+            }
+        }, 300);
+
+        return () => {
+            controller.abort();
+            clearTimeout(debounceTimer);
+        };
+    }, [isUnassigned, searchQuery, selectedPart]);
+
+    const handleSearchChange = (e) => {
+        setSearchQuery(e.target.value);
     };
 
     const handleSelectPart = (part) => {
@@ -77,6 +102,10 @@ const MobileCounter = ({ task, onSubmit, onCancel, itemNumber, totalItems, isUna
         setInputValue('');
     };
 
+    const activePart = isUnassigned ? selectedPart : task;
+    const activeDisplayName = getPartDisplayName(activePart);
+    const activeSecondaryLabel = getPartSecondaryLabel(activePart);
+
     const numpadButtons = [
         [1, 2, 3],
         [4, 5, 6],
@@ -106,7 +135,7 @@ const MobileCounter = ({ task, onSubmit, onCancel, itemNumber, totalItems, isUna
                 {/* Part Identification Area */}
                 {isUnassigned && !selectedPart ? (
                     <div className="flex-1">
-                        <div className="relative mb-4">
+                        <div className="relative mb-2">
                             <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
                                 <Search className="h-5 w-5 text-gray-400" />
                             </div>
@@ -114,12 +143,18 @@ const MobileCounter = ({ task, onSubmit, onCancel, itemNumber, totalItems, isUna
                                 ref={searchInputRef}
                                 type="text"
                                 className="block w-full pl-10 pr-3 py-3 border border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500 text-lg"
-                                placeholder="Scan barcode or type SKU..."
+                                placeholder="Scan barcode or type item name/SKU..."
                                 value={searchQuery}
-                                onChange={handleSearch}
+                                onChange={handleSearchChange}
                             />
                         </div>
+                        {searchQuery.trim().length > 0 && searchQuery.trim().length < 2 && (
+                            <div className="text-sm text-gray-500 mb-3">Type at least 2 characters to search.</div>
+                        )}
                         {searching && <div className="text-center py-4 text-gray-500">Searching...</div>}
+                        {!searching && searchQuery.trim().length >= 2 && searchResults.length === 0 && (
+                            <div className="text-center py-4 text-gray-500">No matching parts found.</div>
+                        )}
                         <div className="space-y-2">
                             {searchResults.map(part => (
                                 <button
@@ -127,20 +162,24 @@ const MobileCounter = ({ task, onSubmit, onCancel, itemNumber, totalItems, isUna
                                     onClick={() => handleSelectPart(part)}
                                     className="w-full text-left p-4 bg-white border border-gray-200 rounded-lg hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors"
                                 >
-                                    <div className="font-bold text-gray-900">{part.internal_sku}</div>
-                                    <div className="text-sm text-gray-600 truncate">{part.detail}</div>
+                                    <div className="font-bold text-gray-900 whitespace-normal break-words line-clamp-3">{getPartDisplayName(part)}</div>
+                                    {getPartSecondaryLabel(part) && (
+                                        <div className="text-sm text-gray-600 whitespace-normal break-words">{getPartSecondaryLabel(part)}</div>
+                                    )}
                                 </button>
                             ))}
                         </div>
                     </div>
                 ) : (
                     <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 mb-6 text-center">
-                        <h2 className="text-3xl font-black text-gray-900 mb-2 tracking-tight">
-                            {isUnassigned ? selectedPart.internal_sku : task.internal_sku}
+                        <h2 className="text-2xl sm:text-3xl font-black text-gray-900 mb-2 tracking-tight whitespace-normal break-words line-clamp-3">
+                            {activeDisplayName}
                         </h2>
-                        <p className="text-lg text-gray-600">
-                            {isUnassigned ? selectedPart.detail : task.detail}
-                        </p>
+                        {activeSecondaryLabel && (
+                            <p className="text-lg text-gray-600 whitespace-normal break-words">
+                                {activeSecondaryLabel}
+                            </p>
+                        )}
                         {isUnassigned && (
                             <button
                                 onClick={() => setSelectedPart(null)}

--- a/packages/web/src/utils/currency.js
+++ b/packages/web/src/utils/currency.js
@@ -14,7 +14,9 @@
  */
 
 // Utility functions for currency formatting
-export const formatCurrency = (value) => {
+export const formatCurrency = (value, currencySymbol = '₱') => {
     const num = Number(value) || 0;
-    return `₱${num.toLocaleString('en-PH', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+    const sign = num < 0 ? '-' : '';
+    const absValue = Math.abs(num);
+    return `${sign}${currencySymbol}${absValue.toLocaleString('en-PH', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 };


### PR DESCRIPTION
### Motivation
- Ensure all monetary values in the Cycle Count UI follow the global application currency settings rather than hardcoded symbols. 
- Fix the “Log Unassigned Find” search which previously produced no suggestions so warehouse staff can locate parts while logging surprise finds. 
- Show the human-friendly `display_name` from `parts_view` in counting UIs so staff can identify items accurately. 

### Description
- Backend: include `parts_view` `display_name` in cycle-count payloads by adding `LEFT JOIN parts_view pv ON pv.part_id = p.part_id` in the `my-tasks` and `manager/review` queries and return `COALESCE(pv.display_name, p.internal_sku, p.detail) AS display_name`. (file: `packages/api/routes/cycleCountRoutes.js`).
- Backend: fix unassigned-find snapshot logic to validate existence and compute `stock_on_hand` from `inventory_transaction` aggregation rather than relying on a non-existent part-level stock field. (file: `packages/api/routes/cycleCountRoutes.js`).
- Frontend (Manager Review): import `useSettings` and the global `formatCurrency` and render financial impact using the configured `DEFAULT_CURRENCY_SYMBOL`; display `display_name` with wrapping-safe Tailwind classes. (file: `packages/web/src/components/cycleCount/ManagerReviewDesk.jsx`).
- Frontend (MobileCounter): replace the broken onChange search with a debounced effect that calls the `power-search` endpoint, uses `AbortController` to cancel stale requests, handles empty/error states, maps results into the suggestion list, and uses `display_name` as primary label with `whitespace-normal break-words line-clamp-3` to prevent layout breakage. (file: `packages/web/src/components/cycleCount/MobileCounter.jsx`).
- Shared util: update `formatCurrency` to accept a `currencySymbol` and correctly format negative values and absolute values using locale formatting. (file: `packages/web/src/utils/currency.js`).

### Testing
- Ran `npm run -w packages/web lint` which completed (project has unrelated lint warnings but no new errors introduced). 
- Built the web bundle with `npm run -w packages/web build` and the build succeeded. 
- Executed `npm run -w packages/web test` (web package has no automated tests) and it ran the no-op test command successfully. 
- Performed a lightweight syntax check `node --check packages/api/routes/cycleCountRoutes.js` and `git diff --check` with no new JS syntax issues; however `npm run -w packages/api lint` could not run in this environment due to the API ESLint config resolving the `globals` package (environment install/layout issue).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2130e736c0833285d40cca1ec045b9)