### PR TITLE
Fix patch-package missing in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
             packages/api/package-lock.json
             packages/web/package-lock.json
           
+      - name: Install root dependencies
+        run: npm install
+
       - name: Install API dependencies
         run: npm install
         working-directory: packages/api


### PR DESCRIPTION
Fixes a CI pipeline error where `patch-package` was not found during `npm install` steps inside workspace subdirectories (`packages/api`, `packages/web`). Added an initial root `npm install` step to the CI workflow so root `devDependencies` (like `patch-package`) are available before the subsequent `postinstall` triggers occur.

---
*PR created automatically by Jules for task [16418262558380118255](https://jules.google.com/task/16418262558380118255) started by @kent1l*