### PR TITLE
Fix rules of hooks lint error in App.jsx

### DIFF
--- a/packages/web/src/App.jsx
+++ b/packages/web/src/App.jsx
@@ -41,11 +41,7 @@ function AppContent() {
 // The main App component will now handle the initial setup check
 function App() {
     const [needsSetup, setNeedsSetup] = useState(null);
-
-    // Intercept mobile setup route immediately to bypass auth and setup checks
-    if (window.location.pathname === '/mobile-setup') {
-        return <MobileSetupPage />;
-    }
+    const isMobileSetup = window.location.pathname === '/mobile-setup';
 
     const checkSetupStatus = async () => {
         try {
@@ -59,8 +55,15 @@ function App() {
     };
 
     useEffect(() => {
-        checkSetupStatus();
-    }, []);
+        if (!isMobileSetup) {
+            checkSetupStatus();
+        }
+    }, [isMobileSetup]);
+
+    // Intercept mobile setup route immediately to bypass auth and setup checks
+    if (isMobileSetup) {
+        return <MobileSetupPage />;
+    }
 
     // Display a loading indicator while checking the setup status
     if (needsSetup === null) {


### PR DESCRIPTION
This PR addresses a build failure caused by ESLint reporting an error in `App.jsx` regarding the `react-hooks/rules-of-hooks` rule. An early return for the `/mobile-setup` route was previously bypassing a `useEffect` hook. I moved the early return below the `useEffect` hook and placed a conditional inside the `useEffect` to avoid running `checkSetupStatus()` when on the `/mobile-setup` route. All linting warnings remain but the single blocking error is fixed, and tests have verified no regressions.

---
*PR created automatically by Jules for task [12975670901836658032](https://jules.google.com/task/12975670901836658032) started by @kent1l*