### PR TITLE
feat: implement mobile login screen, tactile counter, and auth wiring

### DIFF
--- a/packages/mobile/src/app/_layout.tsx
+++ b/packages/mobile/src/app/_layout.tsx
@@ -1,15 +1,37 @@
 import { DarkTheme, DefaultTheme, ThemeProvider } from 'expo-router';
-import { useColorScheme } from 'react-native';
+import { useColorScheme, View, Text, ActivityIndicator } from 'react-native';
+import { useEffect } from 'react';
 
 import { AnimatedSplashOverlay } from '@/components/animated-icon';
-import AppTabs from '@/components/app-tabs';
+import useAuthStore from '../store/useAuthStore';
+import LoginScreen from '../screens/LoginScreen';
 
 export default function TabLayout() {
   const colorScheme = useColorScheme();
+  const { user, isHydrated, hydrate } = useAuthStore();
+
+  useEffect(() => {
+    hydrate();
+  }, [hydrate]);
+
+  if (!isHydrated) {
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
+  if (!user) {
+    return <LoginScreen />;
+  }
+
   return (
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
       <AnimatedSplashOverlay />
-      <AppTabs />
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <Text style={{ fontSize: 24, fontWeight: 'bold' }}>Welcome to Cycle Count</Text>
+      </View>
     </ThemeProvider>
   );
 }

--- a/packages/mobile/src/components/MobileCounter.jsx
+++ b/packages/mobile/src/components/MobileCounter.jsx
@@ -1,0 +1,194 @@
+import React, { useState } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet, Dimensions } from 'react-native';
+
+const { width } = Dimensions.get('window');
+
+// Responsive button sizing based on screen width
+const BUTTON_SIZE = Math.min((width - 80) / 3, 100);
+
+export default function MobileCounter({ initialQuantity = 0, onSubmit }) {
+  const [inputQuantity, setInputQuantity] = useState(initialQuantity.toString());
+
+  const handleNumberPress = (num) => {
+    setInputQuantity((prev) => {
+      // Don't allow multiple leading zeros
+      if (prev === '0') return num.toString();
+      return prev + num.toString();
+    });
+  };
+
+  const handleClear = () => {
+    setInputQuantity('0');
+  };
+
+  const handleIncrement = (amount) => {
+    setInputQuantity((prev) => {
+      const current = parseInt(prev || '0', 10);
+      const next = current + amount;
+      // Prevent negative numbers if needed, but here we just prevent less than 0
+      return Math.max(0, next).toString();
+    });
+  };
+
+  const handleSubmit = () => {
+    if (onSubmit) {
+      onSubmit(parseInt(inputQuantity || '0', 10));
+    }
+  };
+
+  const renderButton = (label, onPress, isSecondary = false, isAction = false) => (
+    <TouchableOpacity
+      style={[
+        styles.button,
+        isSecondary && styles.secondaryButton,
+        isAction && styles.actionButton,
+      ]}
+      onPress={onPress}
+      activeOpacity={0.7}
+    >
+      <Text
+        style={[
+          styles.buttonText,
+          isSecondary && styles.secondaryButtonText,
+          isAction && styles.actionButtonText,
+        ]}
+      >
+        {label}
+      </Text>
+    </TouchableOpacity>
+  );
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.displayContainer}>
+        <Text style={styles.displayLabel}>Current Quantity</Text>
+        <Text style={styles.displayText}>{inputQuantity}</Text>
+      </View>
+
+      <View style={styles.quickActionsContainer}>
+        <TouchableOpacity style={styles.quickButton} onPress={() => handleIncrement(-1)}>
+          <Text style={styles.quickButtonText}>-1</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.quickButton} onPress={() => handleIncrement(1)}>
+          <Text style={styles.quickButtonText}>+1</Text>
+        </TouchableOpacity>
+      </View>
+
+      <View style={styles.numpadContainer}>
+        <View style={styles.row}>
+          {renderButton('1', () => handleNumberPress(1))}
+          {renderButton('2', () => handleNumberPress(2))}
+          {renderButton('3', () => handleNumberPress(3))}
+        </View>
+        <View style={styles.row}>
+          {renderButton('4', () => handleNumberPress(4))}
+          {renderButton('5', () => handleNumberPress(5))}
+          {renderButton('6', () => handleNumberPress(6))}
+        </View>
+        <View style={styles.row}>
+          {renderButton('7', () => handleNumberPress(7))}
+          {renderButton('8', () => handleNumberPress(8))}
+          {renderButton('9', () => handleNumberPress(9))}
+        </View>
+        <View style={styles.row}>
+          {renderButton('C', handleClear, true)}
+          {renderButton('0', () => handleNumberPress(0))}
+          {renderButton('OK', handleSubmit, false, true)}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#fff',
+  },
+  displayContainer: {
+    width: '100%',
+    maxWidth: 400,
+    backgroundColor: '#f3f4f6',
+    borderRadius: 12,
+    padding: 20,
+    marginBottom: 20,
+    alignItems: 'center',
+    borderWidth: 1,
+    borderColor: '#e5e7eb',
+  },
+  displayLabel: {
+    fontSize: 18,
+    color: '#6b7280',
+    marginBottom: 8,
+  },
+  displayText: {
+    fontSize: 48,
+    fontWeight: 'bold',
+    color: '#111827',
+  },
+  quickActionsContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    width: '100%',
+    maxWidth: 400,
+    marginBottom: 20,
+  },
+  quickButton: {
+    flex: 1,
+    backgroundColor: '#e5e7eb',
+    padding: 20,
+    marginHorizontal: 8,
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  quickButtonText: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: '#374151',
+  },
+  numpadContainer: {
+    width: '100%',
+    maxWidth: 400,
+    alignItems: 'center',
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    width: '100%',
+    marginBottom: 16,
+  },
+  button: {
+    width: BUTTON_SIZE,
+    height: BUTTON_SIZE,
+    backgroundColor: '#f3f4f6',
+    borderRadius: BUTTON_SIZE / 2,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginHorizontal: 8,
+    borderWidth: 1,
+    borderColor: '#e5e7eb',
+  },
+  buttonText: {
+    fontSize: 32,
+    fontWeight: 'bold',
+    color: '#1f2937',
+  },
+  secondaryButton: {
+    backgroundColor: '#fee2e2',
+    borderColor: '#fca5a5',
+  },
+  secondaryButtonText: {
+    color: '#ef4444',
+  },
+  actionButton: {
+    backgroundColor: '#3b82f6',
+    borderColor: '#2563eb',
+  },
+  actionButtonText: {
+    color: '#ffffff',
+  },
+});

--- a/packages/mobile/src/global.d.ts
+++ b/packages/mobile/src/global.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';

--- a/packages/mobile/src/screens/LoginScreen.jsx
+++ b/packages/mobile/src/screens/LoginScreen.jsx
@@ -1,0 +1,130 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, TouchableOpacity, StyleSheet, ActivityIndicator, Alert } from 'react-native';
+import apiClient from '../api/client';
+import useAuthStore from '../store/useAuthStore';
+
+export default function LoginScreen() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const { login } = useAuthStore();
+
+  const handleLogin = async () => {
+    if (!username || !password) {
+      Alert.alert('Error', 'Please enter both username and password.');
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const response = await apiClient.post('/login', { username, password });
+      const { token, user } = response.data;
+      if (token && user) {
+        await login(token, user);
+      } else {
+        Alert.alert('Login Failed', 'Invalid response from server.');
+      }
+    } catch (error) {
+      console.error('Login error:', error);
+      Alert.alert('Login Failed', error.response?.data?.message || 'Something went wrong. Please try again.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.card}>
+        <Text style={styles.title}>Welcome Back</Text>
+        <Text style={styles.subtitle}>Sign in to continue</Text>
+
+        <TextInput
+          style={styles.input}
+          placeholder="Username"
+          value={username}
+          onChangeText={setUsername}
+          autoCapitalize="none"
+          editable={!isLoading}
+        />
+
+        <TextInput
+          style={styles.input}
+          placeholder="Password"
+          value={password}
+          onChangeText={setPassword}
+          secureTextEntry
+          editable={!isLoading}
+        />
+
+        <TouchableOpacity
+          style={[styles.button, isLoading && styles.buttonDisabled]}
+          onPress={handleLogin}
+          disabled={isLoading}
+        >
+          {isLoading ? (
+            <ActivityIndicator color="#fff" />
+          ) : (
+            <Text style={styles.buttonText}>Log In</Text>
+          )}
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: 24,
+    backgroundColor: '#f3f4f6',
+  },
+  card: {
+    backgroundColor: '#fff',
+    padding: 24,
+    borderRadius: 12,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 8,
+    elevation: 3,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: 'bold',
+    color: '#1f2937',
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  subtitle: {
+    fontSize: 16,
+    color: '#6b7280',
+    marginBottom: 32,
+    textAlign: 'center',
+  },
+  input: {
+    backgroundColor: '#f9fafb',
+    borderWidth: 1,
+    borderColor: '#d1d5db',
+    borderRadius: 8,
+    padding: 16,
+    marginBottom: 16,
+    fontSize: 16,
+    color: '#1f2937',
+  },
+  button: {
+    backgroundColor: '#3b82f6',
+    padding: 16,
+    borderRadius: 8,
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  buttonDisabled: {
+    backgroundColor: '#9ca3af',
+  },
+  buttonText: {
+    color: '#fff',
+    fontSize: 18,
+    fontWeight: 'bold',
+  },
+});


### PR DESCRIPTION
Implemented Phase 3 of the Mobile App strategy.
- Created `packages/mobile/src/screens/LoginScreen.jsx` with responsive UI for user credentials, wired to send a POST request to `/login` via the `apiClient`, and mapped to the `useAuthStore` upon success.
- Created `packages/mobile/src/components/MobileCounter.jsx` featuring a tactile, responsive custom numpad with quick increment/decrement and a clear visual display header for inventory counting on mobile devices.
- Wired the root navigation (`packages/mobile/src/app/_layout.tsx`) to hydrate the auth state on mount and conditionally render the LoginScreen, an ActivityIndicator during hydration, or a temporary Dashboard placeholder for authenticated users.

---
*PR created automatically by Jules for task [5893808785450804929](https://jules.google.com/task/5893808785450804929) started by @kent1l*