### PR TITLE
Format numeric amounts in cheque PDF generation

### DIFF
--- a/packages/api/helpers/chequeAmountWords.js
+++ b/packages/api/helpers/chequeAmountWords.js
@@ -25,7 +25,8 @@ function chunkToWords(value) {
 
 function amountToWords(amount, options = {}) {
     const suffix = String(options.suffix || 'pesos').trim() || 'pesos';
-    const numericAmount = Number(amount);
+    const cleaned = typeof amount === 'number' ? amount : String(amount || '').replace(/[^0-9.-]/g, '');
+    const numericAmount = Number(cleaned);
     if (Number.isNaN(numericAmount) || numericAmount < 0) {
         throw new Error('Amount must be a non-negative number');
     }

--- a/packages/api/helpers/pdf/chequePdf.js
+++ b/packages/api/helpers/pdf/chequePdf.js
@@ -75,6 +75,17 @@ function toPdfLibSafeText(text, font) {
     }
 }
 
+function formatNumericAmount(amount) {
+    if (amount === null || amount === undefined || amount === '') return '0.00';
+    const cleaned = String(amount).replace(/[^0-9.-]/g, '');
+    const num = Number(cleaned);
+    if (Number.isNaN(num)) return '0.00';
+    return num.toLocaleString('en-US', {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2
+    });
+}
+
 function createFallbackPdf({ rows, template, xOffset, yOffset, testPrint, isLetterFeed }) {
     const positions = template?.field_positions || {};
     const currencySettings = template?.currency_settings || { enabled: true, label: '₱' };
@@ -88,6 +99,7 @@ function createFallbackPdf({ rows, template, xOffset, yOffset, testPrint, isLett
         const words = template?.amount_format === 'upper' ? amountWords.toUpperCase() : amountWords;
         const amountWordsText = applyEndFiller(words, textSettings?.amountWordsFiller, textSettings?.amountWordsFillerEnabled);
         const payeeText = applyEndFiller(row.payee, textSettings?.payeeFiller, textSettings?.payeeFillerEnabled);
+        const formattedAmount = formatNumericAmount(row.amount);
         const drawText = (text, cfg, fallback) => {
             const x = Number(cfg?.x ?? fallback.x) + xOffset;
             const y = Number(cfg?.y ?? fallback.y) + yOffset;
@@ -98,7 +110,7 @@ function createFallbackPdf({ rows, template, xOffset, yOffset, testPrint, isLett
         const lines = [
             drawText(row.date, positions.date, { x: 426, y: 178, fontSize: 11 }),
             drawText(payeeText, positions.payee, { x: 72, y: 136, fontSize: 12 }),
-            drawText(row.amount, positions.amountNumeric, { x: 534, y: 136, fontSize: 12 }),
+            drawText(formattedAmount, positions.amountNumeric, { x: 534, y: 136, fontSize: 12 }),
             drawText(amountWordsText, positions.amountWords, { x: 72, y: 104, fontSize: 11 })
         ];
         if (currencySettings.enabled !== false) {
@@ -258,8 +270,9 @@ async function createChequePdf({ rows, template, printerProfile = { offset_x: 0,
         } else {
             drawText(row.date, dateCfg, { x: 426, y: 178, fontSize: 11, alignment: 'left', charSpacing: 0 });
         }
+        const formattedAmount = formatNumericAmount(row.amount);
         drawText(payeeText, positions.payee, { x: 72, y: 136, fontSize: 12, alignment: 'left', maxWidth: 380, minFontSize: 8 });
-        drawText(row.amount, positions.amountNumeric, { x: 534, y: 136, fontSize: 12, alignment: 'right' });
+        drawText(formattedAmount, positions.amountNumeric, { x: 534, y: 136, fontSize: 12, alignment: 'right' });
         drawText(amountWordsText, positions.amountWords, { x: 72, y: 104, fontSize: 11, alignment: 'left', maxWidth: 420, minFontSize: 8 });
 
         if (currencySettings.enabled !== false) {
@@ -281,4 +294,4 @@ async function createChequePdf({ rows, template, printerProfile = { offset_x: 0,
     }
 }
 
-module.exports = { createChequePdf };
+module.exports = { createChequePdf, formatNumericAmount };

--- a/packages/api/tests/chequePdf.test.js
+++ b/packages/api/tests/chequePdf.test.js
@@ -92,3 +92,21 @@ describe('createChequePdf fallback renderer offsets', () => {
         expect(pdfText).toContain('436 198 Td');
     });
 });
+
+describe('formatNumericAmount', () => {
+    const { formatNumericAmount } = require('../helpers/pdf/chequePdf');
+
+    it('formats amounts with commas for thousands and period for centavos without currency or extra symbols', () => {
+        expect(formatNumericAmount(1234567.89)).toBe('1,234,567.89');
+        expect(formatNumericAmount('1234567.89')).toBe('1,234,567.89');
+        expect(formatNumericAmount(1000)).toBe('1,000.00');
+        expect(formatNumericAmount('500.5')).toBe('500.50');
+        expect(formatNumericAmount(0)).toBe('0.00');
+    });
+
+    it('strips existing currency symbols and extra non-numeric characters', () => {
+        expect(formatNumericAmount('₱1,234,567.89')).toBe('1,234,567.89');
+        expect(formatNumericAmount('$ 12,345.60')).toBe('12,345.60');
+        expect(formatNumericAmount('***1000.00***')).toBe('1,000.00');
+    });
+});

--- a/packages/web/src/components/accounts-payable/IssueOutboundChequeModal.jsx
+++ b/packages/web/src/components/accounts-payable/IssueOutboundChequeModal.jsx
@@ -11,6 +11,9 @@ const PURPOSE_OPTIONS = [
     { value: 'OTHER_EXPENSE', label: 'Other Expense' },
 ];
 
+const LABEL_CLASS = 'block text-xs font-semibold text-gray-700 dark:text-slate-300 mb-1';
+const INPUT_CLASS = 'w-full text-xs p-2 border border-gray-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-100 focus:ring-2 focus:ring-primary-500 focus:border-primary-500';
+
 const IssueOutboundChequeModal = ({ isOpen, onClose, onIssued }) => {
     const [bankAccounts, setBankAccounts] = useState([]);
     const [suppliers, setSuppliers] = useState([]);
@@ -181,16 +184,16 @@ const IssueOutboundChequeModal = ({ isOpen, onClose, onIssued }) => {
             <form onSubmit={handleSubmit} className="space-y-4">
                 <div className="grid grid-cols-2 gap-3">
                     <div>
-                        <label className="block text-xs font-semibold text-gray-700 mb-1">Bank Account</label>
+                        <label className={LABEL_CLASS}>Bank Account</label>
                         <select value={form.bank_account_id} onChange={(e) => handleChange('bank_account_id', e.target.value)}
-                            className="w-full text-xs p-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500">
+                            className={INPUT_CLASS}>
                             <option value="">Select account…</option>
                             {bankAccounts.map(ba => (
                                 <option key={ba.bank_account_id} value={ba.bank_account_id}>{ba.account_name} — {ba.bank_name}</option>
                             ))}
                         </select>
                         {selectedBankAccount && (
-                            <p className="text-[11px] text-gray-400 mt-1">
+                            <p className="text-[11px] text-gray-400 dark:text-slate-500 mt-1">
                                 {selectedBankAccount.default_cheque_template_id
                                     ? '✓ Will auto-print on issue'
                                     : 'No print template linked — will not auto-print'}
@@ -198,35 +201,37 @@ const IssueOutboundChequeModal = ({ isOpen, onClose, onIssued }) => {
                         )}
                     </div>
                     <div>
-                        <label className="block text-xs font-semibold text-gray-700 mb-1">Cheque Number</label>
+                        <label className={LABEL_CLASS}>Cheque Number</label>
                         <input type="text" value={form.cheque_number} onChange={(e) => handleChange('cheque_number', e.target.value)}
-                            className="w-full text-xs p-2 border border-gray-300 rounded-lg font-mono focus:ring-2 focus:ring-blue-500" placeholder="e.g. 0001234" />
+                            className={`${INPUT_CLASS} font-mono`} placeholder="e.g. 0001234" />
                     </div>
                 </div>
 
                 <div className="grid grid-cols-2 gap-3">
                     <div>
-                        <label className="block text-xs font-semibold text-gray-700 mb-1">Cheque Date</label>
+                        <label className={LABEL_CLASS}>Cheque Date</label>
                         <input type="date" value={form.cheque_date} onChange={(e) => handleChange('cheque_date', e.target.value)}
-                            className="w-full text-xs p-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500" />
+                            className={INPUT_CLASS} />
                     </div>
                     <div>
-                        <label className="block text-xs font-semibold text-gray-700 mb-1">Amount (₱)</label>
+                        <label className={LABEL_CLASS}>Amount (₱)</label>
                         <input type="number" step="0.01" value={form.amount} onChange={(e) => handleChange('amount', e.target.value)}
-                            className="w-full text-xs p-2 border border-gray-300 rounded-lg font-mono focus:ring-2 focus:ring-blue-500" />
+                            className={`${INPUT_CLASS} font-mono`} />
                     </div>
                 </div>
 
                 <div>
-                    <label className="block text-xs font-semibold text-gray-700 mb-1">Purpose</label>
+                    <label className={LABEL_CLASS}>Purpose</label>
                     <div className="flex flex-wrap gap-2">
                         {PURPOSE_OPTIONS.map(opt => (
                             <button
                                 key={opt.value}
                                 type="button"
                                 onClick={() => handleChange('purpose_type', opt.value)}
-                                className={`px-3 py-1.5 rounded-lg text-xs font-bold border cursor-pointer ${
-                                    form.purpose_type === opt.value ? 'bg-blue-600 text-white border-blue-600' : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50'
+                                className={`px-3 py-1.5 rounded-lg text-xs font-bold border cursor-pointer transition-colors ${
+                                    form.purpose_type === opt.value
+                                        ? 'bg-primary-600 text-white border-primary-600'
+                                        : 'bg-white dark:bg-slate-800 text-gray-600 dark:text-slate-300 border-gray-300 dark:border-slate-600 hover:bg-gray-50 dark:hover:bg-slate-700'
                                 }`}
                             >
                                 {opt.label}
@@ -238,9 +243,9 @@ const IssueOutboundChequeModal = ({ isOpen, onClose, onIssued }) => {
                 {form.purpose_type === 'SUPPLIER_PAYMENT' ? (
                     <>
                         <div>
-                            <label className="block text-xs font-semibold text-gray-700 mb-1">Supplier</label>
+                            <label className={LABEL_CLASS}>Supplier</label>
                             <select value={form.supplier_id} onChange={(e) => handleChange('supplier_id', e.target.value)}
-                                className="w-full text-xs p-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500">
+                                className={INPUT_CLASS}>
                                 <option value="">Select supplier…</option>
                                 {suppliers.map(s => (
                                     <option key={s.supplier_id} value={s.supplier_id}>{s.supplier_name}</option>
@@ -249,13 +254,13 @@ const IssueOutboundChequeModal = ({ isOpen, onClose, onIssued }) => {
                         </div>
                         {supplierBills.length > 0 && (
                             <div>
-                                <label className="block text-xs font-semibold text-gray-700 mb-1">Apply to Bills (optional)</label>
-                                <div className="max-h-32 overflow-y-auto border border-gray-200 rounded-lg divide-y divide-gray-100">
+                                <label className={LABEL_CLASS}>Apply to Bills (optional)</label>
+                                <div className="max-h-32 overflow-y-auto border border-gray-200 dark:border-slate-700 rounded-lg divide-y divide-gray-100 dark:divide-slate-700">
                                     {supplierBills.map(bill => (
-                                        <label key={bill.bill_id} className="flex items-center gap-2 px-3 py-2 text-xs cursor-pointer hover:bg-gray-50">
+                                        <label key={bill.bill_id} className="flex items-center gap-2 px-3 py-2 text-xs cursor-pointer hover:bg-gray-50 dark:hover:bg-slate-700 text-gray-700 dark:text-slate-300">
                                             <input type="checkbox" checked={form.bill_ids.includes(bill.bill_id)} onChange={() => toggleBill(bill.bill_id)} />
                                             <span className="font-mono">{bill.bill_number || `#${bill.bill_id}`}</span>
-                                            <span className="text-gray-400 flex-1">
+                                            <span className="text-gray-400 dark:text-slate-500 flex-1">
                                                 Owed: ₱{(parseFloat(bill.total_amount) - parseFloat(bill.amount_paid)).toFixed(2)}
                                             </span>
                                         </label>
@@ -267,9 +272,9 @@ const IssueOutboundChequeModal = ({ isOpen, onClose, onIssued }) => {
                 ) : (
                     <>
                         <div>
-                            <label className="block text-xs font-semibold text-gray-700 mb-1">Expense Category</label>
+                            <label className={LABEL_CLASS}>Expense Category</label>
                             <select value={form.expense_category_id} onChange={(e) => handleChange('expense_category_id', e.target.value)}
-                                className="w-full text-xs p-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500">
+                                className={INPUT_CLASS}>
                                 <option value="">Select category…</option>
                                 {categories.map(c => (
                                     <option key={c.category_id} value={c.category_id}>{c.category_name}</option>
@@ -277,31 +282,31 @@ const IssueOutboundChequeModal = ({ isOpen, onClose, onIssued }) => {
                             </select>
                         </div>
                         <div>
-                            <label className="block text-xs font-semibold text-gray-700 mb-1">Payee</label>
+                            <label className={LABEL_CLASS}>Payee</label>
                             <input type="text" value={form.payee} onChange={(e) => handleChange('payee', e.target.value)}
-                                className="w-full text-xs p-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500" />
+                                className={INPUT_CLASS} />
                         </div>
                     </>
                 )}
 
                 <div className="grid grid-cols-2 gap-3">
                     <div>
-                        <label className="block text-xs font-semibold text-gray-700 mb-1">Reference # (optional)</label>
+                        <label className={LABEL_CLASS}>Reference # (optional)</label>
                         <input type="text" value={form.reference_number} onChange={(e) => handleChange('reference_number', e.target.value)}
-                            className="w-full text-xs p-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500" />
+                            className={INPUT_CLASS} />
                     </div>
                     <div>
-                        <label className="block text-xs font-semibold text-gray-700 mb-1">Memo (optional)</label>
+                        <label className={LABEL_CLASS}>Memo (optional)</label>
                         <input type="text" value={form.memo} onChange={(e) => handleChange('memo', e.target.value)}
-                            className="w-full text-xs p-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500" />
+                            className={INPUT_CLASS} />
                     </div>
                 </div>
 
                 <div className="flex justify-end gap-3 pt-2">
-                    <button type="button" onClick={onClose} className="px-4 py-2 text-xs font-semibold text-gray-600 bg-gray-100 hover:bg-gray-200 rounded-lg cursor-pointer">
+                    <button type="button" onClick={onClose} className="px-4 py-2 text-xs font-semibold text-gray-600 dark:text-slate-300 bg-gray-100 dark:bg-slate-700 hover:bg-gray-200 dark:hover:bg-slate-600 rounded-lg cursor-pointer">
                         Cancel
                     </button>
-                    <button type="submit" disabled={submitting} className="px-4 py-2 text-xs font-bold text-white bg-blue-600 hover:bg-blue-700 rounded-lg shadow-xs cursor-pointer disabled:opacity-50">
+                    <button type="submit" disabled={submitting} className="px-4 py-2 text-xs font-bold text-white bg-primary-600 hover:bg-primary-700 rounded-lg shadow-xs cursor-pointer disabled:opacity-50">
                         {submitting ? 'Issuing…' : 'Issue Cheque'}
                     </button>
                 </div>

--- a/packages/web/src/components/accounts-payable/PdcOutboundDeskTable.jsx
+++ b/packages/web/src/components/accounts-payable/PdcOutboundDeskTable.jsx
@@ -1,13 +1,14 @@
 import { useState, useMemo, useEffect } from 'react';
 import { formatCurrency } from '../../utils/currency';
 import PaginationControls from '../ui/PaginationControls';
+import StatusBadge from '../ui/StatusBadge';
 
 const TableSkeleton = () => (
-    <div className="animate-pulse space-y-4 p-6 bg-white rounded-xl border border-gray-200">
-        <div className="h-6 bg-gray-200 rounded w-1/4 mb-4"></div>
+    <div className="animate-pulse space-y-4 p-6 bg-white dark:bg-slate-800 rounded-xl border border-gray-200 dark:border-slate-700">
+        <div className="h-6 bg-gray-200 dark:bg-slate-700 rounded w-1/4 mb-4"></div>
         <div className="space-y-3">
             {[...Array(5)].map((_, i) => (
-                <div key={i} className="h-10 bg-gray-100 rounded w-full"></div>
+                <div key={i} className="h-10 bg-gray-100 dark:bg-slate-700/60 rounded w-full"></div>
             ))}
         </div>
     </div>
@@ -18,6 +19,22 @@ const PURPOSE_LABELS = {
     LOAN_PAYMENT: 'Loan Payment',
     RENT: 'Rent',
     OTHER_EXPENSE: 'Other Expense',
+};
+
+const PDC_STATUS_TONE = {
+    CLEARED: 'success',
+    BOUNCED: 'danger',
+    DEPOSITED: 'info',
+    VOID: 'neutral',
+    REPLACED: 'neutral',
+    ISSUED: 'warning',
+    HELD_FOR_RELEASE: 'warning',
+};
+
+const MATURITY_TONE = {
+    FUTURE_PDC: 'info',
+    STALE_CHEQUE: 'primary',
+    DUE_TODAY: 'warning',
 };
 
 const PdcOutboundDeskTable = ({
@@ -92,26 +109,26 @@ const PdcOutboundDeskTable = ({
 
     return (
         <div className="space-y-6">
-            <div className="bg-white p-6 rounded-xl border border-gray-200 shadow-sm space-y-4">
-                <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 border-b border-gray-100 pb-4">
+            <div className="bg-white dark:bg-slate-800 p-6 rounded-xl border border-gray-200 dark:border-slate-700 shadow-sm space-y-4">
+                <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 border-b border-gray-100 dark:border-slate-700 pb-4">
                     <div>
-                        <h2 className="text-xl font-bold text-gray-800">Outbound Cheque Register</h2>
-                        <p className="text-xs text-gray-500 mt-0.5">
+                        <h2 className="text-xl font-bold text-gray-800 dark:text-slate-100">Outbound Cheque Register</h2>
+                        <p className="text-xs text-gray-500 dark:text-slate-400 mt-0.5">
                             Supplier, loan, rent, and other cheques issued by the business — issue, verify clearance, void, or replace
                         </p>
                     </div>
                     <div className="flex flex-wrap items-center gap-2 text-xs">
-                        <span className="px-2.5 py-1 bg-gray-100 text-gray-700 rounded-md font-medium border border-gray-200">
-                            Total: <strong className="text-gray-900 font-bold">{items.length}</strong>
+                        <span className="px-2.5 py-1 bg-gray-100 dark:bg-slate-700 text-gray-700 dark:text-slate-300 rounded-md font-medium border border-gray-200 dark:border-slate-600">
+                            Total: <strong className="text-gray-900 dark:text-slate-100 font-bold">{items.length}</strong>
                         </span>
-                        <span className="px-2.5 py-1 bg-amber-50 text-amber-700 rounded-md font-medium border border-amber-200">
-                            Pending: <strong className="text-amber-900 font-bold">{(statusCounts.ISSUED + statusCounts.HELD_FOR_RELEASE + statusCounts.DEPOSITED)}</strong>
+                        <span className="px-2.5 py-1 bg-warning-50 dark:bg-warning-900/20 text-warning-700 dark:text-warning-400 rounded-md font-medium border border-warning-200 dark:border-warning-900/40">
+                            Pending: <strong className="text-warning-900 dark:text-warning-300 font-bold">{(statusCounts.ISSUED + statusCounts.HELD_FOR_RELEASE + statusCounts.DEPOSITED)}</strong>
                         </span>
-                        <span className="px-2.5 py-1 bg-emerald-50 text-emerald-700 rounded-md font-medium border border-emerald-200">
-                            Cleared: <strong className="text-emerald-900 font-bold">{statusCounts.CLEARED}</strong>
+                        <span className="px-2.5 py-1 bg-success-50 dark:bg-success-900/20 text-success-700 dark:text-success-400 rounded-md font-medium border border-success-200 dark:border-success-900/40">
+                            Cleared: <strong className="text-success-900 dark:text-success-300 font-bold">{statusCounts.CLEARED}</strong>
                         </span>
-                        <span className="px-2.5 py-1 bg-rose-50 text-rose-700 rounded-md font-medium border border-rose-200">
-                            Bounced: <strong className="text-rose-900 font-bold">{statusCounts.BOUNCED}</strong>
+                        <span className="px-2.5 py-1 bg-danger-50 dark:bg-danger-900/20 text-danger-700 dark:text-danger-400 rounded-md font-medium border border-danger-200 dark:border-danger-900/40">
+                            Bounced: <strong className="text-danger-900 dark:text-danger-300 font-bold">{statusCounts.BOUNCED}</strong>
                         </span>
                     </div>
                 </div>
@@ -124,19 +141,19 @@ const PdcOutboundDeskTable = ({
                                 placeholder="Search payee, cheque #, bank..."
                                 value={searchTerm}
                                 onChange={(e) => setSearchTerm(e.target.value)}
-                                className="w-full pl-9 pr-8 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 bg-white"
+                                className="w-full pl-9 pr-8 py-2 text-sm border border-gray-300 dark:border-slate-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-100"
                             />
-                            <div className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">🔍</div>
+                            <div className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 dark:text-slate-500">🔍</div>
                             {searchTerm && (
-                                <button onClick={() => setSearchTerm('')} className="absolute right-2.5 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 text-xs p-1">✕</button>
+                                <button onClick={() => setSearchTerm('')} className="absolute right-2.5 top-1/2 -translate-y-1/2 text-gray-400 dark:text-slate-500 hover:text-gray-600 dark:hover:text-slate-300 text-xs p-1">✕</button>
                             )}
                         </div>
                         <div className="flex items-center gap-2">
-                            <label className="text-xs font-semibold text-gray-600 uppercase whitespace-nowrap">Maturity:</label>
+                            <label className="text-xs font-semibold text-gray-600 dark:text-slate-400 uppercase whitespace-nowrap">Maturity:</label>
                             <select
                                 value={maturityFilter}
                                 onChange={(e) => onMaturityFilterChange && onMaturityFilterChange(e.target.value)}
-                                className="px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white text-gray-700"
+                                className="px-3 py-2 text-sm border border-gray-300 dark:border-slate-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white dark:bg-slate-800 text-gray-700 dark:text-slate-200"
                             >
                                 <option value="ALL">All Maturity Statuses</option>
                                 <option value="DUE_TODAY">Due Today / Mature</option>
@@ -145,7 +162,7 @@ const PdcOutboundDeskTable = ({
                             </select>
                         </div>
                         {isFiltered && (
-                            <button onClick={handleClearFilters} className="px-3 py-2 text-xs font-semibold text-gray-600 hover:text-gray-900 bg-gray-100 hover:bg-gray-200 rounded-lg transition-colors flex items-center gap-1">
+                            <button onClick={handleClearFilters} className="px-3 py-2 text-xs font-semibold text-gray-600 dark:text-slate-300 hover:text-gray-900 dark:hover:text-slate-100 bg-gray-100 dark:bg-slate-700 hover:bg-gray-200 dark:hover:bg-slate-600 rounded-lg transition-colors flex items-center gap-1">
                                 <span>✕</span> Reset Filters
                             </button>
                         )}
@@ -160,11 +177,11 @@ const PdcOutboundDeskTable = ({
                                     type="button"
                                     onClick={() => onStatusFilterChange && onStatusFilterChange(st)}
                                     className={`px-3 py-1.5 rounded-lg text-xs font-bold uppercase transition-all flex items-center gap-1.5 whitespace-nowrap cursor-pointer ${
-                                        isActive ? 'bg-gray-900 text-white shadow-xs' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                                        isActive ? 'bg-gray-900 dark:bg-primary-600 text-white shadow-xs' : 'bg-gray-100 dark:bg-slate-700 text-gray-600 dark:text-slate-300 hover:bg-gray-200 dark:hover:bg-slate-600'
                                     }`}
                                 >
                                     <span>{st.replace(/_/g, ' ')}</span>
-                                    <span className={`px-1.5 py-0.2 rounded-full text-[10px] ${isActive ? 'bg-gray-700 text-white' : 'bg-gray-200 text-gray-700'}`}>{count}</span>
+                                    <span className={`px-1.5 py-0.2 rounded-full text-[10px] ${isActive ? 'bg-gray-700 dark:bg-primary-800 text-white' : 'bg-gray-200 dark:bg-slate-600 text-gray-700 dark:text-slate-300'}`}>{count}</span>
                                 </button>
                             );
                         })}
@@ -172,10 +189,10 @@ const PdcOutboundDeskTable = ({
                 </div>
             </div>
 
-            <div className="bg-white rounded-xl border border-gray-200 overflow-hidden shadow-sm">
+            <div className="bg-white dark:bg-slate-800 rounded-xl border border-gray-200 dark:border-slate-700 overflow-hidden shadow-sm">
                 <div className="overflow-x-auto">
-                    <table className="w-full text-sm text-left text-gray-500">
-                        <thead className="text-xs text-gray-700 uppercase bg-gray-50 border-b border-gray-200">
+                    <table className="w-full text-sm text-left text-gray-500 dark:text-slate-400">
+                        <thead className="text-xs text-gray-700 dark:text-slate-300 uppercase bg-gray-50 dark:bg-slate-900/50 border-b border-gray-200 dark:border-slate-700">
                             <tr>
                                 <th className="px-4 py-3.5">Bank Account</th>
                                 <th className="px-4 py-3.5">Cheque #</th>
@@ -188,44 +205,29 @@ const PdcOutboundDeskTable = ({
                                 <th className="px-4 py-3.5 text-center">Actions</th>
                             </tr>
                         </thead>
-                        <tbody className="divide-y divide-gray-200">
+                        <tbody className="divide-y divide-gray-200 dark:divide-slate-700">
                             {paginatedItems.map(item => (
-                                <tr key={item.cheque_record_id} className="hover:bg-gray-50 transition-colors">
-                                    <td className="px-4 py-4 text-xs text-gray-600">{item.bank_account_name || '—'}</td>
-                                    <td className="px-4 py-4 font-mono font-medium text-gray-800">{item.cheque_number || `#${item.cheque_record_id}`}</td>
-                                    <td className="px-4 py-4 font-semibold text-gray-900">{item.company_name || item.payee}</td>
+                                <tr key={item.cheque_record_id} className="hover:bg-gray-50 dark:hover:bg-slate-700/40 transition-colors">
+                                    <td className="px-4 py-4 text-xs text-gray-600 dark:text-slate-400">{item.bank_account_name || '—'}</td>
+                                    <td className="px-4 py-4 font-mono font-medium text-gray-800 dark:text-slate-200">{item.cheque_number || `#${item.cheque_record_id}`}</td>
+                                    <td className="px-4 py-4 font-semibold text-gray-900 dark:text-slate-100">{item.company_name || item.payee}</td>
                                     <td className="px-4 py-4 text-xs">
-                                        <span className="px-2 py-0.5 bg-gray-100 text-gray-700 rounded-md border border-gray-200">
+                                        <span className="px-2 py-0.5 bg-gray-100 dark:bg-slate-700 text-gray-700 dark:text-slate-300 rounded-md border border-gray-200 dark:border-slate-600">
                                             {PURPOSE_LABELS[item.purpose_type] || item.purpose_type}
                                         </span>
                                     </td>
-                                    <td className="px-4 py-4 font-semibold text-xs text-blue-900">
+                                    <td className="px-4 py-4 font-semibold text-xs text-primary-900 dark:text-primary-400">
                                         {item.cheque_date ? new Date(item.cheque_date).toLocaleDateString() : '—'}
                                     </td>
-                                    <td className="px-4 py-4 font-mono text-right font-bold text-gray-900">{formatCurrency(item.amount)}</td>
+                                    <td className="px-4 py-4 font-mono text-right font-bold text-gray-900 dark:text-slate-100">{formatCurrency(item.amount)}</td>
                                     <td className="px-4 py-4">
-                                        <span className={`text-[10px] font-bold px-2 py-0.5 rounded-md ${
-                                            item.maturity_status === 'FUTURE_PDC' ? 'bg-blue-100 text-blue-800 border border-blue-200' :
-                                            item.maturity_status === 'STALE_CHEQUE' ? 'bg-purple-100 text-purple-800 border border-purple-200' :
-                                            'bg-amber-100 text-amber-800 border border-amber-200'
-                                        }`}>
-                                            {item.maturity_label || 'Due for Clearance'}
-                                        </span>
+                                        <StatusBadge tone={MATURITY_TONE[item.maturity_status] || 'warning'} label={item.maturity_label || 'Due for Clearance'} pill={false} />
                                     </td>
                                     <td className="px-4 py-4">
                                         <div className="flex flex-col items-start gap-1">
-                                            <span className={`text-[10px] font-bold px-2.5 py-1 rounded-full uppercase ${
-                                                item.pdc_status === 'CLEARED' ? 'bg-emerald-100 text-emerald-800' :
-                                                item.pdc_status === 'BOUNCED' ? 'bg-red-100 text-red-800' :
-                                                item.pdc_status === 'DEPOSITED' ? 'bg-indigo-100 text-indigo-800' :
-                                                item.pdc_status === 'VOID' ? 'bg-gray-200 text-gray-600' :
-                                                item.pdc_status === 'REPLACED' ? 'bg-slate-200 text-slate-600' :
-                                                'bg-amber-100 text-amber-800'
-                                            }`}>
-                                                {item.pdc_status}
-                                            </span>
+                                            <StatusBadge tone={PDC_STATUS_TONE[item.pdc_status] || 'warning'} label={item.pdc_status} />
                                             {item.bounce_count > 0 && (
-                                                <span className="text-[10px] font-semibold text-rose-700 bg-rose-50 border border-rose-200 px-2 py-0.5 rounded-md">
+                                                <span className="text-[10px] font-semibold text-danger-700 dark:text-danger-400 bg-danger-50 dark:bg-danger-900/20 border border-danger-200 dark:border-danger-900/40 px-2 py-0.5 rounded-md">
                                                     ⚠️ {item.bounce_count} {item.bounce_count === 1 ? 'Bounce' : 'Bounces'}
                                                 </span>
                                             )}
@@ -236,18 +238,18 @@ const PdcOutboundDeskTable = ({
                                             {['ISSUED', 'HELD_FOR_RELEASE', 'DEPOSITED'].includes(item.pdc_status) && (
                                                 <>
                                                     <button type="button" onClick={() => onVerifyClearance && onVerifyClearance(item)}
-                                                        className="px-2.5 py-1.5 bg-emerald-600 hover:bg-emerald-700 text-white rounded-lg text-xs font-bold shadow-xs cursor-pointer">
+                                                        className="px-2.5 py-1.5 bg-success-600 hover:bg-success-700 text-white rounded-lg text-xs font-bold shadow-xs cursor-pointer">
                                                         ✓ Clear
                                                     </button>
                                                     <button type="button" onClick={() => onMarkBounced && onMarkBounced(item)}
-                                                        className="px-2.5 py-1.5 bg-rose-600 hover:bg-rose-700 text-white rounded-lg text-xs font-bold shadow-xs cursor-pointer">
+                                                        className="px-2.5 py-1.5 bg-danger-600 hover:bg-danger-700 text-white rounded-lg text-xs font-bold shadow-xs cursor-pointer">
                                                         ⚠️ Bounce
                                                     </button>
                                                 </>
                                             )}
                                             {['ISSUED', 'HELD_FOR_RELEASE'].includes(item.pdc_status) && (
                                                 <button type="button" onClick={() => onVoidCheque && onVoidCheque(item)}
-                                                    className="px-2.5 py-1.5 bg-gray-200 hover:bg-gray-300 text-gray-700 rounded-lg text-xs font-bold cursor-pointer"
+                                                    className="px-2.5 py-1.5 bg-gray-200 dark:bg-slate-700 hover:bg-gray-300 dark:hover:bg-slate-600 text-gray-700 dark:text-slate-200 rounded-lg text-xs font-bold cursor-pointer"
                                                     title="Void this cheque — written incorrectly, never handed over">
                                                     ✕ Void
                                                 </button>
@@ -255,11 +257,11 @@ const PdcOutboundDeskTable = ({
                                             {item.pdc_status === 'BOUNCED' && (
                                                 <>
                                                     <button type="button" onClick={() => onRedepositCheque && onRedepositCheque(item)}
-                                                        className="px-2.5 py-1.5 bg-blue-600 hover:bg-blue-700 text-white rounded-lg text-xs font-bold shadow-xs cursor-pointer">
+                                                        className="px-2.5 py-1.5 bg-primary-600 hover:bg-primary-700 text-white rounded-lg text-xs font-bold shadow-xs cursor-pointer">
                                                         🔄 Re-deposit
                                                     </button>
                                                     <button type="button" onClick={() => onReplaceCheque && onReplaceCheque(item)}
-                                                        className="px-2.5 py-1.5 bg-amber-600 hover:bg-amber-700 text-white rounded-lg text-xs font-bold shadow-xs cursor-pointer"
+                                                        className="px-2.5 py-1.5 bg-warning-600 hover:bg-warning-700 text-white rounded-lg text-xs font-bold shadow-xs cursor-pointer"
                                                         title="Issue a replacement cheque for the same obligation">
                                                         ⟳ Replace
                                                     </button>
@@ -267,19 +269,19 @@ const PdcOutboundDeskTable = ({
                                             )}
                                             {item.maturity_status === 'STALE_CHEQUE' && !['CLEARED', 'VOID', 'REPLACED'].includes(item.pdc_status) && (
                                                 <button type="button" onClick={() => onReplaceCheque && onReplaceCheque(item)}
-                                                    className="px-2.5 py-1.5 bg-amber-600 hover:bg-amber-700 text-white rounded-lg text-xs font-bold shadow-xs cursor-pointer">
+                                                    className="px-2.5 py-1.5 bg-warning-600 hover:bg-warning-700 text-white rounded-lg text-xs font-bold shadow-xs cursor-pointer">
                                                     ⟳ Replace (Stale)
                                                 </button>
                                             )}
                                             {onPrintCheque && ['ISSUED', 'HELD_FOR_RELEASE'].includes(item.pdc_status) && (
                                                 <button type="button" onClick={() => onPrintCheque(item)}
-                                                    className="px-2.5 py-1.5 bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-lg text-xs font-semibold border border-gray-200 cursor-pointer">
+                                                    className="px-2.5 py-1.5 bg-gray-100 dark:bg-slate-700 hover:bg-gray-200 dark:hover:bg-slate-600 text-gray-700 dark:text-slate-200 rounded-lg text-xs font-semibold border border-gray-200 dark:border-slate-600 cursor-pointer">
                                                     🖨️ Print
                                                 </button>
                                             )}
                                             {onViewHistory && (
                                                 <button type="button" onClick={() => onViewHistory(item)}
-                                                    className="px-2.5 py-1.5 bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-lg text-xs font-semibold border border-gray-200 cursor-pointer">
+                                                    className="px-2.5 py-1.5 bg-gray-100 dark:bg-slate-700 hover:bg-gray-200 dark:hover:bg-slate-600 text-gray-700 dark:text-slate-200 rounded-lg text-xs font-semibold border border-gray-200 dark:border-slate-600 cursor-pointer">
                                                     📜 History
                                                 </button>
                                             )}
@@ -289,13 +291,13 @@ const PdcOutboundDeskTable = ({
                             ))}
                             {filteredItems.length === 0 && (
                                 <tr>
-                                    <td colSpan={9} className="px-6 py-12 text-center text-gray-500">
+                                    <td colSpan={9} className="px-6 py-12 text-center text-gray-500 dark:text-slate-400">
                                         <div className="flex flex-col items-center justify-center gap-2">
                                             <span className="text-2xl">📤</span>
-                                            <p className="font-semibold text-gray-700">No outbound cheques found</p>
-                                            <p className="text-xs text-gray-400">Issue a cheque, or adjust your search/status/maturity filters.</p>
+                                            <p className="font-semibold text-gray-700 dark:text-slate-300">No outbound cheques found</p>
+                                            <p className="text-xs text-gray-400 dark:text-slate-500">Issue a cheque, or adjust your search/status/maturity filters.</p>
                                             {isFiltered && (
-                                                <button onClick={handleClearFilters} className="mt-2 text-xs text-blue-600 font-semibold hover:underline">Reset all filters</button>
+                                                <button onClick={handleClearFilters} className="mt-2 text-xs text-primary-600 dark:text-primary-400 font-semibold hover:underline">Reset all filters</button>
                                             )}
                                         </div>
                                     </td>
@@ -305,7 +307,7 @@ const PdcOutboundDeskTable = ({
                     </table>
                 </div>
                 {filteredItems.length > 0 && (
-                    <div className="p-4 border-t border-gray-100">
+                    <div className="p-4 border-t border-gray-100 dark:border-slate-700">
                         <PaginationControls
                             page={page}
                             pageSize={pageSize}

--- a/packages/web/src/components/accounts-receivable/PdcClearanceDeskTable.jsx
+++ b/packages/web/src/components/accounts-receivable/PdcClearanceDeskTable.jsx
@@ -1,17 +1,32 @@
 import { useState, useMemo, useEffect } from 'react';
 import { formatCurrency } from '../../utils/currency';
 import PaginationControls from '../ui/PaginationControls';
+import StatusBadge from '../ui/StatusBadge';
 
 const TableSkeleton = () => (
-    <div className="animate-pulse space-y-4 p-6 bg-white rounded-xl border border-gray-200">
-        <div className="h-6 bg-gray-200 rounded w-1/4 mb-4"></div>
+    <div className="animate-pulse space-y-4 p-6 bg-white dark:bg-slate-800 rounded-xl border border-gray-200 dark:border-slate-700">
+        <div className="h-6 bg-gray-200 dark:bg-slate-700 rounded w-1/4 mb-4"></div>
         <div className="space-y-3">
             {[...Array(5)].map((_, i) => (
-                <div key={i} className="h-10 bg-gray-100 rounded w-full"></div>
+                <div key={i} className="h-10 bg-gray-100 dark:bg-slate-700/60 rounded w-full"></div>
             ))}
         </div>
     </div>
 );
+
+const PDC_STATUS_TONE = {
+    CLEARED: 'success',
+    BOUNCED: 'danger',
+    DEPOSITED: 'info',
+    HELD_IN_SAFE: 'primary',
+    RECEIVED: 'warning',
+};
+
+const MATURITY_TONE = {
+    FUTURE_PDC: 'info',
+    STALE_CHEQUE: 'primary',
+    DUE_TODAY: 'warning',
+};
 
 const PdcClearanceDeskTable = ({
     items = [],
@@ -111,27 +126,27 @@ const PdcClearanceDeskTable = ({
     return (
         <div className="space-y-6">
             {/* Header & Filter Toolbar */}
-            <div className="bg-white p-6 rounded-xl border border-gray-200 shadow-sm space-y-4">
-                <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 border-b border-gray-100 pb-4">
+            <div className="bg-white dark:bg-slate-800 p-6 rounded-xl border border-gray-200 dark:border-slate-700 shadow-sm space-y-4">
+                <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 border-b border-gray-100 dark:border-slate-700 pb-4">
                     <div>
-                        <h2 className="text-xl font-bold text-gray-800">PDC &amp; Collections Clearance Desk</h2>
-                        <p className="text-xs text-gray-500 mt-0.5">
+                        <h2 className="text-xl font-bold text-gray-800 dark:text-slate-100">PDC &amp; Collections Clearance Desk</h2>
+                        <p className="text-xs text-gray-500 dark:text-slate-400 mt-0.5">
                             Verify pending cheque clearances, monitor maturity status, or process bounced cheque reversals
                         </p>
                     </div>
                     {/* Quick Stats Chips */}
                     <div className="flex flex-wrap items-center gap-2 text-xs">
-                        <span className="px-2.5 py-1 bg-gray-100 text-gray-700 rounded-md font-medium border border-gray-200">
-                            Total: <strong className="text-gray-900 font-bold">{items.length}</strong>
+                        <span className="px-2.5 py-1 bg-gray-100 dark:bg-slate-700 text-gray-700 dark:text-slate-300 rounded-md font-medium border border-gray-200 dark:border-slate-600">
+                            Total: <strong className="text-gray-900 dark:text-slate-100 font-bold">{items.length}</strong>
                         </span>
-                        <span className="px-2.5 py-1 bg-amber-50 text-amber-700 rounded-md font-medium border border-amber-200">
-                            Pending: <strong className="text-amber-900 font-bold">{(statusCounts.RECEIVED + statusCounts.HELD_IN_SAFE + statusCounts.DEPOSITED)}</strong>
+                        <span className="px-2.5 py-1 bg-warning-50 dark:bg-warning-900/20 text-warning-700 dark:text-warning-400 rounded-md font-medium border border-warning-200 dark:border-warning-900/40">
+                            Pending: <strong className="text-warning-900 dark:text-warning-300 font-bold">{(statusCounts.RECEIVED + statusCounts.HELD_IN_SAFE + statusCounts.DEPOSITED)}</strong>
                         </span>
-                        <span className="px-2.5 py-1 bg-emerald-50 text-emerald-700 rounded-md font-medium border border-emerald-200">
-                            Cleared: <strong className="text-emerald-900 font-bold">{statusCounts.CLEARED}</strong>
+                        <span className="px-2.5 py-1 bg-success-50 dark:bg-success-900/20 text-success-700 dark:text-success-400 rounded-md font-medium border border-success-200 dark:border-success-900/40">
+                            Cleared: <strong className="text-success-900 dark:text-success-300 font-bold">{statusCounts.CLEARED}</strong>
                         </span>
-                        <span className="px-2.5 py-1 bg-rose-50 text-rose-700 rounded-md font-medium border border-rose-200">
-                            Bounced: <strong className="text-rose-900 font-bold">{statusCounts.BOUNCED}</strong>
+                        <span className="px-2.5 py-1 bg-danger-50 dark:bg-danger-900/20 text-danger-700 dark:text-danger-400 rounded-md font-medium border border-danger-200 dark:border-danger-900/40">
+                            Bounced: <strong className="text-danger-900 dark:text-danger-300 font-bold">{statusCounts.BOUNCED}</strong>
                         </span>
                     </div>
                 </div>
@@ -147,15 +162,15 @@ const PdcClearanceDeskTable = ({
                                 placeholder="Search customer, invoice #, ref..."
                                 value={searchTerm}
                                 onChange={(e) => setSearchTerm(e.target.value)}
-                                className="w-full pl-9 pr-8 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 bg-white"
+                                className="w-full pl-9 pr-8 py-2 text-sm border border-gray-300 dark:border-slate-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-100"
                             />
-                            <div className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
+                            <div className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 dark:text-slate-500">
                                 🔍
                             </div>
                             {searchTerm && (
                                 <button
                                     onClick={() => setSearchTerm('')}
-                                    className="absolute right-2.5 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 text-xs p-1"
+                                    className="absolute right-2.5 top-1/2 -translate-y-1/2 text-gray-400 dark:text-slate-500 hover:text-gray-600 dark:hover:text-slate-300 text-xs p-1"
                                 >
                                     ✕
                                 </button>
@@ -164,11 +179,11 @@ const PdcClearanceDeskTable = ({
 
                         {/* Maturity Filter Select */}
                         <div className="flex items-center gap-2">
-                            <label className="text-xs font-semibold text-gray-600 uppercase whitespace-nowrap">Maturity:</label>
+                            <label className="text-xs font-semibold text-gray-600 dark:text-slate-400 uppercase whitespace-nowrap">Maturity:</label>
                             <select
                                 value={maturityFilter}
                                 onChange={(e) => onMaturityFilterChange && onMaturityFilterChange(e.target.value)}
-                                className="px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white text-gray-700"
+                                className="px-3 py-2 text-sm border border-gray-300 dark:border-slate-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white dark:bg-slate-800 text-gray-700 dark:text-slate-200"
                             >
                                 <option value="ALL">All Maturity Statuses</option>
                                 <option value="DUE_TODAY">Due Today / Mature</option>
@@ -181,7 +196,7 @@ const PdcClearanceDeskTable = ({
                         {isFiltered && (
                             <button
                                 onClick={handleClearFilters}
-                                className="px-3 py-2 text-xs font-semibold text-gray-600 hover:text-gray-900 bg-gray-100 hover:bg-gray-200 rounded-lg transition-colors flex items-center gap-1"
+                                className="px-3 py-2 text-xs font-semibold text-gray-600 dark:text-slate-300 hover:text-gray-900 dark:hover:text-slate-100 bg-gray-100 dark:bg-slate-700 hover:bg-gray-200 dark:hover:bg-slate-600 rounded-lg transition-colors flex items-center gap-1"
                             >
                                 <span>✕</span> Reset Filters
                             </button>
@@ -200,13 +215,13 @@ const PdcClearanceDeskTable = ({
                                     onClick={() => onStatusFilterChange && onStatusFilterChange(st)}
                                     className={`px-3 py-1.5 rounded-lg text-xs font-bold uppercase transition-all flex items-center gap-1.5 whitespace-nowrap cursor-pointer ${
                                         isActive
-                                            ? 'bg-gray-900 text-white shadow-xs'
-                                            : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                                            ? 'bg-gray-900 dark:bg-primary-600 text-white shadow-xs'
+                                            : 'bg-gray-100 dark:bg-slate-700 text-gray-600 dark:text-slate-300 hover:bg-gray-200 dark:hover:bg-slate-600'
                                     }`}
                                 >
                                     <span>{st.replace(/_/g, ' ')}</span>
                                     <span className={`px-1.5 py-0.2 rounded-full text-[10px] ${
-                                        isActive ? 'bg-gray-700 text-white' : 'bg-gray-200 text-gray-700'
+                                        isActive ? 'bg-gray-700 dark:bg-primary-800 text-white' : 'bg-gray-200 dark:bg-slate-600 text-gray-700 dark:text-slate-300'
                                     }`}>
                                         {count}
                                     </span>
@@ -218,10 +233,10 @@ const PdcClearanceDeskTable = ({
             </div>
 
             {/* Table Section */}
-            <div className="bg-white rounded-xl border border-gray-200 overflow-hidden shadow-sm">
+            <div className="bg-white dark:bg-slate-800 rounded-xl border border-gray-200 dark:border-slate-700 overflow-hidden shadow-sm">
                 <div className="overflow-x-auto">
-                    <table className="w-full text-sm text-left text-gray-500">
-                        <thead className="text-xs text-gray-700 uppercase bg-gray-50 border-b border-gray-200">
+                    <table className="w-full text-sm text-left text-gray-500 dark:text-slate-400">
+                        <thead className="text-xs text-gray-700 dark:text-slate-300 uppercase bg-gray-50 dark:bg-slate-900/50 border-b border-gray-200 dark:border-slate-700">
                             <tr>
                                 <th className="px-6 py-3.5">Customer</th>
                                 <th className="px-6 py-3.5">Received Date</th>
@@ -233,54 +248,40 @@ const PdcClearanceDeskTable = ({
                                 <th className="px-6 py-3.5 text-center">Actions</th>
                             </tr>
                         </thead>
-                        <tbody className="divide-y divide-gray-200">
+                        <tbody className="divide-y divide-gray-200 dark:divide-slate-700">
                             {paginatedItems.map(item => (
-                                <tr key={item.payment_id} className="hover:bg-gray-50 transition-colors">
-                                    <td className="px-6 py-4 font-semibold text-gray-900">
+                                <tr key={item.payment_id} className="hover:bg-gray-50 dark:hover:bg-slate-700/40 transition-colors">
+                                    <td className="px-6 py-4 font-semibold text-gray-900 dark:text-slate-100">
                                         {item.company_name || `${item.first_name || ''} ${item.last_name || ''}`.trim() || 'Walk-in Customer'}
                                         {item.invoice_number && (
-                                            <div className="text-xs font-normal text-gray-400">
+                                            <div className="text-xs font-normal text-gray-400 dark:text-slate-500">
                                                 {item.invoice_count > 1
-                                                    ? <span className="inline-flex items-center gap-1"><span className="px-1.5 py-0.5 bg-indigo-100 text-indigo-700 rounded font-bold">{item.invoice_count} invoices</span> {item.invoice_number}</span>
+                                                    ? <span className="inline-flex items-center gap-1"><span className="px-1.5 py-0.5 bg-indigo-100 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-400 rounded font-bold">{item.invoice_count} invoices</span> {item.invoice_number}</span>
                                                     : `Inv: #${item.invoice_number}`
                                                 }
                                             </div>
                                         )}
                                     </td>
-                                    <td className="px-6 py-4 text-xs text-gray-600">
+                                    <td className="px-6 py-4 text-xs text-gray-600 dark:text-slate-400">
                                         {new Date(item.payment_date).toLocaleDateString()}
                                     </td>
-                                    <td className="px-6 py-4 font-semibold text-xs text-blue-900">
+                                    <td className="px-6 py-4 font-semibold text-xs text-primary-900 dark:text-primary-400">
                                         {item.cheque_date ? new Date(item.cheque_date).toLocaleDateString() : new Date(item.payment_date).toLocaleDateString()}
                                     </td>
-                                    <td className="px-6 py-4 font-mono font-medium text-gray-800">
+                                    <td className="px-6 py-4 font-mono font-medium text-gray-800 dark:text-slate-200">
                                         {item.reference_number || `#${item.payment_id}`}
                                     </td>
-                                    <td className="px-6 py-4 font-mono text-right font-bold text-gray-900">
+                                    <td className="px-6 py-4 font-mono text-right font-bold text-gray-900 dark:text-slate-100">
                                         {formatCurrency(item.amount)}
                                     </td>
                                     <td className="px-6 py-4">
-                                        <span className={`text-[10px] font-bold px-2 py-0.5 rounded-md ${
-                                            item.maturity_status === 'FUTURE_PDC' ? 'bg-blue-100 text-blue-800 border border-blue-200' :
-                                            item.maturity_status === 'STALE_CHEQUE' ? 'bg-purple-100 text-purple-800 border border-purple-200' :
-                                            'bg-amber-100 text-amber-800 border border-amber-200'
-                                        }`}>
-                                            {item.maturity_label || 'Due for Clearance'}
-                                        </span>
+                                        <StatusBadge tone={MATURITY_TONE[item.maturity_status] || 'warning'} label={item.maturity_label || 'Due for Clearance'} pill={false} />
                                     </td>
                                     <td className="px-6 py-4">
                                         <div className="flex flex-col items-start gap-1">
-                                            <span className={`text-[10px] font-bold px-2.5 py-1 rounded-full uppercase ${
-                                                item.pdc_status === 'CLEARED' ? 'bg-emerald-100 text-emerald-800' :
-                                                item.pdc_status === 'BOUNCED' ? 'bg-red-100 text-red-800' :
-                                                item.pdc_status === 'DEPOSITED' ? 'bg-indigo-100 text-indigo-800' :
-                                                item.pdc_status === 'HELD_IN_SAFE' ? 'bg-purple-100 text-purple-800' :
-                                                'bg-amber-100 text-amber-800'
-                                            }`}>
-                                                {item.pdc_status}
-                                            </span>
+                                            <StatusBadge tone={PDC_STATUS_TONE[item.pdc_status] || 'warning'} label={item.pdc_status} />
                                             {item.bounce_count > 0 && (
-                                                <span className="text-[10px] font-semibold text-rose-700 bg-rose-50 border border-rose-200 px-2 py-0.5 rounded-md">
+                                                <span className="text-[10px] font-semibold text-danger-700 dark:text-danger-400 bg-danger-50 dark:bg-danger-900/20 border border-danger-200 dark:border-danger-900/40 px-2 py-0.5 rounded-md">
                                                     ⚠️ {item.bounce_count} {item.bounce_count === 1 ? 'Bounce' : 'Bounces'}
                                                 </span>
                                             )}
@@ -293,27 +294,27 @@ const PdcClearanceDeskTable = ({
                                                     <button
                                                         type="button"
                                                         onClick={() => onVerifyClearance && onVerifyClearance({ ...item, action: 'clear' })}
-                                                        className="px-3 py-1.5 bg-emerald-600 hover:bg-emerald-700 text-white rounded-lg text-xs font-bold transition-all shadow-xs flex items-center gap-1 cursor-pointer"
+                                                        className="px-3 py-1.5 bg-success-600 hover:bg-success-700 text-white rounded-lg text-xs font-bold transition-all shadow-xs flex items-center gap-1 cursor-pointer"
                                                     >
                                                         <span>✓</span> Verify Clearance
                                                     </button>
                                                     <button
                                                         type="button"
                                                         onClick={() => onMarkBounced && onMarkBounced({ ...item, action: 'bounce' })}
-                                                        className="px-3 py-1.5 bg-rose-600 hover:bg-rose-700 text-white rounded-lg text-xs font-bold transition-all shadow-xs flex items-center gap-1 cursor-pointer"
+                                                        className="px-3 py-1.5 bg-danger-600 hover:bg-danger-700 text-white rounded-lg text-xs font-bold transition-all shadow-xs flex items-center gap-1 cursor-pointer"
                                                     >
                                                         <span>⚠️</span> Mark Bounced
                                                     </button>
                                                 </>
                                             ) : item.pdc_status === 'CLEARED' ? (
                                                 <>
-                                                    <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-bold bg-emerald-50 text-emerald-700 border border-emerald-200">
+                                                    <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-bold bg-success-50 dark:bg-success-900/20 text-success-700 dark:text-success-400 border border-success-200 dark:border-success-900/40">
                                                         <span>✓</span> Cleared
                                                     </span>
                                                     <button
                                                         type="button"
                                                         onClick={() => onMarkBounced && onMarkBounced({ ...item, action: 'bounce' })}
-                                                        className="text-[11px] font-semibold text-rose-600 hover:text-rose-800 hover:underline cursor-pointer"
+                                                        className="text-[11px] font-semibold text-danger-600 dark:text-danger-400 hover:text-danger-800 dark:hover:text-danger-300 hover:underline cursor-pointer"
                                                         title="Report retroactive cheque bounce"
                                                     >
                                                         Report Bounce
@@ -321,13 +322,13 @@ const PdcClearanceDeskTable = ({
                                                 </>
                                             ) : (
                                                 <>
-                                                    <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-bold bg-red-50 text-red-700 border border-red-200">
+                                                    <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-bold bg-danger-50 dark:bg-danger-900/20 text-danger-700 dark:text-danger-400 border border-danger-200 dark:border-danger-900/40">
                                                         <span>⚠️</span> Bounced
                                                     </span>
                                                     <button
                                                         type="button"
                                                         onClick={() => (onRedepositCheque || onVerifyClearance) && (onRedepositCheque ? onRedepositCheque({ ...item, action: 'redeposit' }) : onVerifyClearance({ ...item, action: 'redeposit' }))}
-                                                        className="px-3 py-1.5 bg-blue-600 hover:bg-blue-700 text-white rounded-lg text-xs font-bold transition-all shadow-xs flex items-center gap-1 cursor-pointer"
+                                                        className="px-3 py-1.5 bg-primary-600 hover:bg-primary-700 text-white rounded-lg text-xs font-bold transition-all shadow-xs flex items-center gap-1 cursor-pointer"
                                                         title="Re-deposit bounced cheque for bank clearing process"
                                                     >
                                                         <span>🔄</span> Re-deposit
@@ -338,7 +339,7 @@ const PdcClearanceDeskTable = ({
                                                 <button
                                                     type="button"
                                                     onClick={() => onViewHistory(item)}
-                                                    className="px-2.5 py-1.5 bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-lg text-xs font-semibold transition-all border border-gray-200 cursor-pointer"
+                                                    className="px-2.5 py-1.5 bg-gray-100 dark:bg-slate-700 hover:bg-gray-200 dark:hover:bg-slate-600 text-gray-700 dark:text-slate-200 rounded-lg text-xs font-semibold transition-all border border-gray-200 dark:border-slate-600 cursor-pointer"
                                                     title="View complete clearance & bounce history timeline"
                                                 >
                                                     📜 History
@@ -350,15 +351,15 @@ const PdcClearanceDeskTable = ({
                             ))}
                             {filteredItems.length === 0 && (
                                 <tr>
-                                    <td colSpan={8} className="px-6 py-12 text-center text-gray-500">
+                                    <td colSpan={8} className="px-6 py-12 text-center text-gray-500 dark:text-slate-400">
                                         <div className="flex flex-col items-center justify-center gap-2">
                                             <span className="text-2xl">📋</span>
-                                            <p className="font-semibold text-gray-700">No cheque / PDC items found</p>
-                                            <p className="text-xs text-gray-400">Try adjusting your search criteria, PDC status filter, or maturity filter.</p>
+                                            <p className="font-semibold text-gray-700 dark:text-slate-300">No cheque / PDC items found</p>
+                                            <p className="text-xs text-gray-400 dark:text-slate-500">Try adjusting your search criteria, PDC status filter, or maturity filter.</p>
                                             {isFiltered && (
                                                 <button
                                                     onClick={handleClearFilters}
-                                                    className="mt-2 text-xs text-blue-600 font-semibold hover:underline"
+                                                    className="mt-2 text-xs text-primary-600 dark:text-primary-400 font-semibold hover:underline"
                                                 >
                                                     Reset all filters
                                                 </button>
@@ -373,7 +374,7 @@ const PdcClearanceDeskTable = ({
 
                 {/* Pagination Controls */}
                 {filteredItems.length > 0 && (
-                    <div className="p-4 border-t border-gray-100">
+                    <div className="p-4 border-t border-gray-100 dark:border-slate-700">
                         <PaginationControls
                             page={page}
                             pageSize={pageSize}

--- a/packages/web/src/components/cheques/ChequeSettingsPanel.jsx
+++ b/packages/web/src/components/cheques/ChequeSettingsPanel.jsx
@@ -1,0 +1,585 @@
+import { useEffect, useMemo, useState } from 'react';
+import { format } from 'date-fns';
+import toast from 'react-hot-toast';
+import api from '../../api';
+import Icon from '../ui/Icon';
+import SegmentedTabs from '../ui/SegmentedTabs';
+import { ICONS } from '../../constants';
+
+const DEFAULT_TEMPLATE = {
+    date: { x: 426, y: 178, alignment: 'left', fontSize: 11, mode: 'boxed', charSpacing: 14 },
+    payee: { x: 72, y: 136, alignment: 'left', fontSize: 12, maxWidth: 380, minFontSize: 8 },
+    amountNumeric: { x: 534, y: 136, alignment: 'right', fontSize: 12 },
+    amountWords: { x: 72, y: 104, alignment: 'left', fontSize: 11, maxWidth: 420 },
+    memo: { x: 72, y: 84, alignment: 'left', fontSize: 10, maxWidth: 220 },
+    currency: { x: 474, y: 136, alignment: 'left', fontSize: 11 }
+};
+
+const SETTINGS_TABS = [
+    { key: 'layout', label: 'Layout' },
+    { key: 'date', label: 'Date' },
+    { key: 'amount', label: 'Amount' },
+    { key: 'currency', label: 'Currency' },
+    { key: 'paper', label: 'Paper' },
+    { key: 'text', label: 'Text' },
+    { key: 'calibration', label: 'Calibration' }
+];
+
+const FIELD_LABELS = {
+    date: 'Date',
+    payee: 'Payee',
+    amountNumeric: 'Amount in figures',
+    amountWords: 'Amount in words',
+    memo: 'Memo',
+    currency: 'Currency symbol'
+};
+
+const BUTTON_BASE = 'inline-flex items-center justify-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50';
+const BUTTON_SECONDARY = `${BUTTON_BASE} border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-700 dark:text-slate-200 hover:bg-gray-50 dark:hover:bg-slate-700`;
+const BUTTON_PRIMARY = `${BUTTON_BASE} bg-primary-600 text-white hover:bg-primary-700`;
+const BUTTON_DANGER = `${BUTTON_BASE} border border-danger-200 dark:border-danger-900/50 bg-white dark:bg-slate-800 text-danger-600 dark:text-danger-400 hover:bg-danger-50 dark:hover:bg-danger-900/20`;
+const INPUT_BASE = 'w-full rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-100 px-3 py-2 text-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-100 dark:focus:ring-primary-900/30';
+const LABEL_CLASS = 'block text-xs font-semibold text-gray-500 dark:text-slate-400 uppercase tracking-wide mb-1';
+
+const ChequeSettingsPanel = () => {
+    const [templates, setTemplates] = useState([]);
+    const [printerProfiles, setPrinterProfiles] = useState([]);
+    const [selectedTemplateId, setSelectedTemplateId] = useState('');
+    const [selectedProfileId, setSelectedProfileId] = useState('');
+    const [activeTab, setActiveTab] = useState('layout');
+    const [draftProfile, setDraftProfile] = useState({ profile_name: '', feed_type: 'native', offset_x: 0, offset_y: 0, is_default: false });
+
+    const selectedTemplate = useMemo(() => templates.find((tpl) => String(tpl.id) === String(selectedTemplateId)), [templates, selectedTemplateId]);
+    const selectedProfile = useMemo(() => printerProfiles.find((profile) => String(profile.id) === String(selectedProfileId)), [printerProfiles, selectedProfileId]);
+
+    const loadData = async () => {
+        try {
+            const [templatesRes, profilesRes] = await Promise.all([api.get('/cheques/templates'), api.get('/cheques/printer-profiles')]);
+            const templateRows = templatesRes.data || [];
+            const profileRows = profilesRes.data || [];
+            setTemplates(templateRows);
+            setPrinterProfiles(profileRows);
+            if (!selectedTemplateId && templateRows.length) setSelectedTemplateId(String(templateRows[0].id));
+            if (!selectedProfileId && profileRows.length) {
+                const defaultProfile = profileRows.find((profile) => profile.is_default) || profileRows[0];
+                setSelectedProfileId(String(defaultProfile.id));
+            }
+        } catch (error) {
+            toast.error(error?.response?.data?.message || 'Failed to load cheque templates & printer profiles.');
+        }
+    };
+
+    useEffect(() => { loadData(); }, []);
+    useEffect(() => {
+        if (!selectedProfile) {
+            setDraftProfile({ profile_name: '', feed_type: 'native', offset_x: 0, offset_y: 0, is_default: false });
+            return;
+        }
+        setDraftProfile({
+            profile_name: selectedProfile.profile_name || '',
+            feed_type: selectedProfile.feed_type || 'native',
+            offset_x: Number(selectedProfile.offset_x || 0),
+            offset_y: Number(selectedProfile.offset_y || 0),
+            is_default: Boolean(selectedProfile.is_default)
+        });
+    }, [selectedProfileId]);
+
+    const updateTemplate = async (patch) => {
+        if (!selectedTemplate) return;
+        try {
+            const response = await api.put(`/cheques/templates/${selectedTemplate.id}`, {
+                ...selectedTemplate,
+                ...patch
+            });
+            setTemplates((prev) => prev.map((template) => (template.id === response.data.id ? response.data : template)));
+        } catch (error) {
+            toast.error(error?.response?.data?.message || 'Template update failed.');
+        }
+    };
+
+    const upsertProfile = async (patch) => {
+        try {
+            if (!selectedProfile) {
+                const created = await api.post('/cheques/printer-profiles', {
+                    profile_name: patch.profile_name || `Profile ${printerProfiles.length + 1}`,
+                    feed_type: patch.feed_type || 'native',
+                    offset_x: patch.offset_x || 0,
+                    offset_y: patch.offset_y || 0,
+                    is_default: patch.is_default || false
+                });
+                setPrinterProfiles((prev) => [...prev, created.data]);
+                setSelectedProfileId(String(created.data.id));
+                return;
+            }
+
+            const response = await api.put(`/cheques/printer-profiles/${selectedProfile.id}`, {
+                ...selectedProfile,
+                ...patch
+            });
+
+            setPrinterProfiles((prev) => prev.map((profile) => (profile.id === response.data.id ? response.data : profile)));
+        } catch (error) {
+            toast.error(error?.response?.data?.message || 'Printer profile update failed.');
+        }
+    };
+
+    const createTemplateFromCurrent = async () => {
+        const baseName = selectedTemplate?.bank_name || 'New Bank Preset';
+        const bankName = window.prompt('Enter name for bank preset:', selectedTemplate ? `${baseName} Copy` : baseName);
+        if (!bankName?.trim()) return;
+        try {
+            const res = await api.post('/cheques/templates', {
+                ...(selectedTemplate || {}),
+                bank_name: bankName.trim(),
+                field_positions: selectedTemplate?.field_positions || DEFAULT_TEMPLATE
+            });
+            setTemplates((prev) => [...prev, res.data].sort((a, b) => a.bank_name.localeCompare(b.bank_name)));
+            setSelectedTemplateId(String(res.data.id));
+            toast.success(selectedTemplate ? 'Bank preset duplicated.' : 'Bank preset created.');
+        } catch (error) {
+            toast.error(error?.response?.data?.message || 'Failed to save bank preset.');
+        }
+    };
+
+    const deleteCurrentTemplate = async () => {
+        if (!selectedTemplate) return;
+        if (!window.confirm(`Delete bank preset "${selectedTemplate.bank_name}"?`)) return;
+        try {
+            await api.delete(`/cheques/templates/${selectedTemplate.id}`);
+            toast.success('Bank preset deleted.');
+            await loadData();
+            setSelectedTemplateId('');
+        } catch (error) {
+            toast.error(error?.response?.data?.message || 'Failed to delete bank preset.');
+        }
+    };
+
+    const duplicateCurrentProfile = async () => {
+        if (!selectedProfile) return;
+        const profileName = window.prompt('Enter name for duplicated printer profile:', `${selectedProfile.profile_name} Copy`);
+        if (!profileName?.trim()) return;
+        try {
+            const created = await api.post('/cheques/printer-profiles', {
+                profile_name: profileName.trim(),
+                feed_type: selectedProfile.feed_type || 'native',
+                offset_x: Number(selectedProfile.offset_x || 0),
+                offset_y: Number(selectedProfile.offset_y || 0),
+                is_default: false
+            });
+            setPrinterProfiles((prev) => [...prev, created.data]);
+            setSelectedProfileId(String(created.data.id));
+            toast.success('Printer profile duplicated.');
+        } catch (error) {
+            toast.error(error?.response?.data?.message || 'Failed to duplicate printer profile.');
+        }
+    };
+
+    const deleteCurrentProfile = async () => {
+        if (!selectedProfile) return;
+        if (!window.confirm(`Delete printer profile "${selectedProfile.profile_name}"?`)) return;
+        try {
+            await api.delete(`/cheques/printer-profiles/${selectedProfile.id}`);
+            toast.success('Printer profile deleted.');
+            await loadData();
+            setSelectedProfileId('');
+        } catch (error) {
+            toast.error(error?.response?.data?.message || 'Failed to delete printer profile.');
+        }
+    };
+
+    const downloadSettingsExport = async () => {
+        try {
+            const response = await api.get('/cheques/settings-export', { responseType: 'blob' });
+            const blobUrl = window.URL.createObjectURL(new Blob([response.data], { type: 'application/json' }));
+            const link = document.createElement('a');
+            link.href = blobUrl;
+            link.setAttribute('download', `cheque-settings-${format(new Date(), 'yyyy-MM-dd')}.json`);
+            document.body.appendChild(link);
+            link.click();
+            link.remove();
+            window.URL.revokeObjectURL(blobUrl);
+            toast.success('Cheque settings exported.');
+        } catch (error) {
+            toast.error(error?.response?.data?.message || 'Failed to export cheque settings.');
+        }
+    };
+
+    const importSettingsFile = async (event) => {
+        const file = event.target.files?.[0];
+        if (!file) return;
+        try {
+            const payload = JSON.parse(await file.text());
+            const overwrite = window.confirm('Overwrite existing presets/profiles with matching names? Click Cancel to append only.');
+            await api.post('/cheques/settings-import', { ...payload, overwrite });
+            toast.success('Cheque settings imported.');
+            await loadData();
+        } catch (error) {
+            toast.error(error?.response?.data?.message || 'Failed to import cheque settings file.');
+        } finally {
+            event.target.value = '';
+        }
+    };
+
+    return (
+        <div className="space-y-4 pb-4">
+            <div className="bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-xl p-4 md:p-5">
+                <h2 className="text-lg md:text-xl font-semibold text-gray-900 dark:text-slate-100">Templates &amp; Settings</h2>
+                <p className="text-sm text-gray-500 dark:text-slate-400 mt-1">Manage bank cheque presets and printer calibration profiles used across Print Cheques and the Treasury Desk.</p>
+            </div>
+
+            <div className="bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-xl p-4 md:p-5 space-y-4">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div>
+                        <label className={LABEL_CLASS}>Bank preset</label>
+                        <select className={INPUT_BASE} value={selectedTemplateId} onChange={(e) => setSelectedTemplateId(e.target.value)}>
+                            {!templates.length && <option value="">No bank preset yet</option>}
+                            {templates.map((template) => <option key={template.id} value={template.id}>{template.bank_name}</option>)}
+                        </select>
+                        <div className="flex gap-2 mt-2">
+                            <button className={BUTTON_SECONDARY} onClick={createTemplateFromCurrent}>{selectedTemplate ? 'Duplicate Preset' : 'Create Preset'}</button>
+                            <button className={BUTTON_DANGER} onClick={deleteCurrentTemplate} disabled={!selectedTemplate || templates.length <= 1}>Delete Preset</button>
+                        </div>
+                    </div>
+                    <div>
+                        <label className={LABEL_CLASS}>Printer profile</label>
+                        <select className={INPUT_BASE} value={selectedProfileId} onChange={(e) => setSelectedProfileId(e.target.value)}>
+                            <option value="">{printerProfiles.length ? 'None' : 'No printer profile yet'}</option>
+                            {printerProfiles.map((profile) => <option key={profile.id} value={profile.id}>{profile.profile_name}{profile.is_default ? ' (Default)' : ''}</option>)}
+                        </select>
+                        <div className="flex gap-2 mt-2">
+                            <button className={BUTTON_SECONDARY} onClick={duplicateCurrentProfile} disabled={!selectedProfile}>Duplicate Profile</button>
+                            <button className={BUTTON_DANGER} onClick={deleteCurrentProfile} disabled={!selectedProfile}>Delete Profile</button>
+                        </div>
+                    </div>
+                </div>
+
+                <div className="border-t border-gray-200 dark:border-slate-700 pt-3 overflow-x-auto">
+                    <SegmentedTabs tabs={SETTINGS_TABS} active={activeTab} onChange={setActiveTab} />
+                </div>
+
+                <div className="text-sm space-y-4">
+                    {activeTab === 'layout' && selectedTemplate && (
+                        <div className="space-y-3">
+                            <div className="flex flex-wrap items-center justify-between gap-2 border border-gray-200 dark:border-slate-700 rounded-lg bg-gray-50 dark:bg-slate-900/40 p-3">
+                                <div>
+                                    <p className="font-medium text-gray-900 dark:text-slate-100">Bank preset details</p>
+                                    <p className="text-xs text-gray-500 dark:text-slate-400">Save and share this bank preset including cheque layout variables.</p>
+                                </div>
+                                <button className={BUTTON_PRIMARY} onClick={() => updateTemplate({ ...selectedTemplate })}>
+                                    <Icon path={ICONS.settings} className="h-4 w-4" />
+                                    Save Bank Preset
+                                </button>
+                            </div>
+                            <div>
+                                <label className={LABEL_CLASS}>Bank preset name</label>
+                                <input className={INPUT_BASE} value={selectedTemplate.bank_name || ''} onChange={(e) => updateTemplate({ bank_name: e.target.value })} />
+                            </div>
+                            <p className="text-gray-600 dark:text-slate-400">Fine-tune field placements and sizes for this cheque template.</p>
+                            <div className="grid grid-cols-4 lg:grid-cols-6 gap-2 text-xs font-semibold text-gray-500 dark:text-slate-400 uppercase tracking-wide">
+                                <span>Field</span>
+                                <span>X Position</span>
+                                <span>Y Position</span>
+                                <span>Font Size</span>
+                                <span className="hidden lg:block">Max Width</span>
+                                <span className="hidden lg:block">Min Font</span>
+                            </div>
+                            {Object.entries(selectedTemplate.field_positions || {}).map(([field, cfg]) => {
+                                const showExtras = ['payee', 'amountWords', 'memo'].includes(field);
+                                return (
+                                    <div key={field} className="grid grid-cols-4 lg:grid-cols-6 gap-2 items-center border border-gray-200 dark:border-slate-700 rounded-lg p-2">
+                                        <span className="font-medium truncate text-gray-800 dark:text-slate-200" title={FIELD_LABELS[field] || field}>{FIELD_LABELS[field] || field}</span>
+                                        <input type="number" className={INPUT_BASE} aria-label={`${field} X`} value={cfg.x ?? 0} onChange={(e) => updateTemplate({ field_positions: { ...selectedTemplate.field_positions, [field]: { ...cfg, x: Number(e.target.value) } } })} />
+                                        <input type="number" className={INPUT_BASE} aria-label={`${field} Y`} value={cfg.y ?? 0} onChange={(e) => updateTemplate({ field_positions: { ...selectedTemplate.field_positions, [field]: { ...cfg, y: Number(e.target.value) } } })} />
+                                        <input type="number" className={INPUT_BASE} aria-label={`${field} Font`} value={cfg.fontSize ?? 11} onChange={(e) => updateTemplate({ field_positions: { ...selectedTemplate.field_positions, [field]: { ...cfg, fontSize: Number(e.target.value) } } })} />
+                                        {showExtras ? (
+                                            <>
+                                                <input type="number" className={`${INPUT_BASE} col-span-2 lg:col-span-1`} aria-label={`${field} Max Width`} placeholder="Max Width" value={cfg.maxWidth ?? ''} onChange={(e) => updateTemplate({ field_positions: { ...selectedTemplate.field_positions, [field]: { ...cfg, maxWidth: e.target.value ? Number(e.target.value) : null } } })} />
+                                                <input type="number" className={`${INPUT_BASE} col-span-2 lg:col-span-1`} aria-label={`${field} Min Font`} placeholder="Min Font" value={cfg.minFontSize ?? ''} onChange={(e) => updateTemplate({ field_positions: { ...selectedTemplate.field_positions, [field]: { ...cfg, minFontSize: e.target.value ? Number(e.target.value) : null } } })} />
+                                            </>
+                                        ) : (
+                                            <div className="hidden lg:block lg:col-span-2"></div>
+                                        )}
+                                    </div>
+                                );
+                            })}
+                        </div>
+                    )}
+                    {activeTab === 'layout' && !selectedTemplate && (
+                        <div className="space-y-3">
+                            <p className="text-gray-600 dark:text-slate-400">No bank preset exists yet. Create one or import settings to begin configuring cheque layout.</p>
+                            <div className="flex gap-2">
+                                <button className={BUTTON_PRIMARY} onClick={createTemplateFromCurrent}>Create Bank Preset</button>
+                                <label className={`${BUTTON_SECONDARY} cursor-pointer`}>
+                                    Import Presets &amp; Profiles
+                                    <input type="file" accept="application/json" className="hidden" onChange={importSettingsFile} />
+                                </label>
+                            </div>
+                        </div>
+                    )}
+
+                    {activeTab === 'date' && selectedTemplate && (
+                        <div className="space-y-3">
+                            <div>
+                                <label className={LABEL_CLASS}>Date output format</label>
+                                <select className={INPUT_BASE} value={selectedTemplate.date_format || 'MM-dd-yyyy'} onChange={(e) => updateTemplate({ date_format: e.target.value })}>
+                                    <option value="MM-dd-yyyy">MM-DD-YYYY</option>
+                                    <option value="MM/dd/yyyy">MM/dd/yyyy</option>
+                                    <option value="dd/MM/yyyy">dd/MM/yyyy</option>
+                                    <option value="MMM dd, yyyy">MMM dd, yyyy</option>
+                                </select>
+                            </div>
+                            <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+                                <div>
+                                    <label className={LABEL_CLASS}>Date Mode</label>
+                                    <select
+                                        className={INPUT_BASE}
+                                        value={selectedTemplate.field_positions?.date?.mode || 'single'}
+                                        onChange={(e) => updateTemplate({
+                                            field_positions: {
+                                                ...selectedTemplate.field_positions,
+                                                date: { ...(selectedTemplate.field_positions?.date || {}), mode: e.target.value }
+                                            }
+                                        })}
+                                    >
+                                        <option value="single">Single-line date mode</option>
+                                        <option value="boxed">Boxed date mode (MMDDYYYY without separators)</option>
+                                    </select>
+                                </div>
+                                <div className="flex gap-2">
+                                    <div className="flex-1">
+                                        <label className={LABEL_CLASS}>Char Spacing</label>
+                                        <input
+                                            type="number"
+                                            step="0.5"
+                                            className={INPUT_BASE}
+                                            placeholder="Character spacing"
+                                            title="Character spacing"
+                                            value={selectedTemplate.field_positions?.date?.charSpacing ?? 0}
+                                            onChange={(e) => updateTemplate({
+                                                field_positions: {
+                                                    ...selectedTemplate.field_positions,
+                                                    date: { ...(selectedTemplate.field_positions?.date || {}), charSpacing: Number(e.target.value) || 0 }
+                                                }
+                                            })}
+                                        />
+                                    </div>
+                                    {selectedTemplate.field_positions?.date?.mode === 'boxed' && (
+                                        <div className="flex-1">
+                                            <label className={LABEL_CLASS}>Block Spacing</label>
+                                            <input
+                                                type="number"
+                                                step="0.5"
+                                                className={INPUT_BASE}
+                                                placeholder="Block Spacing (pt)"
+                                                title="Block Spacing (pt)"
+                                                value={selectedTemplate.field_positions?.date?.blockSpacing ?? selectedTemplate.field_positions?.date?.charSpacing ?? 0}
+                                                onChange={(e) => updateTemplate({
+                                                    field_positions: {
+                                                        ...selectedTemplate.field_positions,
+                                                        date: { ...(selectedTemplate.field_positions?.date || {}), blockSpacing: Number(e.target.value) || 0 }
+                                                    }
+                                                })}
+                                            />
+                                        </div>
+                                    )}
+                                </div>
+                            </div>
+                        </div>
+                    )}
+
+                    {activeTab === 'amount' && selectedTemplate && (
+                        <div className="space-y-3">
+                            <div>
+                                <label className={LABEL_CLASS}>Amount words casing</label>
+                                <select className={INPUT_BASE} value={selectedTemplate.amount_format || 'title_case'} onChange={(e) => updateTemplate({ amount_format: e.target.value })}>
+                                    <option value="title_case">Title Case</option>
+                                    <option value="upper">UPPER CASE</option>
+                                </select>
+                            </div>
+                            <div>
+                                <label className={LABEL_CLASS}>Amount suffix</label>
+                                <input
+                                    className={INPUT_BASE}
+                                    placeholder="pesos"
+                                    value={selectedTemplate.amount_words_settings?.suffix || 'pesos'}
+                                    onChange={(e) => updateTemplate({
+                                        amount_words_settings: {
+                                            ...(selectedTemplate.amount_words_settings || {}),
+                                            suffix: e.target.value
+                                        }
+                                    })}
+                                />
+                                <p className="text-xs text-gray-500 dark:text-slate-400 mt-1">Whole numbers render as “&lt;amount&gt; suffix only”. Decimal amounts render as “&lt;amount&gt; suffix and xx/100”.</p>
+                            </div>
+                        </div>
+                    )}
+
+                    {activeTab === 'currency' && selectedTemplate && (
+                        <div className="space-y-2">
+                            <label className="flex items-center gap-2 text-gray-700 dark:text-slate-300"><input type="checkbox" checked={selectedTemplate.currency_settings?.enabled !== false} onChange={(e) => updateTemplate({ currency_settings: { ...selectedTemplate.currency_settings, enabled: e.target.checked } })} /> Show currency label</label>
+                            <label className={LABEL_CLASS}>Symbol outside amount box</label>
+                            <input className={INPUT_BASE} value={selectedTemplate.currency_settings?.label || ''} onChange={(e) => updateTemplate({ currency_settings: { ...selectedTemplate.currency_settings, label: e.target.value } })} />
+                        </div>
+                    )}
+
+                    {activeTab === 'paper' && selectedTemplate && (
+                        <div className="space-y-3">
+                            <p className="text-gray-600 dark:text-slate-400">Paper size is stored in the selected bank preset.</p>
+                            <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+                                <div>
+                                    <label className={LABEL_CLASS}>Width (inches)</label>
+                                    <input
+                                        type="number"
+                                        min="1"
+                                        step="0.1"
+                                        className={INPUT_BASE}
+                                        value={selectedTemplate.paper_settings?.widthIn ?? 8}
+                                        onChange={(e) => updateTemplate({ paper_settings: { ...(selectedTemplate.paper_settings || {}), widthIn: Number(e.target.value) || 8, unit: 'in' } })}
+                                    />
+                                </div>
+                                <div>
+                                    <label className={LABEL_CLASS}>Height (inches)</label>
+                                    <input
+                                        type="number"
+                                        min="1"
+                                        step="0.1"
+                                        className={INPUT_BASE}
+                                        value={selectedTemplate.paper_settings?.heightIn ?? 3}
+                                        onChange={(e) => updateTemplate({ paper_settings: { ...(selectedTemplate.paper_settings || {}), heightIn: Number(e.target.value) || 3, unit: 'in' } })}
+                                    />
+                                </div>
+                            </div>
+                            <p className="text-xs text-gray-500 dark:text-slate-400">Recommended standardized size: 8" x 3".</p>
+                        </div>
+                    )}
+
+                    {activeTab === 'text' && selectedTemplate && (
+                        <div className="space-y-3">
+                            <p className="text-gray-600 dark:text-slate-400">Payee overflow mitigation uses template font size and width values; no line wrapping is applied.</p>
+                            <div className="border border-gray-200 dark:border-slate-700 rounded-lg p-3 space-y-2 bg-gray-50 dark:bg-slate-900/40">
+                                <label className="flex items-center gap-2 text-gray-700 dark:text-slate-300">
+                                    <input
+                                        type="checkbox"
+                                        checked={Boolean(selectedTemplate.text_settings?.payeeFillerEnabled)}
+                                        onChange={(e) => updateTemplate({
+                                            text_settings: {
+                                                ...(selectedTemplate.text_settings || {}),
+                                                payeeFillerEnabled: e.target.checked
+                                            }
+                                        })}
+                                    />
+                                    Add filler at both ends of payee text
+                                </label>
+                                <input
+                                    className={INPUT_BASE}
+                                    placeholder="***"
+                                    value={selectedTemplate.text_settings?.payeeFiller || '***'}
+                                    onChange={(e) => updateTemplate({
+                                        text_settings: {
+                                            ...(selectedTemplate.text_settings || {}),
+                                            payeeFiller: e.target.value
+                                        }
+                                    })}
+                                />
+                            </div>
+                            <div className="border border-gray-200 dark:border-slate-700 rounded-lg p-3 space-y-2 bg-gray-50 dark:bg-slate-900/40">
+                                <label className="flex items-center gap-2 text-gray-700 dark:text-slate-300">
+                                    <input
+                                        type="checkbox"
+                                        checked={Boolean(selectedTemplate.text_settings?.amountWordsFillerEnabled)}
+                                        onChange={(e) => updateTemplate({
+                                            text_settings: {
+                                                ...(selectedTemplate.text_settings || {}),
+                                                amountWordsFillerEnabled: e.target.checked
+                                            }
+                                        })}
+                                    />
+                                    Add filler at both ends of amount-in-words
+                                </label>
+                                <input
+                                    className={INPUT_BASE}
+                                    placeholder="***"
+                                    value={selectedTemplate.text_settings?.amountWordsFiller || '***'}
+                                    onChange={(e) => updateTemplate({
+                                        text_settings: {
+                                            ...(selectedTemplate.text_settings || {}),
+                                            amountWordsFiller: e.target.value
+                                        }
+                                    })}
+                                />
+                            </div>
+                        </div>
+                    )}
+
+                    {activeTab === 'calibration' && (
+                        <div className="space-y-3">
+                            <div className="border border-gray-200 dark:border-slate-700 rounded-lg p-3 bg-gray-50 dark:bg-slate-900/40 space-y-2">
+                                <p className="font-medium text-gray-900 dark:text-slate-100">Import / Export Configuration</p>
+                                <p className="text-xs text-gray-600 dark:text-slate-400">Export all bank presets and printer profiles to a JSON file for sharing or backup.</p>
+                                <div className="flex flex-wrap gap-2">
+                                    <button className={BUTTON_SECONDARY} onClick={downloadSettingsExport}>Export Presets &amp; Profiles</button>
+                                    <label className={`${BUTTON_SECONDARY} cursor-pointer`}>
+                                        Import Presets &amp; Profiles
+                                        <input type="file" accept="application/json" className="hidden" onChange={importSettingsFile} />
+                                    </label>
+                                </div>
+                            </div>
+                            <p className="text-gray-600 dark:text-slate-400">Save profile offsets to match your printer's physical output alignment.</p>
+                            <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+                                <input
+                                    className={INPUT_BASE}
+                                    placeholder="Profile name"
+                                    value={draftProfile.profile_name}
+                                    onChange={(e) => setDraftProfile((prev) => ({ ...prev, profile_name: e.target.value }))}
+                                />
+                                <select
+                                    className={INPUT_BASE}
+                                    value={draftProfile.feed_type || 'native'}
+                                    onChange={(e) => setDraftProfile((prev) => ({ ...prev, feed_type: e.target.value }))}
+                                >
+                                    <option value="native">Native (Custom Paper Size)</option>
+                                    <option value="letter_center">Letter Size (Center Feed)</option>
+                                    <option value="letter_left">Letter Size (Left Feed)</option>
+                                    <option value="letter_right">Letter Size (Right Feed)</option>
+                                </select>
+                                <input
+                                    type="number"
+                                    step="0.1"
+                                    className={INPUT_BASE}
+                                    placeholder="Offset X"
+                                    value={draftProfile.offset_x}
+                                    onChange={(e) => setDraftProfile((prev) => ({ ...prev, offset_x: Number(e.target.value) || 0 }))}
+                                />
+                                <input
+                                    type="number"
+                                    step="0.1"
+                                    className={INPUT_BASE}
+                                    placeholder="Offset Y"
+                                    value={draftProfile.offset_y}
+                                    onChange={(e) => setDraftProfile((prev) => ({ ...prev, offset_y: Number(e.target.value) || 0 }))}
+                                />
+                            </div>
+                            <p className="text-xs text-gray-500 dark:text-slate-400">If your printer rejects custom 8x3 paper sizes, select your manual tray&apos;s feed alignment. The system will print on a Letter canvas to bypass the error.</p>
+                            <label className="flex items-center gap-2 text-gray-700 dark:text-slate-300">
+                                <input
+                                    type="checkbox"
+                                    checked={Boolean(draftProfile.is_default)}
+                                    onChange={(e) => setDraftProfile((prev) => ({ ...prev, is_default: e.target.checked }))}
+                                />
+                                Set as default profile
+                            </label>
+                            <div className="flex gap-2">
+                                <button className={BUTTON_PRIMARY} onClick={() => upsertProfile(draftProfile)}><Icon path={ICONS.settings} className="h-4 w-4" />{selectedProfile ? 'Save Profile' : 'Create Profile'}</button>
+                                {!selectedProfile && (
+                                    <button className={BUTTON_SECONDARY} onClick={() => setDraftProfile({ profile_name: `Profile ${printerProfiles.length + 1}`, feed_type: 'native', offset_x: 0, offset_y: 0, is_default: false })}><Icon path={ICONS.edit} className="h-4 w-4" />Quick Fill</button>
+                                )}
+                            </div>
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default ChequeSettingsPanel;

--- a/packages/web/src/components/cheques/ChequeSettingsPanel.jsx
+++ b/packages/web/src/components/cheques/ChequeSettingsPanel.jsx
@@ -1,0 +1,625 @@
+import { useEffect, useMemo, useState } from 'react';
+import { format } from 'date-fns';
+import toast from 'react-hot-toast';
+import api from '../../api';
+import Icon from '../ui/Icon';
+import SegmentedTabs from '../ui/SegmentedTabs';
+import { ICONS } from '../../constants';
+
+const DEFAULT_TEMPLATE = {
+    date: { x: 426, y: 178, alignment: 'left', fontSize: 11, mode: 'boxed', charSpacing: 14 },
+    payee: { x: 72, y: 136, alignment: 'left', fontSize: 12, maxWidth: 380, minFontSize: 8 },
+    amountNumeric: { x: 534, y: 136, alignment: 'right', fontSize: 12 },
+    amountWords: { x: 72, y: 104, alignment: 'left', fontSize: 11, maxWidth: 420 },
+    memo: { x: 72, y: 84, alignment: 'left', fontSize: 10, maxWidth: 220 },
+    currency: { x: 474, y: 136, alignment: 'left', fontSize: 11 }
+};
+
+const SETTINGS_TABS = [
+    { key: 'layout', label: 'Layout' },
+    { key: 'date', label: 'Date' },
+    { key: 'amount', label: 'Amount' },
+    { key: 'currency', label: 'Currency' },
+    { key: 'paper', label: 'Paper' },
+    { key: 'text', label: 'Text' },
+    { key: 'calibration', label: 'Calibration' }
+];
+
+const FIELD_LABELS = {
+    date: 'Date',
+    payee: 'Payee',
+    amountNumeric: 'Amount in figures',
+    amountWords: 'Amount in words',
+    memo: 'Memo',
+    currency: 'Currency symbol'
+};
+
+const BUTTON_BASE = 'inline-flex items-center justify-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50';
+const BUTTON_SECONDARY = `${BUTTON_BASE} border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-700 dark:text-slate-200 hover:bg-gray-50 dark:hover:bg-slate-700`;
+const BUTTON_PRIMARY = `${BUTTON_BASE} bg-primary-600 text-white hover:bg-primary-700`;
+const BUTTON_DANGER = `${BUTTON_BASE} border border-danger-200 dark:border-danger-900/50 bg-white dark:bg-slate-800 text-danger-600 dark:text-danger-400 hover:bg-danger-50 dark:hover:bg-danger-900/20`;
+const BUTTON_SM = 'text-xs px-2.5 py-1.5';
+const INPUT_BASE = 'w-full rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-100 px-3 py-2 text-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-100 dark:focus:ring-primary-900/30';
+const INPUT_MONO = `${INPUT_BASE} font-mono tabular-nums`;
+const LABEL_CLASS = 'block text-xs font-semibold text-gray-500 dark:text-slate-400 uppercase tracking-wide mb-1';
+const SECTION_EYEBROW = 'flex items-center gap-1.5 text-xs font-bold text-gray-500 dark:text-slate-400 uppercase tracking-wide';
+
+const EmptyPresetNotice = ({ onCreate }) => (
+    <div className="flex flex-col items-center justify-center gap-2 text-center py-10 border border-dashed border-gray-300 dark:border-slate-700 rounded-lg">
+        <Icon path={ICONS.bank} className="h-6 w-6 text-gray-300 dark:text-slate-600" />
+        <p className="text-sm font-medium text-gray-600 dark:text-slate-300">Select or create a bank preset to configure this section.</p>
+        <button className={`${BUTTON_PRIMARY} ${BUTTON_SM}`} onClick={onCreate}>Create Bank Preset</button>
+    </div>
+);
+
+const ChequeSettingsPanel = () => {
+    const [templates, setTemplates] = useState([]);
+    const [printerProfiles, setPrinterProfiles] = useState([]);
+    const [selectedTemplateId, setSelectedTemplateId] = useState('');
+    const [selectedProfileId, setSelectedProfileId] = useState('');
+    const [activeTab, setActiveTab] = useState('layout');
+    const [draftProfile, setDraftProfile] = useState({ profile_name: '', feed_type: 'native', offset_x: 0, offset_y: 0, is_default: false });
+
+    const selectedTemplate = useMemo(() => templates.find((tpl) => String(tpl.id) === String(selectedTemplateId)), [templates, selectedTemplateId]);
+    const selectedProfile = useMemo(() => printerProfiles.find((profile) => String(profile.id) === String(selectedProfileId)), [printerProfiles, selectedProfileId]);
+
+    const loadData = async () => {
+        try {
+            const [templatesRes, profilesRes] = await Promise.all([api.get('/cheques/templates'), api.get('/cheques/printer-profiles')]);
+            const templateRows = templatesRes.data || [];
+            const profileRows = profilesRes.data || [];
+            setTemplates(templateRows);
+            setPrinterProfiles(profileRows);
+            if (!selectedTemplateId && templateRows.length) setSelectedTemplateId(String(templateRows[0].id));
+            if (!selectedProfileId && profileRows.length) {
+                const defaultProfile = profileRows.find((profile) => profile.is_default) || profileRows[0];
+                setSelectedProfileId(String(defaultProfile.id));
+            }
+        } catch (error) {
+            toast.error(error?.response?.data?.message || 'Failed to load cheque templates & printer profiles.');
+        }
+    };
+
+    useEffect(() => { loadData(); }, []);
+    useEffect(() => {
+        if (!selectedProfile) {
+            setDraftProfile({ profile_name: '', feed_type: 'native', offset_x: 0, offset_y: 0, is_default: false });
+            return;
+        }
+        setDraftProfile({
+            profile_name: selectedProfile.profile_name || '',
+            feed_type: selectedProfile.feed_type || 'native',
+            offset_x: Number(selectedProfile.offset_x || 0),
+            offset_y: Number(selectedProfile.offset_y || 0),
+            is_default: Boolean(selectedProfile.is_default)
+        });
+    }, [selectedProfileId]);
+
+    const updateTemplate = async (patch) => {
+        if (!selectedTemplate) return;
+        try {
+            const response = await api.put(`/cheques/templates/${selectedTemplate.id}`, {
+                ...selectedTemplate,
+                ...patch
+            });
+            setTemplates((prev) => prev.map((template) => (template.id === response.data.id ? response.data : template)));
+        } catch (error) {
+            toast.error(error?.response?.data?.message || 'Template update failed.');
+        }
+    };
+
+    const upsertProfile = async (patch) => {
+        try {
+            if (!selectedProfile) {
+                const created = await api.post('/cheques/printer-profiles', {
+                    profile_name: patch.profile_name || `Profile ${printerProfiles.length + 1}`,
+                    feed_type: patch.feed_type || 'native',
+                    offset_x: patch.offset_x || 0,
+                    offset_y: patch.offset_y || 0,
+                    is_default: patch.is_default || false
+                });
+                setPrinterProfiles((prev) => [...prev, created.data]);
+                setSelectedProfileId(String(created.data.id));
+                return;
+            }
+
+            const response = await api.put(`/cheques/printer-profiles/${selectedProfile.id}`, {
+                ...selectedProfile,
+                ...patch
+            });
+
+            setPrinterProfiles((prev) => prev.map((profile) => (profile.id === response.data.id ? response.data : profile)));
+        } catch (error) {
+            toast.error(error?.response?.data?.message || 'Printer profile update failed.');
+        }
+    };
+
+    const createTemplateFromCurrent = async () => {
+        const baseName = selectedTemplate?.bank_name || 'New Bank Preset';
+        const bankName = window.prompt('Enter name for bank preset:', selectedTemplate ? `${baseName} Copy` : baseName);
+        if (!bankName?.trim()) return;
+        try {
+            const res = await api.post('/cheques/templates', {
+                ...(selectedTemplate || {}),
+                bank_name: bankName.trim(),
+                field_positions: selectedTemplate?.field_positions || DEFAULT_TEMPLATE
+            });
+            setTemplates((prev) => [...prev, res.data].sort((a, b) => a.bank_name.localeCompare(b.bank_name)));
+            setSelectedTemplateId(String(res.data.id));
+            toast.success(selectedTemplate ? 'Bank preset duplicated.' : 'Bank preset created.');
+        } catch (error) {
+            toast.error(error?.response?.data?.message || 'Failed to save bank preset.');
+        }
+    };
+
+    const deleteCurrentTemplate = async () => {
+        if (!selectedTemplate) return;
+        if (!window.confirm(`Delete bank preset "${selectedTemplate.bank_name}"?`)) return;
+        try {
+            await api.delete(`/cheques/templates/${selectedTemplate.id}`);
+            toast.success('Bank preset deleted.');
+            await loadData();
+            setSelectedTemplateId('');
+        } catch (error) {
+            toast.error(error?.response?.data?.message || 'Failed to delete bank preset.');
+        }
+    };
+
+    const duplicateCurrentProfile = async () => {
+        if (!selectedProfile) return;
+        const profileName = window.prompt('Enter name for duplicated printer profile:', `${selectedProfile.profile_name} Copy`);
+        if (!profileName?.trim()) return;
+        try {
+            const created = await api.post('/cheques/printer-profiles', {
+                profile_name: profileName.trim(),
+                feed_type: selectedProfile.feed_type || 'native',
+                offset_x: Number(selectedProfile.offset_x || 0),
+                offset_y: Number(selectedProfile.offset_y || 0),
+                is_default: false
+            });
+            setPrinterProfiles((prev) => [...prev, created.data]);
+            setSelectedProfileId(String(created.data.id));
+            toast.success('Printer profile duplicated.');
+        } catch (error) {
+            toast.error(error?.response?.data?.message || 'Failed to duplicate printer profile.');
+        }
+    };
+
+    const deleteCurrentProfile = async () => {
+        if (!selectedProfile) return;
+        if (!window.confirm(`Delete printer profile "${selectedProfile.profile_name}"?`)) return;
+        try {
+            await api.delete(`/cheques/printer-profiles/${selectedProfile.id}`);
+            toast.success('Printer profile deleted.');
+            await loadData();
+            setSelectedProfileId('');
+        } catch (error) {
+            toast.error(error?.response?.data?.message || 'Failed to delete printer profile.');
+        }
+    };
+
+    const downloadSettingsExport = async () => {
+        try {
+            const response = await api.get('/cheques/settings-export', { responseType: 'blob' });
+            const blobUrl = window.URL.createObjectURL(new Blob([response.data], { type: 'application/json' }));
+            const link = document.createElement('a');
+            link.href = blobUrl;
+            link.setAttribute('download', `cheque-settings-${format(new Date(), 'yyyy-MM-dd')}.json`);
+            document.body.appendChild(link);
+            link.click();
+            link.remove();
+            window.URL.revokeObjectURL(blobUrl);
+            toast.success('Cheque settings exported.');
+        } catch (error) {
+            toast.error(error?.response?.data?.message || 'Failed to export cheque settings.');
+        }
+    };
+
+    const importSettingsFile = async (event) => {
+        const file = event.target.files?.[0];
+        if (!file) return;
+        try {
+            const payload = JSON.parse(await file.text());
+            const overwrite = window.confirm('Overwrite existing presets/profiles with matching names? Click Cancel to append only.');
+            await api.post('/cheques/settings-import', { ...payload, overwrite });
+            toast.success('Cheque settings imported.');
+            await loadData();
+        } catch (error) {
+            toast.error(error?.response?.data?.message || 'Failed to import cheque settings file.');
+        } finally {
+            event.target.value = '';
+        }
+    };
+
+    return (
+        <div className="space-y-4 pb-4">
+            <div className="bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-xl p-4 md:p-5">
+                <h2 className="text-lg md:text-xl font-semibold text-gray-900 dark:text-slate-100">Templates &amp; Settings</h2>
+                <p className="text-sm text-gray-500 dark:text-slate-400 mt-1">Manage bank cheque presets and printer calibration profiles used across Print Cheques and the Treasury Desk.</p>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-xl p-4 space-y-3">
+                    <span className={SECTION_EYEBROW}><Icon path={ICONS.bank} className="h-3.5 w-3.5" /> Bank Presets</span>
+                    <select className={INPUT_BASE} value={selectedTemplateId} onChange={(e) => setSelectedTemplateId(e.target.value)}>
+                        {!templates.length && <option value="">No bank preset yet</option>}
+                        {templates.map((template) => <option key={template.id} value={template.id}>{template.bank_name}</option>)}
+                    </select>
+                    <div className="flex gap-2">
+                        <button className={`${BUTTON_SECONDARY} ${BUTTON_SM}`} onClick={createTemplateFromCurrent}>{selectedTemplate ? 'Duplicate' : 'Create Preset'}</button>
+                        <button className={`${BUTTON_DANGER} ${BUTTON_SM}`} onClick={deleteCurrentTemplate} disabled={!selectedTemplate || templates.length <= 1}>Delete</button>
+                    </div>
+                </div>
+                <div className="bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-xl p-4 space-y-3">
+                    <span className={SECTION_EYEBROW}><Icon path={ICONS.settings} className="h-3.5 w-3.5" /> Printer Profiles</span>
+                    <select className={INPUT_BASE} value={selectedProfileId} onChange={(e) => setSelectedProfileId(e.target.value)}>
+                        <option value="">{printerProfiles.length ? 'None' : 'No printer profile yet'}</option>
+                        {printerProfiles.map((profile) => <option key={profile.id} value={profile.id}>{profile.profile_name}{profile.is_default ? ' (Default)' : ''}</option>)}
+                    </select>
+                    <div className="flex gap-2">
+                        <button className={`${BUTTON_SECONDARY} ${BUTTON_SM}`} onClick={duplicateCurrentProfile} disabled={!selectedProfile}>Duplicate</button>
+                        <button className={`${BUTTON_DANGER} ${BUTTON_SM}`} onClick={deleteCurrentProfile} disabled={!selectedProfile}>Delete</button>
+                    </div>
+                </div>
+            </div>
+
+            <div className="bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-xl p-4 md:p-5 space-y-4">
+                <div className="flex items-center justify-between flex-wrap gap-2">
+                    <span className={SECTION_EYEBROW}>Preset Configuration</span>
+                    <div className="overflow-x-auto">
+                        <SegmentedTabs tabs={SETTINGS_TABS} active={activeTab} onChange={setActiveTab} variant="pills" />
+                    </div>
+                </div>
+
+                <div className="text-sm space-y-4 border-t border-gray-200 dark:border-slate-700 pt-4">
+                    {activeTab === 'layout' && selectedTemplate && (
+                        <div className="space-y-3">
+                            <div className="flex flex-wrap items-center justify-between gap-2 border border-gray-200 dark:border-slate-700 rounded-lg bg-gray-50 dark:bg-slate-900/40 p-3">
+                                <div>
+                                    <p className="font-medium text-gray-900 dark:text-slate-100">Bank preset details</p>
+                                    <p className="text-xs text-gray-500 dark:text-slate-400">Save and share this bank preset including cheque layout variables.</p>
+                                </div>
+                                <button className={BUTTON_PRIMARY} onClick={() => updateTemplate({ ...selectedTemplate })}>
+                                    <Icon path={ICONS.check} className="h-4 w-4" />
+                                    Save Bank Preset
+                                </button>
+                            </div>
+                            <div>
+                                <label className={LABEL_CLASS}>Bank preset name</label>
+                                <input className={INPUT_BASE} value={selectedTemplate.bank_name || ''} onChange={(e) => updateTemplate({ bank_name: e.target.value })} />
+                            </div>
+                            <div>
+                                <p className="text-gray-600 dark:text-slate-400">Fine-tune field placements and sizes for this cheque template. All positions are in points (pt).</p>
+                            </div>
+                            <div className="border border-gray-200 dark:border-slate-700 rounded-lg overflow-hidden">
+                                <div className="hidden lg:grid grid-cols-6 gap-2 px-3 py-2 text-xs font-semibold text-gray-500 dark:text-slate-400 uppercase tracking-wide bg-gray-50 dark:bg-slate-900/40">
+                                    <span>Field</span>
+                                    <span>X</span>
+                                    <span>Y</span>
+                                    <span>Font Size</span>
+                                    <span>Max Width</span>
+                                    <span>Min Font</span>
+                                </div>
+                                <div className="divide-y divide-gray-100 dark:divide-slate-700">
+                                    {Object.entries(selectedTemplate.field_positions || {}).map(([field, cfg]) => {
+                                        const showExtras = ['payee', 'amountWords', 'memo'].includes(field);
+                                        return (
+                                            <div key={field} className="grid grid-cols-4 lg:grid-cols-6 gap-2 items-center p-2">
+                                                <span className="font-medium truncate text-gray-800 dark:text-slate-200 text-xs lg:text-sm" title={FIELD_LABELS[field] || field}>{FIELD_LABELS[field] || field}</span>
+                                                <input type="number" className={INPUT_MONO} aria-label={`${field} X`} value={cfg.x ?? 0} onChange={(e) => updateTemplate({ field_positions: { ...selectedTemplate.field_positions, [field]: { ...cfg, x: Number(e.target.value) } } })} />
+                                                <input type="number" className={INPUT_MONO} aria-label={`${field} Y`} value={cfg.y ?? 0} onChange={(e) => updateTemplate({ field_positions: { ...selectedTemplate.field_positions, [field]: { ...cfg, y: Number(e.target.value) } } })} />
+                                                <input type="number" className={INPUT_MONO} aria-label={`${field} Font`} value={cfg.fontSize ?? 11} onChange={(e) => updateTemplate({ field_positions: { ...selectedTemplate.field_positions, [field]: { ...cfg, fontSize: Number(e.target.value) } } })} />
+                                                {showExtras ? (
+                                                    <>
+                                                        <input type="number" className={`${INPUT_MONO} col-span-2 lg:col-span-1`} aria-label={`${field} Max Width`} placeholder="Max Width" value={cfg.maxWidth ?? ''} onChange={(e) => updateTemplate({ field_positions: { ...selectedTemplate.field_positions, [field]: { ...cfg, maxWidth: e.target.value ? Number(e.target.value) : null } } })} />
+                                                        <input type="number" className={`${INPUT_MONO} col-span-2 lg:col-span-1`} aria-label={`${field} Min Font`} placeholder="Min Font" value={cfg.minFontSize ?? ''} onChange={(e) => updateTemplate({ field_positions: { ...selectedTemplate.field_positions, [field]: { ...cfg, minFontSize: e.target.value ? Number(e.target.value) : null } } })} />
+                                                    </>
+                                                ) : (
+                                                    <div className="hidden lg:block lg:col-span-2"></div>
+                                                )}
+                                            </div>
+                                        );
+                                    })}
+                                </div>
+                            </div>
+                        </div>
+                    )}
+                    {activeTab === 'layout' && !selectedTemplate && (
+                        <div className="space-y-3">
+                            <EmptyPresetNotice onCreate={createTemplateFromCurrent} />
+                            <div className="flex justify-center">
+                                <label className={`${BUTTON_SECONDARY} ${BUTTON_SM} cursor-pointer`}>
+                                    Import Presets &amp; Profiles
+                                    <input type="file" accept="application/json" className="hidden" onChange={importSettingsFile} />
+                                </label>
+                            </div>
+                        </div>
+                    )}
+
+                    {['date', 'amount', 'currency', 'paper', 'text'].includes(activeTab) && !selectedTemplate && (
+                        <EmptyPresetNotice onCreate={createTemplateFromCurrent} />
+                    )}
+
+                    {activeTab === 'date' && selectedTemplate && (
+                        <div className="space-y-3">
+                            <div>
+                                <label className={LABEL_CLASS}>Date output format</label>
+                                <select className={INPUT_BASE} value={selectedTemplate.date_format || 'MM-dd-yyyy'} onChange={(e) => updateTemplate({ date_format: e.target.value })}>
+                                    <option value="MM-dd-yyyy">MM-DD-YYYY</option>
+                                    <option value="MM/dd/yyyy">MM/dd/yyyy</option>
+                                    <option value="dd/MM/yyyy">dd/MM/yyyy</option>
+                                    <option value="MMM dd, yyyy">MMM dd, yyyy</option>
+                                </select>
+                            </div>
+                            <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+                                <div>
+                                    <label className={LABEL_CLASS}>Date Mode</label>
+                                    <select
+                                        className={INPUT_BASE}
+                                        value={selectedTemplate.field_positions?.date?.mode || 'single'}
+                                        onChange={(e) => updateTemplate({
+                                            field_positions: {
+                                                ...selectedTemplate.field_positions,
+                                                date: { ...(selectedTemplate.field_positions?.date || {}), mode: e.target.value }
+                                            }
+                                        })}
+                                    >
+                                        <option value="single">Single-line date mode</option>
+                                        <option value="boxed">Boxed date mode (MMDDYYYY without separators)</option>
+                                    </select>
+                                </div>
+                                <div className="flex gap-2">
+                                    <div className="flex-1">
+                                        <label className={LABEL_CLASS}>Char Spacing</label>
+                                        <input
+                                            type="number"
+                                            step="0.5"
+                                            className={INPUT_BASE}
+                                            placeholder="Character spacing"
+                                            title="Character spacing"
+                                            value={selectedTemplate.field_positions?.date?.charSpacing ?? 0}
+                                            onChange={(e) => updateTemplate({
+                                                field_positions: {
+                                                    ...selectedTemplate.field_positions,
+                                                    date: { ...(selectedTemplate.field_positions?.date || {}), charSpacing: Number(e.target.value) || 0 }
+                                                }
+                                            })}
+                                        />
+                                    </div>
+                                    {selectedTemplate.field_positions?.date?.mode === 'boxed' && (
+                                        <div className="flex-1">
+                                            <label className={LABEL_CLASS}>Block Spacing</label>
+                                            <input
+                                                type="number"
+                                                step="0.5"
+                                                className={INPUT_BASE}
+                                                placeholder="Block Spacing (pt)"
+                                                title="Block Spacing (pt)"
+                                                value={selectedTemplate.field_positions?.date?.blockSpacing ?? selectedTemplate.field_positions?.date?.charSpacing ?? 0}
+                                                onChange={(e) => updateTemplate({
+                                                    field_positions: {
+                                                        ...selectedTemplate.field_positions,
+                                                        date: { ...(selectedTemplate.field_positions?.date || {}), blockSpacing: Number(e.target.value) || 0 }
+                                                    }
+                                                })}
+                                            />
+                                        </div>
+                                    )}
+                                </div>
+                            </div>
+                        </div>
+                    )}
+
+                    {activeTab === 'amount' && selectedTemplate && (
+                        <div className="space-y-3">
+                            <div>
+                                <label className={LABEL_CLASS}>Amount words casing</label>
+                                <select className={INPUT_BASE} value={selectedTemplate.amount_format || 'title_case'} onChange={(e) => updateTemplate({ amount_format: e.target.value })}>
+                                    <option value="title_case">Title Case</option>
+                                    <option value="upper">UPPER CASE</option>
+                                </select>
+                            </div>
+                            <div>
+                                <label className={LABEL_CLASS}>Amount suffix</label>
+                                <input
+                                    className={INPUT_BASE}
+                                    placeholder="pesos"
+                                    value={selectedTemplate.amount_words_settings?.suffix || 'pesos'}
+                                    onChange={(e) => updateTemplate({
+                                        amount_words_settings: {
+                                            ...(selectedTemplate.amount_words_settings || {}),
+                                            suffix: e.target.value
+                                        }
+                                    })}
+                                />
+                                <p className="text-xs text-gray-500 dark:text-slate-400 mt-1">Whole numbers render as “&lt;amount&gt; suffix only”. Decimal amounts render as “&lt;amount&gt; suffix and xx/100”.</p>
+                            </div>
+                        </div>
+                    )}
+
+                    {activeTab === 'currency' && selectedTemplate && (
+                        <div className="space-y-3">
+                            <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-slate-300 cursor-pointer">
+                                <input type="checkbox" className="rounded text-primary-600 focus:ring-primary-500" checked={selectedTemplate.currency_settings?.enabled !== false} onChange={(e) => updateTemplate({ currency_settings: { ...selectedTemplate.currency_settings, enabled: e.target.checked } })} />
+                                Show currency label
+                            </label>
+                            <div>
+                                <label className={LABEL_CLASS}>Symbol outside amount box</label>
+                                <input className={INPUT_BASE} placeholder="e.g. PHP" value={selectedTemplate.currency_settings?.label || ''} onChange={(e) => updateTemplate({ currency_settings: { ...selectedTemplate.currency_settings, label: e.target.value } })} />
+                            </div>
+                        </div>
+                    )}
+
+                    {activeTab === 'paper' && selectedTemplate && (
+                        <div className="space-y-3">
+                            <p className="text-gray-600 dark:text-slate-400">Paper size is stored in the selected bank preset.</p>
+                            <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+                                <div>
+                                    <label className={LABEL_CLASS}>Width (inches)</label>
+                                    <input
+                                        type="number"
+                                        min="1"
+                                        step="0.1"
+                                        className={INPUT_BASE}
+                                        value={selectedTemplate.paper_settings?.widthIn ?? 8}
+                                        onChange={(e) => updateTemplate({ paper_settings: { ...(selectedTemplate.paper_settings || {}), widthIn: Number(e.target.value) || 8, unit: 'in' } })}
+                                    />
+                                </div>
+                                <div>
+                                    <label className={LABEL_CLASS}>Height (inches)</label>
+                                    <input
+                                        type="number"
+                                        min="1"
+                                        step="0.1"
+                                        className={INPUT_BASE}
+                                        value={selectedTemplate.paper_settings?.heightIn ?? 3}
+                                        onChange={(e) => updateTemplate({ paper_settings: { ...(selectedTemplate.paper_settings || {}), heightIn: Number(e.target.value) || 3, unit: 'in' } })}
+                                    />
+                                </div>
+                            </div>
+                            <p className="text-xs text-gray-500 dark:text-slate-400">Recommended standardized size: 8" x 3".</p>
+                        </div>
+                    )}
+
+                    {activeTab === 'text' && selectedTemplate && (
+                        <div className="space-y-3">
+                            <p className="text-gray-600 dark:text-slate-400">Payee overflow mitigation uses template font size and width values; no line wrapping is applied.</p>
+                            <div className="border border-gray-200 dark:border-slate-700 rounded-lg p-3 space-y-2 bg-gray-50 dark:bg-slate-900/40">
+                                <label className="flex items-center gap-2 text-gray-700 dark:text-slate-300">
+                                    <input
+                                        type="checkbox"
+                                        checked={Boolean(selectedTemplate.text_settings?.payeeFillerEnabled)}
+                                        onChange={(e) => updateTemplate({
+                                            text_settings: {
+                                                ...(selectedTemplate.text_settings || {}),
+                                                payeeFillerEnabled: e.target.checked
+                                            }
+                                        })}
+                                    />
+                                    Add filler at both ends of payee text
+                                </label>
+                                <input
+                                    className={INPUT_BASE}
+                                    placeholder="***"
+                                    value={selectedTemplate.text_settings?.payeeFiller || '***'}
+                                    onChange={(e) => updateTemplate({
+                                        text_settings: {
+                                            ...(selectedTemplate.text_settings || {}),
+                                            payeeFiller: e.target.value
+                                        }
+                                    })}
+                                />
+                            </div>
+                            <div className="border border-gray-200 dark:border-slate-700 rounded-lg p-3 space-y-2 bg-gray-50 dark:bg-slate-900/40">
+                                <label className="flex items-center gap-2 text-gray-700 dark:text-slate-300">
+                                    <input
+                                        type="checkbox"
+                                        checked={Boolean(selectedTemplate.text_settings?.amountWordsFillerEnabled)}
+                                        onChange={(e) => updateTemplate({
+                                            text_settings: {
+                                                ...(selectedTemplate.text_settings || {}),
+                                                amountWordsFillerEnabled: e.target.checked
+                                            }
+                                        })}
+                                    />
+                                    Add filler at both ends of amount-in-words
+                                </label>
+                                <input
+                                    className={INPUT_BASE}
+                                    placeholder="***"
+                                    value={selectedTemplate.text_settings?.amountWordsFiller || '***'}
+                                    onChange={(e) => updateTemplate({
+                                        text_settings: {
+                                            ...(selectedTemplate.text_settings || {}),
+                                            amountWordsFiller: e.target.value
+                                        }
+                                    })}
+                                />
+                            </div>
+                        </div>
+                    )}
+
+                    {activeTab === 'calibration' && (
+                        <div className="space-y-4">
+                            <div className="border border-gray-200 dark:border-slate-700 rounded-lg p-3 space-y-2">
+                                <span className={SECTION_EYEBROW}><Icon path={ICONS.download} className="h-3.5 w-3.5" /> Import / Export</span>
+                                <p className="text-xs text-gray-600 dark:text-slate-400">Export all bank presets and printer profiles to a JSON file for sharing or backup.</p>
+                                <div className="flex flex-wrap gap-2">
+                                    <button className={`${BUTTON_SECONDARY} ${BUTTON_SM}`} onClick={downloadSettingsExport}>Export Presets &amp; Profiles</button>
+                                    <label className={`${BUTTON_SECONDARY} ${BUTTON_SM} cursor-pointer`}>
+                                        Import Presets &amp; Profiles
+                                        <input type="file" accept="application/json" className="hidden" onChange={importSettingsFile} />
+                                    </label>
+                                </div>
+                            </div>
+
+                            <div className="border border-gray-200 dark:border-slate-700 rounded-lg p-3 space-y-3">
+                                <span className={SECTION_EYEBROW}><Icon path={ICONS.settings} className="h-3.5 w-3.5" /> Printer Profile Offsets</span>
+                                <p className="text-xs text-gray-600 dark:text-slate-400">Save profile offsets to match your printer's physical output alignment.</p>
+                                <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+                                    <input
+                                        className={INPUT_BASE}
+                                        placeholder="Profile name"
+                                        value={draftProfile.profile_name}
+                                        onChange={(e) => setDraftProfile((prev) => ({ ...prev, profile_name: e.target.value }))}
+                                    />
+                                    <select
+                                        className={INPUT_BASE}
+                                        value={draftProfile.feed_type || 'native'}
+                                        onChange={(e) => setDraftProfile((prev) => ({ ...prev, feed_type: e.target.value }))}
+                                    >
+                                        <option value="native">Native (Custom Paper Size)</option>
+                                        <option value="letter_center">Letter Size (Center Feed)</option>
+                                        <option value="letter_left">Letter Size (Left Feed)</option>
+                                        <option value="letter_right">Letter Size (Right Feed)</option>
+                                    </select>
+                                    <div>
+                                        <label className={LABEL_CLASS}>Offset X (pt)</label>
+                                        <input
+                                            type="number"
+                                            step="0.1"
+                                            className={INPUT_MONO}
+                                            value={draftProfile.offset_x}
+                                            onChange={(e) => setDraftProfile((prev) => ({ ...prev, offset_x: Number(e.target.value) || 0 }))}
+                                        />
+                                    </div>
+                                    <div>
+                                        <label className={LABEL_CLASS}>Offset Y (pt)</label>
+                                        <input
+                                            type="number"
+                                            step="0.1"
+                                            className={INPUT_MONO}
+                                            value={draftProfile.offset_y}
+                                            onChange={(e) => setDraftProfile((prev) => ({ ...prev, offset_y: Number(e.target.value) || 0 }))}
+                                        />
+                                    </div>
+                                </div>
+                                <p className="text-xs text-gray-500 dark:text-slate-400 flex items-start gap-1.5">
+                                    <Icon path={ICONS.info} className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+                                    If your printer rejects custom 8x3 paper sizes, select your manual tray&apos;s feed alignment. The system will print on a Letter canvas to bypass the error.
+                                </p>
+                                <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-slate-300 cursor-pointer">
+                                    <input
+                                        type="checkbox"
+                                        className="rounded text-primary-600 focus:ring-primary-500"
+                                        checked={Boolean(draftProfile.is_default)}
+                                        onChange={(e) => setDraftProfile((prev) => ({ ...prev, is_default: e.target.checked }))}
+                                    />
+                                    Set as default profile
+                                </label>
+                                <div className="flex gap-2">
+                                    <button className={BUTTON_PRIMARY} onClick={() => upsertProfile(draftProfile)}><Icon path={ICONS.check} className="h-4 w-4" />{selectedProfile ? 'Save Profile' : 'Create Profile'}</button>
+                                    {!selectedProfile && (
+                                        <button className={BUTTON_SECONDARY} onClick={() => setDraftProfile({ profile_name: `Profile ${printerProfiles.length + 1}`, feed_type: 'native', offset_x: 0, offset_y: 0, is_default: false })}><Icon path={ICONS.edit} className="h-4 w-4" />Quick Fill</button>
+                                    )}
+                                </div>
+                            </div>
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default ChequeSettingsPanel;

--- a/packages/web/src/components/layout/MainLayout.jsx
+++ b/packages/web/src/components/layout/MainLayout.jsx
@@ -18,11 +18,9 @@ import SettingsPage from '../../pages/SettingsPage';
 import POSPage from '../../pages/POSPage';
 import PurchaseOrderPage from '../../pages/PurchaseOrderPage';
 import AccountsReceivablePage from '../../pages/AccountsReceivablePage';
-import PdcTreasuryPage from '../../pages/PdcTreasuryPage';
-import BankAccountsPage from '../../pages/BankAccountsPage';
+import ChequesTreasuryPage from '../../pages/ChequesTreasuryPage';
 import SalesHistoryPage from '../../pages/SalesHistoryPage'; // <-- Import new page
 import DocumentsPage from '../../pages/DocumentsPage';
-import ChequePrintingPage from '../../pages/ChequePrintingPage';
 import CycleCountExecutionPage from '../../pages/CycleCountExecutionPage';
 import ManagerReviewDesk from '../cycleCount/ManagerReviewDesk';
 import CashierApprovalDesk from '../../pages/CashierApprovalDesk';
@@ -50,11 +48,9 @@ const MainLayout = ({ user, onLogout, onNavigate, currentPage, pageState, posLin
             case 'invoicing': return <InvoicingPage user={user} onNavigate={onNavigate} pageState={currentPage === 'invoicing' ? pageState : null} />;
             case 'sales_history': return <SalesHistoryPage />; // <-- Add case for new page
             case 'documents': return <DocumentsPage />;
-            case 'cheques': return <ChequePrintingPage />;
             case 'purchase_orders': return <PurchaseOrderPage />;
             case 'ar': return <AccountsReceivablePage />;
-            case 'pdc': return <PdcTreasuryPage />;
-            case 'bank_accounts': return <BankAccountsPage />;
+            case 'cheques_treasury': return <ChequesTreasuryPage />;
             case 'soa_gen': return <SoaGenPage />;
             case 'staged_sales': return <CashierApprovalDesk onNavigate={onNavigate} />;
             case 'inventory': return <InventoryPage user={user} />;

--- a/packages/web/src/components/layout/Sidebar.jsx
+++ b/packages/web/src/components/layout/Sidebar.jsx
@@ -24,7 +24,6 @@ const CATEGORIES = [
             { name: 'Approval Queue', icon: ICONS.ar,            page: 'staged_sales',  permission: 'invoicing:create', badge: true },
             { name: 'Invoicing',      icon: ICONS.invoice,       page: 'invoicing',     permission: 'invoicing:create' },
             { name: 'Sales History',  icon: ICONS.history,       page: 'sales_history', permission: 'invoicing:create' },
-            { name: 'Cheques',        icon: ICONS.receipt,       page: 'cheques',       permission: 'cheques:view' },
             { name: 'A/R',            icon: ICONS.ar,            page: 'ar',            permission: 'ar:view' },
         ],
     },
@@ -59,8 +58,7 @@ const CATEGORIES = [
         title: 'Finance & Expenses',
         icon: ICONS.receipt,
         items: [
-            { name: 'PDC & Treasury',    icon: ICONS.receipt, page: 'pdc',                permission: ['pdc:view', 'ar:view', 'ap-pdc:view'] },
-            { name: 'Bank Accounts',    icon: ICONS.receipt, page: 'bank_accounts',      permission: 'ap-pdc:view' },
+            { name: 'Cheques & Treasury', icon: ICONS.bank,    page: 'cheques_treasury',   permission: ['cheques:view', 'pdc:view', 'ar:view', 'ap-pdc:view'] },
             { name: 'Bulk SOA Generator', icon: ICONS.documents, page: 'soa_gen',          permission: 'ar:view' },
             { name: 'Expenses',           icon: ICONS.receipt, page: 'expenses',           permission: 'expenses:view' },
             { name: 'Expense Categories', icon: ICONS.tag,     page: 'expense_categories', permission: 'expenses:manage_categories' },

--- a/packages/web/src/components/ui/KPICard.jsx
+++ b/packages/web/src/components/ui/KPICard.jsx
@@ -21,15 +21,15 @@ const ICON_ALIASES = {
 };
 
 const COLOR_VARIANTS = {
-    gray: { iconBg: 'bg-gray-100', iconColor: 'text-gray-500', accent: 'border-gray-200' },
-    green: { iconBg: 'bg-green-100', iconColor: 'text-green-600', accent: 'border-green-200' },
-    blue: { iconBg: 'bg-blue-100', iconColor: 'text-blue-600', accent: 'border-blue-200' },
-    purple: { iconBg: 'bg-purple-100', iconColor: 'text-purple-600', accent: 'border-purple-200' },
-    orange: { iconBg: 'bg-orange-100', iconColor: 'text-orange-600', accent: 'border-orange-200' },
-    red: { iconBg: 'bg-red-100', iconColor: 'text-red-600', accent: 'border-red-200' },
-    amber: { iconBg: 'bg-amber-100', iconColor: 'text-amber-600', accent: 'border-amber-200' },
-    emerald: { iconBg: 'bg-emerald-100', iconColor: 'text-emerald-600', accent: 'border-emerald-200' },
-    rose: { iconBg: 'bg-rose-100', iconColor: 'text-rose-600', accent: 'border-rose-200' },
+    gray: { iconBg: 'bg-neutral-100 dark:bg-slate-700', iconColor: 'text-neutral-500 dark:text-slate-300', accent: 'border-neutral-200 dark:border-slate-700' },
+    green: { iconBg: 'bg-success-100 dark:bg-success-900/30', iconColor: 'text-success-600 dark:text-success-400', accent: 'border-success-200 dark:border-success-900/50' },
+    blue: { iconBg: 'bg-primary-100 dark:bg-primary-900/30', iconColor: 'text-primary-600 dark:text-primary-400', accent: 'border-primary-200 dark:border-primary-900/50' },
+    purple: { iconBg: 'bg-purple-100 dark:bg-purple-900/30', iconColor: 'text-purple-600 dark:text-purple-400', accent: 'border-purple-200 dark:border-purple-900/50' },
+    orange: { iconBg: 'bg-orange-100 dark:bg-orange-900/30', iconColor: 'text-orange-600 dark:text-orange-400', accent: 'border-orange-200 dark:border-orange-900/50' },
+    red: { iconBg: 'bg-danger-100 dark:bg-danger-900/30', iconColor: 'text-danger-600 dark:text-danger-400', accent: 'border-danger-200 dark:border-danger-900/50' },
+    amber: { iconBg: 'bg-warning-100 dark:bg-warning-900/30', iconColor: 'text-warning-600 dark:text-warning-400', accent: 'border-warning-200 dark:border-warning-900/50' },
+    emerald: { iconBg: 'bg-success-100 dark:bg-success-900/30', iconColor: 'text-success-600 dark:text-success-400', accent: 'border-success-200 dark:border-success-900/50' },
+    rose: { iconBg: 'bg-danger-100 dark:bg-danger-900/30', iconColor: 'text-danger-600 dark:text-danger-400', accent: 'border-danger-200 dark:border-danger-900/50' },
 };
 
 const compactFormatter = new Intl.NumberFormat('en-US', { notation: 'compact', compactDisplay: 'short', maximumFractionDigits: 1 });
@@ -58,13 +58,13 @@ const KPICard = ({
 }) => {
     if (loading) {
         return (
-            <div className="bg-white p-6 rounded-lg border border-gray-200 animate-pulse">
+            <div className="bg-white dark:bg-slate-800 p-6 rounded-lg border border-gray-200 dark:border-slate-700 animate-pulse">
                 <div className="flex items-center gap-x-3 mb-2">
-                    <div className="w-12 h-12 rounded-full bg-gray-200"></div>
-                    <div className="h-4 bg-gray-200 rounded w-24"></div>
+                    <div className="w-12 h-12 rounded-full bg-gray-200 dark:bg-slate-700"></div>
+                    <div className="h-4 bg-gray-200 dark:bg-slate-700 rounded w-24"></div>
                 </div>
-                <div className="h-8 bg-gray-200 rounded w-20 mb-2"></div>
-                <div className="h-3 bg-gray-200 rounded w-32"></div>
+                <div className="h-8 bg-gray-200 dark:bg-slate-700 rounded w-20 mb-2"></div>
+                <div className="h-3 bg-gray-200 dark:bg-slate-700 rounded w-32"></div>
             </div>
         );
     }
@@ -75,24 +75,24 @@ const KPICard = ({
     return (
         <div
             onClick={onClick}
-            className={`bg-white p-6 rounded-lg border ${colors.accent} flex flex-col gap-y-2 transition-shadow ${onClick ? 'cursor-pointer hover:shadow-md' : ''} ${urgent ? 'ring-2 ring-orange-400/50' : ''}`}
+            className={`bg-white dark:bg-slate-800 p-6 rounded-lg border ${colors.accent} flex flex-col gap-y-2 transition-shadow ${onClick ? 'cursor-pointer hover:shadow-md' : ''} ${urgent ? 'ring-2 ring-orange-400/50' : ''}`}
         >
             <div className="flex items-center justify-between">
                 <div className="flex items-center gap-x-3">
                     <div className={`w-12 h-12 rounded-full ${colors.iconBg} flex items-center justify-center`}>
                         <Icon path={iconPath} className={`h-6 w-6 ${colors.iconColor}`} />
                     </div>
-                    <h3 className="text-gray-500 font-medium">{title}</h3>
+                    <h3 className="text-gray-500 dark:text-slate-400 font-medium">{title}</h3>
                 </div>
                 {urgent && (
-                    <span className="px-2 py-1 bg-orange-100 text-orange-800 text-xs font-medium rounded-full">URGENT</span>
+                    <span className="px-2 py-1 bg-warning-100 dark:bg-warning-900/30 text-warning-800 dark:text-warning-400 text-xs font-medium rounded-full">URGENT</span>
                 )}
             </div>
-            <p className="text-3xl font-bold text-gray-800">{formatValue(value, isMonetary)}</p>
-            {subtitle && <p className="text-xs text-gray-500">{subtitle}</p>}
+            <p className="text-3xl font-bold text-gray-800 dark:text-slate-100">{formatValue(value, isMonetary)}</p>
+            {subtitle && <p className="text-xs text-gray-500 dark:text-slate-400">{subtitle}</p>}
             {trend && <p className={`text-sm ${trendColorClass}`}>{trend}</p>}
             {change != null && trendDirection && (
-                <p className={`text-sm font-medium flex items-center gap-1 ${trendDirection === 'up' ? 'text-green-600' : 'text-red-500'}`}>
+                <p className={`text-sm font-medium flex items-center gap-1 ${trendDirection === 'up' ? 'text-success-600 dark:text-success-400' : 'text-danger-500 dark:text-danger-400'}`}>
                     <Icon path={trendDirection === 'up' ? ICONS.chevronUp : ICONS.chevronDown} className="h-3.5 w-3.5" />
                     {change}
                 </p>

--- a/packages/web/src/components/ui/PaginationControls.jsx
+++ b/packages/web/src/components/ui/PaginationControls.jsx
@@ -37,14 +37,14 @@ const PaginationControls = ({
 
     return (
         <div className={`mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between ${className}`}>
-            <div className="text-sm text-gray-600">
+            <div className="text-sm text-gray-600 dark:text-slate-400">
                 Showing {start}-{end} of {total} items
             </div>
             <div className="flex flex-wrap items-center gap-2">
-                <label htmlFor="pageSize" className="text-sm text-gray-600">Rows per page</label>
+                <label htmlFor="pageSize" className="text-sm text-gray-600 dark:text-slate-400">Rows per page</label>
                 <select
                     id="pageSize"
-                    className="rounded-md border border-gray-300 px-2 py-1 text-sm"
+                    className="rounded-md border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-100 px-2 py-1 text-sm"
                     value={pageSize}
                     onChange={(e) => onPageSizeChange(Number(e.target.value))}
                 >
@@ -54,7 +54,7 @@ const PaginationControls = ({
                 </select>
                 <button
                     type="button"
-                    className="rounded-md border border-gray-300 px-3 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+                    className="rounded-md border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-700 dark:text-slate-200 px-3 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-50"
                     onClick={() => handlePageChange(safePage - 1)}
                     disabled={safePage <= 1}
                 >
@@ -63,15 +63,15 @@ const PaginationControls = ({
                 <div className="hidden items-center gap-1 md:flex">
                     {pageButtons[0] > 1 && (
                         <>
-                            <button type="button" className="rounded-md border border-gray-300 px-2 py-1 text-sm" onClick={() => handlePageChange(1)}>1</button>
-                            {pageButtons[0] > 2 && <span className="px-1 text-xs text-gray-500">…</span>}
+                            <button type="button" className="rounded-md border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-700 dark:text-slate-200 px-2 py-1 text-sm" onClick={() => handlePageChange(1)}>1</button>
+                            {pageButtons[0] > 2 && <span className="px-1 text-xs text-gray-500 dark:text-slate-500">…</span>}
                         </>
                     )}
                     {pageButtons.map((pageNumber) => (
                         <button
                             key={pageNumber}
                             type="button"
-                            className={`rounded-md border px-2 py-1 text-sm ${pageNumber === safePage ? 'border-blue-600 bg-blue-50 text-blue-700' : 'border-gray-300'}`}
+                            className={`rounded-md border px-2 py-1 text-sm ${pageNumber === safePage ? 'border-primary-600 bg-primary-50 dark:bg-primary-900/30 text-primary-700 dark:text-primary-400' : 'border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-700 dark:text-slate-200'}`}
                             onClick={() => handlePageChange(pageNumber)}
                         >
                             {pageNumber}
@@ -79,24 +79,24 @@ const PaginationControls = ({
                     ))}
                     {pageButtons[pageButtons.length - 1] < totalPages && (
                         <>
-                            {pageButtons[pageButtons.length - 1] < totalPages - 1 && <span className="px-1 text-xs text-gray-500">…</span>}
-                            <button type="button" className="rounded-md border border-gray-300 px-2 py-1 text-sm" onClick={() => handlePageChange(totalPages)}>{totalPages}</button>
+                            {pageButtons[pageButtons.length - 1] < totalPages - 1 && <span className="px-1 text-xs text-gray-500 dark:text-slate-500">…</span>}
+                            <button type="button" className="rounded-md border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-700 dark:text-slate-200 px-2 py-1 text-sm" onClick={() => handlePageChange(totalPages)}>{totalPages}</button>
                         </>
                     )}
                 </div>
-                <span className="text-sm text-gray-700">
+                <span className="text-sm text-gray-700 dark:text-slate-300">
                     Page {safePage} / {totalPages}
                 </span>
                 <button
                     type="button"
-                    className="rounded-md border border-gray-300 px-3 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+                    className="rounded-md border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-700 dark:text-slate-200 px-3 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-50"
                     onClick={() => handlePageChange(safePage + 1)}
                     disabled={safePage >= totalPages}
                 >
                     Next
                 </button>
                 <div className="flex items-center gap-1">
-                    <label htmlFor="jumpPage" className="text-sm text-gray-600">Jump</label>
+                    <label htmlFor="jumpPage" className="text-sm text-gray-600 dark:text-slate-400">Jump</label>
                     <input
                         id="jumpPage"
                         type="number"
@@ -104,11 +104,11 @@ const PaginationControls = ({
                         max={totalPages}
                         value={jumpPage}
                         onChange={(e) => setJumpPage(e.target.value)}
-                        className="w-16 rounded-md border border-gray-300 px-2 py-1 text-sm"
+                        className="w-16 rounded-md border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-100 px-2 py-1 text-sm"
                     />
                     <button
                         type="button"
-                        className="rounded-md border border-gray-300 px-2 py-1 text-sm"
+                        className="rounded-md border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-700 dark:text-slate-200 px-2 py-1 text-sm"
                         onClick={() => handlePageChange(Number(jumpPage || safePage))}
                     >
                         Go

--- a/packages/web/src/components/ui/SegmentedTabs.jsx
+++ b/packages/web/src/components/ui/SegmentedTabs.jsx
@@ -1,0 +1,34 @@
+/**
+ * Underline-style tab switcher shared across pages that split content into a
+ * few top-level sections (e.g. Treasury Desk's Inbound/Outbound split, and
+ * the Cheques & Treasury module's section nav). Centralizes the active/hover
+ * color so it stays on the brand's primary token instead of a hardcoded blue.
+ */
+const SegmentedTabs = ({ tabs = [], active, onChange, className = '' }) => (
+    <div className={`flex flex-wrap gap-x-6 gap-y-1 ${className}`}>
+        {tabs.map((tab) => {
+            const isActive = tab.key === active;
+            return (
+                <button
+                    key={tab.key}
+                    type="button"
+                    onClick={() => onChange(tab.key)}
+                    className={`py-3 px-1 border-b-2 font-bold text-sm transition-all cursor-pointer flex items-center gap-2 ${
+                        isActive
+                            ? 'border-primary-600 text-primary-600 dark:border-primary-500 dark:text-primary-500'
+                            : 'border-transparent text-gray-500 dark:text-slate-400 hover:text-gray-700 dark:hover:text-slate-200 hover:border-gray-300 dark:hover:border-slate-600'
+                    }`}
+                >
+                    {tab.label}
+                    {tab.badge > 0 && (
+                        <span className="min-w-[18px] h-[18px] px-1 rounded-full bg-amber-500 text-white text-[10px] font-bold flex items-center justify-center">
+                            {tab.badge > 99 ? '99+' : tab.badge}
+                        </span>
+                    )}
+                </button>
+            );
+        })}
+    </div>
+);
+
+export default SegmentedTabs;

--- a/packages/web/src/components/ui/SegmentedTabs.jsx
+++ b/packages/web/src/components/ui/SegmentedTabs.jsx
@@ -1,0 +1,71 @@
+/**
+ * Tab switcher shared across pages that split content into a few sections
+ * (e.g. Treasury Desk's Inbound/Outbound split, the Cheques & Treasury
+ * module's top-level section nav, and nested settings sub-tabs).
+ * Centralizes the active/hover color so it stays on the brand's primary
+ * token instead of a hardcoded blue.
+ *
+ * `variant="underline"` (default) reads as primary navigation — use it for
+ * the outermost tab level. `variant="pills"` reads as a secondary, nested
+ * control — use it one level deeper (e.g. settings sub-tabs) so the two
+ * levels are visually distinguishable at a glance.
+ */
+const SegmentedTabs = ({ tabs = [], active, onChange, className = '', variant = 'underline' }) => {
+    if (variant === 'pills') {
+        return (
+            <div className={`inline-flex flex-wrap gap-1 rounded-lg bg-gray-100 dark:bg-slate-900/60 p-1 ${className}`}>
+                {tabs.map((tab) => {
+                    const isActive = tab.key === active;
+                    return (
+                        <button
+                            key={tab.key}
+                            type="button"
+                            onClick={() => onChange(tab.key)}
+                            className={`px-3 py-1.5 rounded-md text-xs font-semibold transition-all cursor-pointer flex items-center gap-1.5 ${
+                                isActive
+                                    ? 'bg-white dark:bg-slate-700 text-primary-700 dark:text-primary-400 shadow-sm'
+                                    : 'text-gray-500 dark:text-slate-400 hover:text-gray-800 dark:hover:text-slate-200'
+                            }`}
+                        >
+                            {tab.label}
+                            {tab.badge > 0 && (
+                                <span className="min-w-[16px] h-[16px] px-1 rounded-full bg-amber-500 text-white text-[9px] font-bold flex items-center justify-center">
+                                    {tab.badge > 99 ? '99+' : tab.badge}
+                                </span>
+                            )}
+                        </button>
+                    );
+                })}
+            </div>
+        );
+    }
+
+    return (
+        <div className={`flex flex-wrap gap-x-6 gap-y-1 ${className}`}>
+            {tabs.map((tab) => {
+                const isActive = tab.key === active;
+                return (
+                    <button
+                        key={tab.key}
+                        type="button"
+                        onClick={() => onChange(tab.key)}
+                        className={`py-3 px-1 border-b-2 font-bold text-sm transition-all cursor-pointer flex items-center gap-2 ${
+                            isActive
+                                ? 'border-primary-600 text-primary-600 dark:border-primary-500 dark:text-primary-500'
+                                : 'border-transparent text-gray-500 dark:text-slate-400 hover:text-gray-700 dark:hover:text-slate-200 hover:border-gray-300 dark:hover:border-slate-600'
+                        }`}
+                    >
+                        {tab.label}
+                        {tab.badge > 0 && (
+                            <span className="min-w-[18px] h-[18px] px-1 rounded-full bg-amber-500 text-white text-[10px] font-bold flex items-center justify-center">
+                                {tab.badge > 99 ? '99+' : tab.badge}
+                            </span>
+                        )}
+                    </button>
+                );
+            })}
+        </div>
+    );
+};
+
+export default SegmentedTabs;

--- a/packages/web/src/components/ui/StatusBadge.jsx
+++ b/packages/web/src/components/ui/StatusBadge.jsx
@@ -1,0 +1,23 @@
+const TONE_CLASSES = {
+    success: 'bg-success-100 text-success-800 dark:bg-success-900/30 dark:text-success-400',
+    danger: 'bg-danger-100 text-danger-800 dark:bg-danger-900/30 dark:text-danger-400',
+    warning: 'bg-warning-100 text-warning-800 dark:bg-warning-900/30 dark:text-warning-400',
+    info: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
+    primary: 'bg-primary-100 text-primary-800 dark:bg-primary-900/30 dark:text-primary-400',
+    neutral: 'bg-neutral-100 text-neutral-700 dark:bg-slate-700 dark:text-slate-300',
+};
+
+/**
+ * Shared status/maturity pill badge. `tone` maps to the app's semantic color
+ * tokens so status meaning stays visually consistent (and dark-mode-correct)
+ * across the cheque/PDC desk tables and history views.
+ */
+const StatusBadge = ({ tone = 'neutral', label, className = '', pill = true }) => (
+    <span
+        className={`text-[10px] font-bold uppercase px-2.5 py-1 ${pill ? 'rounded-full' : 'rounded-md'} ${TONE_CLASSES[tone] || TONE_CLASSES.neutral} ${className}`}
+    >
+        {label}
+    </span>
+);
+
+export default StatusBadge;

--- a/packages/web/src/pages/BankAccountsPage.jsx
+++ b/packages/web/src/pages/BankAccountsPage.jsx
@@ -4,8 +4,12 @@ import toast from 'react-hot-toast';
 import { useAuth } from '../contexts/AuthContext';
 import { formatCurrency } from '../utils/currency';
 import Modal from '../components/ui/Modal';
+import StatusBadge from '../components/ui/StatusBadge';
 
 const emptyForm = { account_name: '', bank_name: '', account_number: '', currency: 'PHP', opening_balance: '0', notes: '', default_cheque_template_id: '' };
+
+const LABEL_CLASS = 'block text-xs font-semibold text-gray-700 dark:text-slate-300 mb-1';
+const INPUT_CLASS = 'w-full text-xs p-2 border border-gray-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-100 focus:ring-2 focus:ring-primary-500 focus:border-primary-500';
 
 const BankAccountsPage = () => {
     const { hasPermission } = useAuth();
@@ -96,19 +100,19 @@ const BankAccountsPage = () => {
         <div className="space-y-6">
             <div className="flex justify-between items-center">
                 <div>
-                    <h1 className="text-3xl font-bold text-gray-900">Bank Accounts</h1>
-                    <p className="text-sm text-gray-500 mt-1">The business's own bank accounts, used for issuing and reconciling outbound cheques</p>
+                    <h1 className="text-2xl font-bold text-gray-900 dark:text-slate-100">Bank Accounts</h1>
+                    <p className="text-sm text-gray-500 dark:text-slate-400 mt-1">The business's own bank accounts, used for issuing and reconciling outbound cheques</p>
                 </div>
                 {canManage && (
-                    <button onClick={openCreate} className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-xl text-sm font-bold shadow-xs cursor-pointer">
+                    <button onClick={openCreate} className="px-4 py-2 bg-primary-600 hover:bg-primary-700 text-white rounded-xl text-sm font-bold shadow-xs cursor-pointer">
                         + New Bank Account
                     </button>
                 )}
             </div>
 
-            <div className="bg-white rounded-xl border border-gray-200 overflow-hidden shadow-sm">
-                <table className="w-full text-sm text-left text-gray-500">
-                    <thead className="text-xs text-gray-700 uppercase bg-gray-50 border-b border-gray-200">
+            <div className="bg-white dark:bg-slate-800 rounded-xl border border-gray-200 dark:border-slate-700 overflow-hidden shadow-sm">
+                <table className="w-full text-sm text-left text-gray-500 dark:text-slate-400">
+                    <thead className="text-xs text-gray-700 dark:text-slate-300 uppercase bg-gray-50 dark:bg-slate-900/50 border-b border-gray-200 dark:border-slate-700">
                         <tr>
                             <th className="px-6 py-3.5">Account Name</th>
                             <th className="px-6 py-3.5">Bank</th>
@@ -119,33 +123,47 @@ const BankAccountsPage = () => {
                             {canManage && <th className="px-6 py-3.5 text-center">Actions</th>}
                         </tr>
                     </thead>
-                    <tbody className="divide-y divide-gray-200">
+                    <tbody className="divide-y divide-gray-200 dark:divide-slate-700">
                         {loading ? (
-                            <tr><td colSpan={7} className="px-6 py-8 text-center text-gray-400">Loading…</td></tr>
+                            [...Array(3)].map((_, i) => (
+                                <tr key={i} className="animate-pulse">
+                                    <td colSpan={7} className="px-6 py-4">
+                                        <div className="h-4 bg-gray-100 dark:bg-slate-700 rounded w-full" />
+                                    </td>
+                                </tr>
+                            ))
                         ) : accounts.length === 0 ? (
-                            <tr><td colSpan={7} className="px-6 py-8 text-center text-gray-400">No bank accounts yet.</td></tr>
+                            <tr>
+                                <td colSpan={7} className="px-6 py-12 text-center">
+                                    <div className="flex flex-col items-center justify-center gap-2">
+                                        <span className="text-2xl">🏦</span>
+                                        <p className="font-semibold text-gray-700 dark:text-slate-300">No bank accounts yet</p>
+                                        <p className="text-xs text-gray-400 dark:text-slate-500">
+                                            {canManage ? 'Add one to start issuing and receiving cheques.' : 'Ask an administrator to add one.'}
+                                        </p>
+                                    </div>
+                                </td>
+                            </tr>
                         ) : accounts.map(acc => (
-                            <tr key={acc.bank_account_id} className="hover:bg-gray-50">
-                                <td className="px-6 py-4 font-semibold text-gray-900">{acc.account_name}</td>
+                            <tr key={acc.bank_account_id} className="hover:bg-gray-50 dark:hover:bg-slate-700/40">
+                                <td className="px-6 py-4 font-semibold text-gray-900 dark:text-slate-100">{acc.account_name}</td>
                                 <td className="px-6 py-4">{acc.bank_name}</td>
                                 <td className="px-6 py-4 font-mono">{acc.account_number || '—'}</td>
                                 <td className="px-6 py-4 text-right font-mono">{formatCurrency(acc.opening_balance)}</td>
                                 <td className="px-6 py-4 text-xs">
                                     {acc.default_cheque_template_id ? (
-                                        <span className="px-2 py-0.5 bg-blue-50 text-blue-700 rounded-md border border-blue-200">{templateName(acc.default_cheque_template_id) || `#${acc.default_cheque_template_id}`}</span>
+                                        <span className="px-2 py-0.5 bg-primary-50 dark:bg-primary-900/20 text-primary-700 dark:text-primary-400 rounded-md border border-primary-200 dark:border-primary-900/40">{templateName(acc.default_cheque_template_id) || `#${acc.default_cheque_template_id}`}</span>
                                     ) : (
-                                        <span className="text-gray-400">Not linked (manual print)</span>
+                                        <span className="text-gray-400 dark:text-slate-500">Not linked (manual print)</span>
                                     )}
                                 </td>
                                 <td className="px-6 py-4">
-                                    <span className={`text-[10px] font-bold px-2 py-0.5 rounded-full uppercase ${acc.is_active ? 'bg-emerald-100 text-emerald-800' : 'bg-gray-200 text-gray-600'}`}>
-                                        {acc.is_active ? 'Active' : 'Inactive'}
-                                    </span>
+                                    <StatusBadge tone={acc.is_active ? 'success' : 'neutral'} label={acc.is_active ? 'Active' : 'Inactive'} />
                                 </td>
                                 {canManage && (
                                     <td className="px-6 py-4 text-center whitespace-nowrap">
-                                        <button onClick={() => openEdit(acc)} className="text-xs font-semibold text-blue-600 hover:underline mr-3 cursor-pointer">Edit</button>
-                                        <button onClick={() => toggleActive(acc)} className="text-xs font-semibold text-gray-500 hover:underline cursor-pointer">
+                                        <button onClick={() => openEdit(acc)} className="text-xs font-semibold text-primary-600 dark:text-primary-400 hover:underline mr-3 cursor-pointer">Edit</button>
+                                        <button onClick={() => toggleActive(acc)} className="text-xs font-semibold text-gray-500 dark:text-slate-400 hover:underline cursor-pointer">
                                             {acc.is_active ? 'Deactivate' : 'Activate'}
                                         </button>
                                     </td>
@@ -159,51 +177,51 @@ const BankAccountsPage = () => {
             <Modal isOpen={modalOpen} onClose={() => setModalOpen(false)} title={editingId ? 'Edit Bank Account' : 'New Bank Account'}>
                 <form onSubmit={handleSubmit} className="space-y-3">
                     <div>
-                        <label className="block text-xs font-semibold text-gray-700 mb-1">Account Name</label>
+                        <label className={LABEL_CLASS}>Account Name</label>
                         <input type="text" value={form.account_name} onChange={(e) => setForm({ ...form, account_name: e.target.value })}
-                            className="w-full text-xs p-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500" />
+                            className={INPUT_CLASS} />
                     </div>
                     <div>
-                        <label className="block text-xs font-semibold text-gray-700 mb-1">Bank Name</label>
+                        <label className={LABEL_CLASS}>Bank Name</label>
                         <input type="text" value={form.bank_name} onChange={(e) => setForm({ ...form, bank_name: e.target.value })}
-                            className="w-full text-xs p-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500" />
+                            className={INPUT_CLASS} />
                     </div>
                     <div>
-                        <label className="block text-xs font-semibold text-gray-700 mb-1">Account Number</label>
+                        <label className={LABEL_CLASS}>Account Number</label>
                         <input type="text" value={form.account_number} onChange={(e) => setForm({ ...form, account_number: e.target.value })}
-                            className="w-full text-xs p-2 border border-gray-300 rounded-lg font-mono focus:ring-2 focus:ring-blue-500" />
+                            className={`${INPUT_CLASS} font-mono`} />
                     </div>
                     <div className="grid grid-cols-2 gap-3">
                         <div>
-                            <label className="block text-xs font-semibold text-gray-700 mb-1">Currency</label>
+                            <label className={LABEL_CLASS}>Currency</label>
                             <input type="text" value={form.currency} onChange={(e) => setForm({ ...form, currency: e.target.value })}
-                                className="w-full text-xs p-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500" />
+                                className={INPUT_CLASS} />
                         </div>
                         <div>
-                            <label className="block text-xs font-semibold text-gray-700 mb-1">Opening Balance</label>
+                            <label className={LABEL_CLASS}>Opening Balance</label>
                             <input type="number" step="0.01" value={form.opening_balance} onChange={(e) => setForm({ ...form, opening_balance: e.target.value })}
-                                className="w-full text-xs p-2 border border-gray-300 rounded-lg font-mono focus:ring-2 focus:ring-blue-500" />
+                                className={`${INPUT_CLASS} font-mono`} />
                         </div>
                     </div>
                     <div>
-                        <label className="block text-xs font-semibold text-gray-700 mb-1">Default Cheque Print Template</label>
+                        <label className={LABEL_CLASS}>Default Cheque Print Template</label>
                         <select value={form.default_cheque_template_id} onChange={(e) => setForm({ ...form, default_cheque_template_id: e.target.value })}
-                            className="w-full text-xs p-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500">
+                            className={INPUT_CLASS}>
                             <option value="">None — print manually from Cheque Printing</option>
                             {templates.map(t => (
                                 <option key={t.id} value={t.id}>{t.bank_name}</option>
                             ))}
                         </select>
-                        <p className="text-[11px] text-gray-400 mt-1">When set, issuing a cheque from this account auto-generates and opens the printable PDF.</p>
+                        <p className="text-[11px] text-gray-400 dark:text-slate-500 mt-1">When set, issuing a cheque from this account auto-generates and opens the printable PDF.</p>
                     </div>
                     <div>
-                        <label className="block text-xs font-semibold text-gray-700 mb-1">Notes</label>
+                        <label className={LABEL_CLASS}>Notes</label>
                         <textarea value={form.notes} onChange={(e) => setForm({ ...form, notes: e.target.value })}
-                            className="w-full text-xs p-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500" rows={2} />
+                            className={INPUT_CLASS} rows={2} />
                     </div>
                     <div className="flex justify-end gap-3 pt-2">
-                        <button type="button" onClick={() => setModalOpen(false)} className="px-4 py-2 text-xs font-semibold text-gray-600 bg-gray-100 hover:bg-gray-200 rounded-lg cursor-pointer">Cancel</button>
-                        <button type="submit" disabled={submitting} className="px-4 py-2 text-xs font-bold text-white bg-blue-600 hover:bg-blue-700 rounded-lg shadow-xs cursor-pointer disabled:opacity-50">
+                        <button type="button" onClick={() => setModalOpen(false)} className="px-4 py-2 text-xs font-semibold text-gray-600 dark:text-slate-300 bg-gray-100 dark:bg-slate-700 hover:bg-gray-200 dark:hover:bg-slate-600 rounded-lg cursor-pointer">Cancel</button>
+                        <button type="submit" disabled={submitting} className="px-4 py-2 text-xs font-bold text-white bg-primary-600 hover:bg-primary-700 rounded-lg shadow-xs cursor-pointer disabled:opacity-50">
                             {submitting ? 'Saving…' : 'Save'}
                         </button>
                     </div>

--- a/packages/web/src/pages/ChequePrintingPage.jsx
+++ b/packages/web/src/pages/ChequePrintingPage.jsx
@@ -4,42 +4,16 @@ import toast from 'react-hot-toast';
 import api from '../api';
 // eslint-disable-next-line no-unused-vars
 import Icon from '../components/ui/Icon';
+import Modal from '../components/ui/Modal';
 import { ICONS } from '../constants';
 
 const blankRow = () => ({ date: format(new Date(), 'yyyy-MM-dd'), payee: '', amount: '', memo: '' });
-const DEFAULT_TEMPLATE = {
-    date: { x: 426, y: 178, alignment: 'left', fontSize: 11, mode: 'boxed', charSpacing: 14 },
-    payee: { x: 72, y: 136, alignment: 'left', fontSize: 12, maxWidth: 380, minFontSize: 8 },
-    amountNumeric: { x: 534, y: 136, alignment: 'right', fontSize: 12 },
-    amountWords: { x: 72, y: 104, alignment: 'left', fontSize: 11, maxWidth: 420 },
-    memo: { x: 72, y: 84, alignment: 'left', fontSize: 10, maxWidth: 220 },
-    currency: { x: 474, y: 136, alignment: 'left', fontSize: 11 }
-};
-
-const SETTINGS_TABS = [
-    { id: 'layout', label: 'Layout' },
-    { id: 'date', label: 'Date' },
-    { id: 'amount', label: 'Amount' },
-    { id: 'currency', label: 'Currency' },
-    { id: 'paper', label: 'Paper' },
-    { id: 'text', label: 'Text' },
-    { id: 'calibration', label: 'Calibration' }
-];
-
-const FIELD_LABELS = {
-    date: 'Date',
-    payee: 'Payee',
-    amountNumeric: 'Amount in figures',
-    amountWords: 'Amount in words',
-    memo: 'Memo',
-    currency: 'Currency symbol'
-};
 
 const BUTTON_BASE = 'inline-flex items-center justify-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50';
-const BUTTON_SECONDARY = `${BUTTON_BASE} border border-gray-300 bg-white text-gray-700 hover:bg-gray-50`;
-const BUTTON_PRIMARY = `${BUTTON_BASE} bg-blue-600 text-white hover:bg-blue-700`;
-const BUTTON_DANGER = `${BUTTON_BASE} border border-red-200 bg-white text-red-600 hover:bg-red-50`;
-const INPUT_BASE = 'w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100';
+const BUTTON_SECONDARY = `${BUTTON_BASE} border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-700 dark:text-slate-200 hover:bg-gray-50 dark:hover:bg-slate-700`;
+const BUTTON_PRIMARY = `${BUTTON_BASE} bg-primary-600 text-white hover:bg-primary-700`;
+const BUTTON_DANGER = `${BUTTON_BASE} border border-danger-200 dark:border-danger-900/50 bg-white dark:bg-slate-800 text-danger-600 dark:text-danger-400 hover:bg-danger-50 dark:hover:bg-danger-900/20`;
+const INPUT_BASE = 'w-full rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-100 px-3 py-2 text-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-100 dark:focus:ring-primary-900/30';
 
 const ChequePrintingPage = () => {
     const [templates, setTemplates] = useState([]);
@@ -49,18 +23,14 @@ const ChequePrintingPage = () => {
     const [rows, setRows] = useState([blankRow()]);
     const [history, setHistory] = useState([]);
     const [historyOpen, setHistoryOpen] = useState(false);
-    const [settingsOpen, setSettingsOpen] = useState(false);
-    const [activeTab, setActiveTab] = useState('layout');
     const [saving, setSaving] = useState(false);
     const [persistRecords, setPersistRecords] = useState(true);
     const [testPrintMode, setTestPrintMode] = useState(false);
     const [historyQuery, setHistoryQuery] = useState('');
     const [historyBankFilter, setHistoryBankFilter] = useState('all');
     const [pendingHistoryEntry, setPendingHistoryEntry] = useState(null);
-    const [draftProfile, setDraftProfile] = useState({ profile_name: '', feed_type: 'native', offset_x: 0, offset_y: 0, is_default: false });
 
     const selectedTemplate = useMemo(() => templates.find((tpl) => String(tpl.id) === String(selectedTemplateId)), [templates, selectedTemplateId]);
-    const selectedProfile = useMemo(() => printerProfiles.find((profile) => String(profile.id) === String(selectedProfileId)), [printerProfiles, selectedProfileId]);
 
     const loadData = async () => {
         try {
@@ -81,19 +51,6 @@ const ChequePrintingPage = () => {
     };
 
     useEffect(() => { loadData(); }, []);
-    useEffect(() => {
-        if (!selectedProfile) {
-            setDraftProfile({ profile_name: '', feed_type: 'native', offset_x: 0, offset_y: 0, is_default: false });
-            return;
-        }
-        setDraftProfile({
-            profile_name: selectedProfile.profile_name || '',
-            feed_type: selectedProfile.feed_type || 'native',
-            offset_x: Number(selectedProfile.offset_x || 0),
-            offset_y: Number(selectedProfile.offset_y || 0),
-            is_default: Boolean(selectedProfile.is_default)
-        });
-    }, [selectedProfileId]);
 
     const updateRow = (idx, field, value) => {
         setRows((prev) => {
@@ -261,110 +218,6 @@ const ChequePrintingPage = () => {
         applyHistoryEntryToEditor(entry, 'overwrite');
     };
 
-    const updateTemplate = async (patch) => {
-        if (!selectedTemplate) return;
-        try {
-            const response = await api.put(`/cheques/templates/${selectedTemplate.id}`, {
-                ...selectedTemplate,
-                ...patch
-            });
-            setTemplates((prev) => prev.map((template) => (template.id === response.data.id ? response.data : template)));
-        } catch (error) {
-            toast.error(error?.response?.data?.message || 'Template update failed.');
-        }
-    };
-
-    const upsertProfile = async (patch) => {
-        try {
-            if (!selectedProfile) {
-                const created = await api.post('/cheques/printer-profiles', {
-                    profile_name: patch.profile_name || `Profile ${printerProfiles.length + 1}`,
-                    feed_type: patch.feed_type || 'native',
-                    offset_x: patch.offset_x || 0,
-                    offset_y: patch.offset_y || 0,
-                    is_default: patch.is_default || false
-                });
-                setPrinterProfiles((prev) => [...prev, created.data]);
-                setSelectedProfileId(String(created.data.id));
-                return;
-            }
-
-            const response = await api.put(`/cheques/printer-profiles/${selectedProfile.id}`, {
-                ...selectedProfile,
-                ...patch
-            });
-
-            setPrinterProfiles((prev) => prev.map((profile) => (profile.id === response.data.id ? response.data : profile)));
-        } catch (error) {
-            toast.error(error?.response?.data?.message || 'Printer profile update failed.');
-        }
-    };
-
-    const createTemplateFromCurrent = async () => {
-        const baseName = selectedTemplate?.bank_name || 'New Bank Preset';
-        const bankName = window.prompt('Enter name for bank preset:', selectedTemplate ? `${baseName} Copy` : baseName);
-        if (!bankName?.trim()) return;
-        try {
-            const res = await api.post('/cheques/templates', {
-                ...(selectedTemplate || {}),
-                bank_name: bankName.trim()
-                ,
-                field_positions: selectedTemplate?.field_positions || DEFAULT_TEMPLATE
-            });
-            setTemplates((prev) => [...prev, res.data].sort((a, b) => a.bank_name.localeCompare(b.bank_name)));
-            setSelectedTemplateId(String(res.data.id));
-            toast.success(selectedTemplate ? 'Bank preset duplicated.' : 'Bank preset created.');
-        } catch (error) {
-            toast.error(error?.response?.data?.message || 'Failed to save bank preset.');
-        }
-    };
-
-    const deleteCurrentTemplate = async () => {
-        if (!selectedTemplate) return;
-        if (!window.confirm(`Delete bank preset "${selectedTemplate.bank_name}"?`)) return;
-        try {
-            await api.delete(`/cheques/templates/${selectedTemplate.id}`);
-            toast.success('Bank preset deleted.');
-            await loadData();
-            setSelectedTemplateId('');
-        } catch (error) {
-            toast.error(error?.response?.data?.message || 'Failed to delete bank preset.');
-        }
-    };
-
-    const duplicateCurrentProfile = async () => {
-        if (!selectedProfile) return;
-        const profileName = window.prompt('Enter name for duplicated printer profile:', `${selectedProfile.profile_name} Copy`);
-        if (!profileName?.trim()) return;
-        try {
-            const created = await api.post('/cheques/printer-profiles', {
-                profile_name: profileName.trim(),
-                feed_type: selectedProfile.feed_type || 'native',
-                offset_x: Number(selectedProfile.offset_x || 0),
-                offset_y: Number(selectedProfile.offset_y || 0),
-                is_default: false
-            });
-            setPrinterProfiles((prev) => [...prev, created.data]);
-            setSelectedProfileId(String(created.data.id));
-            toast.success('Printer profile duplicated.');
-        } catch (error) {
-            toast.error(error?.response?.data?.message || 'Failed to duplicate printer profile.');
-        }
-    };
-
-    const deleteCurrentProfile = async () => {
-        if (!selectedProfile) return;
-        if (!window.confirm(`Delete printer profile "${selectedProfile.profile_name}"?`)) return;
-        try {
-            await api.delete(`/cheques/printer-profiles/${selectedProfile.id}`);
-            toast.success('Printer profile deleted.');
-            await loadData();
-            setSelectedProfileId('');
-        } catch (error) {
-            toast.error(error?.response?.data?.message || 'Failed to delete printer profile.');
-        }
-    };
-
     const onRowKeyDown = (event, rowIndex, fieldIndex) => {
         if (event.key !== 'Enter') return;
         event.preventDefault();
@@ -373,52 +226,18 @@ const ChequePrintingPage = () => {
         if (next) next.focus();
     };
 
-    const downloadSettingsExport = async () => {
-        try {
-            const response = await api.get('/cheques/settings-export', { responseType: 'blob' });
-            const blobUrl = window.URL.createObjectURL(new Blob([response.data], { type: 'application/json' }));
-            const link = document.createElement('a');
-            link.href = blobUrl;
-            link.setAttribute('download', `cheque-settings-${format(new Date(), 'yyyy-MM-dd')}.json`);
-            document.body.appendChild(link);
-            link.click();
-            link.remove();
-            window.URL.revokeObjectURL(blobUrl);
-            toast.success('Cheque settings exported.');
-        } catch (error) {
-            toast.error(error?.response?.data?.message || 'Failed to export cheque settings.');
-        }
-    };
-
-    const importSettingsFile = async (event) => {
-        const file = event.target.files?.[0];
-        if (!file) return;
-        try {
-            const payload = JSON.parse(await file.text());
-            const overwrite = window.confirm('Overwrite existing presets/profiles with matching names? Click Cancel to append only.');
-            await api.post('/cheques/settings-import', { ...payload, overwrite });
-            toast.success('Cheque settings imported.');
-            await loadData();
-        } catch (error) {
-            toast.error(error?.response?.data?.message || 'Failed to import cheque settings file.');
-        } finally {
-            event.target.value = '';
-        }
-    };
+    const queueCount = activeRows.length;
+    const queueTotal = activeRows.reduce((sum, row) => sum + (Number(row.amount) || 0), 0);
 
     return (
         <div className="space-y-4 pb-4">
-            <div className="bg-white border rounded-xl p-4 md:p-5">
+            <div className="bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-xl p-4 md:p-5">
                 <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
                     <div>
-                        <h1 className="text-lg md:text-xl font-semibold text-gray-900">Cheque Printing</h1>
-                        <p className="text-sm text-gray-500 mt-1">Prepare cheques, manage print calibration, and review printed cheque history in one place.</p>
+                        <h2 className="text-lg md:text-xl font-semibold text-gray-900 dark:text-slate-100">Print Cheques</h2>
+                        <p className="text-sm text-gray-500 dark:text-slate-400 mt-1">Prepare cheques for printing and review printed cheque history. Bank presets and printer profiles live under Templates &amp; Settings.</p>
                     </div>
                     <div className="flex flex-wrap gap-2">
-                        <button className={BUTTON_SECONDARY} onClick={() => setSettingsOpen(true)}>
-                            <Icon path={ICONS.settings} className="h-4 w-4" />
-                            Open Settings
-                        </button>
                         <button className={BUTTON_SECONDARY} onClick={() => setHistoryOpen(true)}>
                             <Icon path={ICONS.history} className="h-4 w-4" />
                             View History
@@ -432,9 +251,17 @@ const ChequePrintingPage = () => {
             </div>
 
             <div className="grid grid-cols-1 xl:grid-cols-3 gap-4">
-                <div className="xl:col-span-2 bg-white border rounded-xl p-4 space-y-4">
-                    <h2 className="text-sm font-semibold text-gray-700 uppercase tracking-wide">Print Queue</h2>
-                    <div className="hidden md:grid grid-cols-[120px_1fr_160px_1fr_80px] gap-3 px-2 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                <div className="xl:col-span-2 bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-xl p-4 space-y-4">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                        <h2 className="text-sm font-semibold text-gray-700 dark:text-slate-300 uppercase tracking-wide">Print Queue</h2>
+                        {queueCount > 0 && (
+                            <span className="text-xs font-medium text-gray-500 dark:text-slate-400">
+                                {queueCount} cheque{queueCount === 1 ? '' : 's'} · <span className="font-semibold text-gray-700 dark:text-slate-300 font-mono">₱{queueTotal.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
+                            </span>
+                        )}
+                    </div>
+                    <div className="hidden md:grid grid-cols-[28px_120px_1fr_160px_1fr_80px] gap-3 px-2 text-xs font-semibold text-gray-500 dark:text-slate-400 uppercase tracking-wide">
+                        <span></span>
                         <span>Date</span>
                         <span>Payee</span>
                         <span>Amount</span>
@@ -445,7 +272,14 @@ const ChequePrintingPage = () => {
                     {rows.map((row, idx) => {
                         const isTrailingBlank = idx === rows.length - 1 && !row.payee && !row.amount && !row.memo;
                         return (
-                            <div key={idx} className="bg-gray-50/70 border rounded-xl p-3 grid grid-cols-1 md:grid-cols-[120px_1fr_160px_1fr_80px] gap-3 items-start">
+                            <div key={idx} className={`border rounded-xl p-3 grid grid-cols-1 md:grid-cols-[28px_120px_1fr_160px_1fr_80px] gap-3 md:items-center transition-colors ${isTrailingBlank ? 'border-dashed border-gray-300 dark:border-slate-700 bg-transparent' : 'border-gray-200 dark:border-slate-700 bg-gray-50/70 dark:bg-slate-900/40'}`}>
+                                <div className="hidden md:flex items-center justify-center">
+                                    {!isTrailingBlank && (
+                                        <span className="h-5 w-5 rounded-full bg-primary-100 dark:bg-primary-900/40 text-primary-700 dark:text-primary-400 text-[11px] font-bold flex items-center justify-center">
+                                            {idx + 1}
+                                        </span>
+                                    )}
+                                </div>
                                 {[
                                     { field: 'date', placeholder: 'Date' },
                                     { field: 'payee', placeholder: 'Payee' },
@@ -453,523 +287,186 @@ const ChequePrintingPage = () => {
                                     { field: 'memo', placeholder: 'Memo' }
                                 ].map((column, fieldIndex) => (
                                     <div key={column.field} className="space-y-1">
-                                        <label className="md:hidden text-xs font-semibold text-gray-500 uppercase tracking-wide">{column.placeholder}</label>
-                                        <input
-                                            type={column.field === 'date' ? 'date' : 'text'}
-                                            className={INPUT_BASE}
-                                            value={row[column.field]}
-                                            onChange={(e) => updateRow(idx, column.field, e.target.value)}
-                                            onKeyDown={(e) => onRowKeyDown(e, idx, fieldIndex)}
-                                            placeholder={column.placeholder}
-                                            data-row={idx}
-                                            data-field-index={fieldIndex}
-                                        />
+                                        <label className="md:hidden text-xs font-semibold text-gray-500 dark:text-slate-400 uppercase tracking-wide">{column.placeholder}</label>
+                                        {column.field === 'amount' ? (
+                                            <div className="relative">
+                                                <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-sm text-gray-400 dark:text-slate-500">₱</span>
+                                                <input
+                                                    type="text"
+                                                    inputMode="decimal"
+                                                    className={`${INPUT_BASE} pl-7 font-mono`}
+                                                    value={row.amount}
+                                                    onChange={(e) => updateRow(idx, 'amount', e.target.value)}
+                                                    onKeyDown={(e) => onRowKeyDown(e, idx, fieldIndex)}
+                                                    placeholder="0.00"
+                                                    data-row={idx}
+                                                    data-field-index={fieldIndex}
+                                                />
+                                            </div>
+                                        ) : (
+                                            <input
+                                                type={column.field === 'date' ? 'date' : 'text'}
+                                                className={INPUT_BASE}
+                                                value={row[column.field]}
+                                                onChange={(e) => updateRow(idx, column.field, e.target.value)}
+                                                onKeyDown={(e) => onRowKeyDown(e, idx, fieldIndex)}
+                                                placeholder={column.placeholder}
+                                                data-row={idx}
+                                                data-field-index={fieldIndex}
+                                            />
+                                        )}
                                     </div>
                                 ))}
                                 <div className="flex md:justify-end">
-                                    <button
-                                        className={BUTTON_DANGER}
-                                        onClick={() => removeRow(idx)}
-                                        disabled={rows.length === 1 || isTrailingBlank}
-                                    >
-                                        <Icon path={ICONS.trash} className="h-4 w-4" />
-                                        Remove
-                                    </button>
+                                    {isTrailingBlank ? (
+                                        <span className="hidden md:inline text-xs text-gray-400 dark:text-slate-500">Start typing to add</span>
+                                    ) : (
+                                        <button
+                                            className={BUTTON_DANGER}
+                                            onClick={() => removeRow(idx)}
+                                            disabled={rows.length === 1}
+                                            title="Remove this cheque"
+                                        >
+                                            <Icon path={ICONS.trash} className="h-4 w-4" />
+                                            <span className="md:hidden">Remove</span>
+                                        </button>
+                                    )}
                                 </div>
                             </div>
                         );
                     })}
                 </div>
 
-                <div className="bg-white border rounded-xl p-4 space-y-4">
-                    <h2 className="text-sm font-semibold text-gray-700 uppercase tracking-wide">Print Controls</h2>
+                <div className="bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-xl p-4 space-y-4">
+                    <h2 className="text-sm font-semibold text-gray-700 dark:text-slate-300 uppercase tracking-wide">Print Controls</h2>
                     <div className="space-y-3">
                         <div>
-                            <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">Bank preset</label>
+                            <label className="flex items-center gap-1.5 text-xs font-semibold text-gray-500 dark:text-slate-400 uppercase tracking-wide mb-1">
+                                <Icon path={ICONS.bank} className="h-3.5 w-3.5" /> Bank preset
+                            </label>
                             <select className={INPUT_BASE} value={selectedTemplateId} onChange={(e) => setSelectedTemplateId(e.target.value)}>
                                 {!templates.length && <option value="">No bank preset yet</option>}
                                 {templates.map((template) => <option key={template.id} value={template.id}>{template.bank_name}</option>)}
                             </select>
-                            <div className="flex gap-2 mt-2">
-                                <button className={BUTTON_SECONDARY} onClick={createTemplateFromCurrent}>{selectedTemplate ? 'Duplicate Preset' : 'Create Preset'}</button>
-                                <button className={BUTTON_DANGER} onClick={deleteCurrentTemplate} disabled={!selectedTemplate || templates.length <= 1}>Delete Preset</button>
-                            </div>
                         </div>
                         <div>
-                            <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">Printer profile</label>
+                            <label className="flex items-center gap-1.5 text-xs font-semibold text-gray-500 dark:text-slate-400 uppercase tracking-wide mb-1">
+                                <Icon path={ICONS.settings} className="h-3.5 w-3.5" /> Printer profile
+                            </label>
                             <select className={INPUT_BASE} value={selectedProfileId} onChange={(e) => setSelectedProfileId(e.target.value)}>
                                 <option value="">{printerProfiles.length ? 'None' : 'No printer profile yet'}</option>
                                 {printerProfiles.map((profile) => <option key={profile.id} value={profile.id}>{profile.profile_name}{profile.is_default ? ' (Default)' : ''}</option>)}
                             </select>
-                            <div className="flex gap-2 mt-2">
-                                <button className={BUTTON_SECONDARY} onClick={duplicateCurrentProfile} disabled={!selectedProfile}>Duplicate Profile</button>
-                                <button className={BUTTON_DANGER} onClick={deleteCurrentProfile} disabled={!selectedProfile}>Delete Profile</button>
-                            </div>
                         </div>
                     </div>
 
-                    <div className="space-y-2 border-t pt-3">
-                        {!templates.length && (
-                            <div className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded-lg p-2">
-                                No bank preset found. Create one in Settings or import presets before generating cheques.
-                            </div>
-                        )}
-                        {!printerProfiles.length && (
-                            <div className="text-xs text-blue-700 bg-blue-50 border border-blue-200 rounded-lg p-2">
-                                No printer profile found. You can still generate a PDF, but creating a profile is recommended for proper alignment.
-                            </div>
-                        )}
-                        <label className="flex items-center gap-2 text-sm">
-                            <input type="checkbox" checked={persistRecords} onChange={(e) => setPersistRecords(e.target.checked)} />
+                    {(!templates.length || !printerProfiles.length) && (
+                        <div className="space-y-2">
+                            {!templates.length && (
+                                <div className="flex items-start gap-2 text-xs text-warning-700 dark:text-warning-400 bg-warning-50 dark:bg-warning-900/20 border border-warning-200 dark:border-warning-900/40 rounded-lg p-2">
+                                    <Icon path={ICONS.warning} className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+                                    <span>No bank preset found. Create one in Templates &amp; Settings before generating cheques.</span>
+                                </div>
+                            )}
+                            {!printerProfiles.length && (
+                                <div className="flex items-start gap-2 text-xs text-primary-700 dark:text-primary-400 bg-primary-50 dark:bg-primary-900/20 border border-primary-200 dark:border-primary-900/40 rounded-lg p-2">
+                                    <Icon path={ICONS.info} className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+                                    <span>No printer profile found. A PDF can still be generated, but a profile keeps alignment consistent.</span>
+                                </div>
+                            )}
+                        </div>
+                    )}
+
+                    <div className="space-y-2 border-t border-gray-200 dark:border-slate-700 pt-3">
+                        <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-slate-300 cursor-pointer">
+                            <input type="checkbox" className="rounded text-primary-600 focus:ring-primary-500" checked={persistRecords} onChange={(e) => setPersistRecords(e.target.checked)} />
                             Save generated cheques to history
                         </label>
-                        <label className="flex items-center gap-2 text-sm">
-                            <input type="checkbox" checked={testPrintMode} onChange={(e) => setTestPrintMode(e.target.checked)} />
+                        <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-slate-300 cursor-pointer">
+                            <input type="checkbox" className="rounded text-primary-600 focus:ring-primary-500" checked={testPrintMode} onChange={(e) => setTestPrintMode(e.target.checked)} />
                             Test print mode
                         </label>
                     </div>
 
-                    <div className="text-xs text-gray-500 bg-blue-50 border border-blue-100 rounded-lg p-3">
-                        Tip: Use <span className="font-semibold">100% print scale</span> for proper cheque alignment.
-                    </div>
+                    <p className="text-xs text-gray-400 dark:text-slate-500 flex items-start gap-1.5">
+                        <Icon path={ICONS.info} className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+                        Use 100% print scale for proper cheque alignment.
+                    </p>
                 </div>
             </div>
 
-            {settingsOpen && (
-                <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
-                    <div className="bg-white rounded-xl border w-full max-w-6xl max-h-[90vh] overflow-hidden flex flex-col">
-                        <div className="p-4 border-b flex items-center justify-between">
-                            <div>
-                                <h3 className="font-semibold text-gray-900">Cheque Settings</h3>
-                                <p className="text-xs text-gray-500 mt-0.5">Preset: {selectedTemplate?.bank_name || 'None selected'}</p>
-                            </div>
-                            <button className={BUTTON_SECONDARY} onClick={() => setSettingsOpen(false)}><Icon path={ICONS.close} className="h-4 w-4" />Close</button>
-                        </div>
-
-                        <div className="min-h-0 flex-1 flex flex-col">
-                            <div className="border-b px-4 md:px-5 overflow-x-auto">
-                                <div className="flex items-center gap-5 min-w-max">
-                                    {SETTINGS_TABS.map((tab) => (
-                                        <button
-                                            key={tab.id}
-                                            type="button"
-                                            className={`py-3 px-1 border-b-2 font-medium text-sm ${activeTab === tab.id ? 'border-blue-600 text-blue-600' : 'border-transparent text-gray-500 hover:border-gray-300'}`}
-                                            onClick={() => setActiveTab(tab.id)}
-                                        >
-                                            {tab.label}
-                                        </button>
-                                    ))}
-                                </div>
-                            </div>
-
-                            <div className="p-4 md:p-5 overflow-auto text-sm space-y-4">
-                                {activeTab === 'layout' && selectedTemplate && (
-                                    <div className="space-y-3">
-                                        <div className="flex flex-wrap items-center justify-between gap-2 border rounded-lg bg-gray-50 p-3">
-                                            <div>
-                                                <p className="font-medium text-gray-900">Bank preset details</p>
-                                                <p className="text-xs text-gray-500">Save and share this bank preset including cheque layout variables.</p>
-                                            </div>
-                                            <button className={BUTTON_PRIMARY} onClick={() => updateTemplate({ ...selectedTemplate })}>
-                                                <Icon path={ICONS.settings} className="h-4 w-4" />
-                                                Save Bank Preset
-                                            </button>
-                                        </div>
-                                        <div>
-                                            <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">Bank preset name</label>
-                                            <input className={INPUT_BASE} value={selectedTemplate.bank_name || ''} onChange={(e) => updateTemplate({ bank_name: e.target.value })} />
-                                        </div>
-                                        <p className="text-gray-600">Fine-tune field placements and sizes for this cheque template.</p>
-                                        <div className="grid grid-cols-4 lg:grid-cols-6 gap-2 text-xs font-semibold text-gray-500 uppercase tracking-wide">
-                                            <span>Field</span>
-                                            <span>X Position</span>
-                                            <span>Y Position</span>
-                                            <span>Font Size</span>
-                                            <span className="hidden lg:block">Max Width</span>
-                                            <span className="hidden lg:block">Min Font</span>
-                                        </div>
-                                        {Object.entries(selectedTemplate.field_positions || {}).map(([field, cfg]) => {
-                                            const showExtras = ['payee', 'amountWords', 'memo'].includes(field);
-                                            return (
-                                                <div key={field} className="grid grid-cols-4 lg:grid-cols-6 gap-2 items-center border rounded-lg p-2">
-                                                    <span className="font-medium truncate" title={FIELD_LABELS[field] || field}>{FIELD_LABELS[field] || field}</span>
-                                                    <input type="number" className={INPUT_BASE} aria-label={`${field} X`} value={cfg.x ?? 0} onChange={(e) => updateTemplate({ field_positions: { ...selectedTemplate.field_positions, [field]: { ...cfg, x: Number(e.target.value) } } })} />
-                                                    <input type="number" className={INPUT_BASE} aria-label={`${field} Y`} value={cfg.y ?? 0} onChange={(e) => updateTemplate({ field_positions: { ...selectedTemplate.field_positions, [field]: { ...cfg, y: Number(e.target.value) } } })} />
-                                                    <input type="number" className={INPUT_BASE} aria-label={`${field} Font`} value={cfg.fontSize ?? 11} onChange={(e) => updateTemplate({ field_positions: { ...selectedTemplate.field_positions, [field]: { ...cfg, fontSize: Number(e.target.value) } } })} />
-                                                    {showExtras ? (
-                                                        <>
-                                                            <input type="number" className={`${INPUT_BASE} col-span-2 lg:col-span-1`} aria-label={`${field} Max Width`} placeholder="Max Width" value={cfg.maxWidth ?? ''} onChange={(e) => updateTemplate({ field_positions: { ...selectedTemplate.field_positions, [field]: { ...cfg, maxWidth: e.target.value ? Number(e.target.value) : null } } })} />
-                                                            <input type="number" className={`${INPUT_BASE} col-span-2 lg:col-span-1`} aria-label={`${field} Min Font`} placeholder="Min Font" value={cfg.minFontSize ?? ''} onChange={(e) => updateTemplate({ field_positions: { ...selectedTemplate.field_positions, [field]: { ...cfg, minFontSize: e.target.value ? Number(e.target.value) : null } } })} />
-                                                        </>
-                                                    ) : (
-                                                        <div className="hidden lg:block lg:col-span-2"></div>
-                                                    )}
-                                                </div>
-                                            );
-                                        })}
-                                    </div>
-                                )}
-                                {activeTab === 'layout' && !selectedTemplate && (
-                                    <div className="space-y-3">
-                                        <p className="text-gray-600">No bank preset exists yet. Create one or import settings to begin configuring cheque layout.</p>
-                                        <div className="flex gap-2">
-                                            <button className={BUTTON_PRIMARY} onClick={createTemplateFromCurrent}>Create Bank Preset</button>
-                                            <label className={`${BUTTON_SECONDARY} cursor-pointer`}>
-                                                Import Presets & Profiles
-                                                <input type="file" accept="application/json" className="hidden" onChange={importSettingsFile} />
-                                            </label>
-                                        </div>
-                                    </div>
-                                )}
-
-                                {activeTab === 'date' && (
-                                    <div className="space-y-3">
-                                        <div>
-                                            <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">Date output format</label>
-                                            <select className={INPUT_BASE} value={selectedTemplate.date_format || 'MM-dd-yyyy'} onChange={(e) => updateTemplate({ date_format: e.target.value })}>
-                                                <option value="MM-dd-yyyy">MM-DD-YYYY</option>
-                                                <option value="MM/dd/yyyy">MM/dd/yyyy</option>
-                                                <option value="dd/MM/yyyy">dd/MM/yyyy</option>
-                                                <option value="MMM dd, yyyy">MMM dd, yyyy</option>
-                                            </select>
-                                        </div>
-                                        <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
-                                            <div>
-                                                <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">Date Mode</label>
-                                                <select
-                                                    className={INPUT_BASE}
-                                                    value={selectedTemplate.field_positions?.date?.mode || 'single'}
-                                                    onChange={(e) => updateTemplate({
-                                                        field_positions: {
-                                                            ...selectedTemplate.field_positions,
-                                                            date: { ...(selectedTemplate.field_positions?.date || {}), mode: e.target.value }
-                                                        }
-                                                    })}
-                                                >
-                                                    <option value="single">Single-line date mode</option>
-                                                    <option value="boxed">Boxed date mode (MMDDYYYY without separators)</option>
-                                                </select>
-                                            </div>
-                                            <div className="flex gap-2">
-                                                <div className="flex-1">
-                                                    <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">Char Spacing</label>
-                                                    <input
-                                                        type="number"
-                                                        step="0.5"
-                                                        className={INPUT_BASE}
-                                                        placeholder="Character spacing"
-                                                        title="Character spacing"
-                                                        value={selectedTemplate.field_positions?.date?.charSpacing ?? 0}
-                                                        onChange={(e) => updateTemplate({
-                                                            field_positions: {
-                                                                ...selectedTemplate.field_positions,
-                                                                date: { ...(selectedTemplate.field_positions?.date || {}), charSpacing: Number(e.target.value) || 0 }
-                                                            }
-                                                        })}
-                                                    />
-                                                </div>
-                                                {selectedTemplate.field_positions?.date?.mode === 'boxed' && (
-                                                    <div className="flex-1">
-                                                        <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">Block Spacing</label>
-                                                        <input
-                                                            type="number"
-                                                            step="0.5"
-                                                            className={INPUT_BASE}
-                                                            placeholder="Block Spacing (pt)"
-                                                            title="Block Spacing (pt)"
-                                                            value={selectedTemplate.field_positions?.date?.blockSpacing ?? selectedTemplate.field_positions?.date?.charSpacing ?? 0}
-                                                            onChange={(e) => updateTemplate({
-                                                                field_positions: {
-                                                                    ...selectedTemplate.field_positions,
-                                                                    date: { ...(selectedTemplate.field_positions?.date || {}), blockSpacing: Number(e.target.value) || 0 }
-                                                                }
-                                                            })}
-                                                        />
-                                                    </div>
-                                                )}
-                                            </div>
-                                        </div>
-                                    </div>
-                                )}
-
-                                {activeTab === 'amount' && (
-                                    <div className="space-y-3">
-                                        <div>
-                                            <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">Amount words casing</label>
-                                            <select className={INPUT_BASE} value={selectedTemplate.amount_format || 'title_case'} onChange={(e) => updateTemplate({ amount_format: e.target.value })}>
-                                                <option value="title_case">Title Case</option>
-                                                <option value="upper">UPPER CASE</option>
-                                            </select>
-                                        </div>
-                                        <div>
-                                            <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">Amount suffix</label>
-                                            <input
-                                                className={INPUT_BASE}
-                                                placeholder="pesos"
-                                                value={selectedTemplate.amount_words_settings?.suffix || 'pesos'}
-                                                onChange={(e) => updateTemplate({
-                                                    amount_words_settings: {
-                                                        ...(selectedTemplate.amount_words_settings || {}),
-                                                        suffix: e.target.value
-                                                    }
-                                                })}
-                                            />
-                                            <p className="text-xs text-gray-500 mt-1">Whole numbers render as “&lt;amount&gt; suffix only”. Decimal amounts render as “&lt;amount&gt; suffix and xx/100”.</p>
-                                        </div>
-                                    </div>
-                                )}
-
-                                {activeTab === 'currency' && (
-                                    <div className="space-y-2">
-                                        <label className="flex items-center gap-2"><input type="checkbox" checked={selectedTemplate.currency_settings?.enabled !== false} onChange={(e) => updateTemplate({ currency_settings: { ...selectedTemplate.currency_settings, enabled: e.target.checked } })} /> Show currency label</label>
-                                        <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide">Symbol outside amount box</label>
-                                        <input className={INPUT_BASE} value={selectedTemplate.currency_settings?.label || ''} onChange={(e) => updateTemplate({ currency_settings: { ...selectedTemplate.currency_settings, label: e.target.value } })} />
-                                    </div>
-                                )}
-
-                                {activeTab === 'paper' && (
-                                    <div className="space-y-3">
-                                        <p className="text-gray-600">Paper size is stored in the selected bank preset.</p>
-                                        <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
-                                            <div>
-                                                <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">Width (inches)</label>
-                                                <input
-                                                    type="number"
-                                                    min="1"
-                                                    step="0.1"
-                                                    className={INPUT_BASE}
-                                                    value={selectedTemplate.paper_settings?.widthIn ?? 8}
-                                                    onChange={(e) => updateTemplate({ paper_settings: { ...(selectedTemplate.paper_settings || {}), widthIn: Number(e.target.value) || 8, unit: 'in' } })}
-                                                />
-                                            </div>
-                                            <div>
-                                                <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">Height (inches)</label>
-                                                <input
-                                                    type="number"
-                                                    min="1"
-                                                    step="0.1"
-                                                    className={INPUT_BASE}
-                                                    value={selectedTemplate.paper_settings?.heightIn ?? 3}
-                                                    onChange={(e) => updateTemplate({ paper_settings: { ...(selectedTemplate.paper_settings || {}), heightIn: Number(e.target.value) || 3, unit: 'in' } })}
-                                                />
-                                            </div>
-                                        </div>
-                                        <p className="text-xs text-gray-500">Recommended standardized size: 8" x 3".</p>
-                                    </div>
-                                )}
-
-                                {activeTab === 'text' && (
-                                    <div className="space-y-3">
-                                        <p className="text-gray-600">Payee overflow mitigation uses template font size and width values; no line wrapping is applied.</p>
-                                        <div className="border rounded-lg p-3 space-y-2 bg-gray-50">
-                                            <label className="flex items-center gap-2">
-                                                <input
-                                                    type="checkbox"
-                                                    checked={Boolean(selectedTemplate.text_settings?.payeeFillerEnabled)}
-                                                    onChange={(e) => updateTemplate({
-                                                        text_settings: {
-                                                            ...(selectedTemplate.text_settings || {}),
-                                                            payeeFillerEnabled: e.target.checked
-                                                        }
-                                                    })}
-                                                />
-                                                Add filler at both ends of payee text
-                                            </label>
-                                            <input
-                                                className={INPUT_BASE}
-                                                placeholder="***"
-                                                value={selectedTemplate.text_settings?.payeeFiller || '***'}
-                                                onChange={(e) => updateTemplate({
-                                                    text_settings: {
-                                                        ...(selectedTemplate.text_settings || {}),
-                                                        payeeFiller: e.target.value
-                                                    }
-                                                })}
-                                            />
-                                        </div>
-                                        <div className="border rounded-lg p-3 space-y-2 bg-gray-50">
-                                            <label className="flex items-center gap-2">
-                                                <input
-                                                    type="checkbox"
-                                                    checked={Boolean(selectedTemplate.text_settings?.amountWordsFillerEnabled)}
-                                                    onChange={(e) => updateTemplate({
-                                                        text_settings: {
-                                                            ...(selectedTemplate.text_settings || {}),
-                                                            amountWordsFillerEnabled: e.target.checked
-                                                        }
-                                                    })}
-                                                />
-                                                Add filler at both ends of amount-in-words
-                                            </label>
-                                            <input
-                                                className={INPUT_BASE}
-                                                placeholder="***"
-                                                value={selectedTemplate.text_settings?.amountWordsFiller || '***'}
-                                                onChange={(e) => updateTemplate({
-                                                    text_settings: {
-                                                        ...(selectedTemplate.text_settings || {}),
-                                                        amountWordsFiller: e.target.value
-                                                    }
-                                                })}
-                                            />
-                                        </div>
-                                    </div>
-                                )}
-
-                                {activeTab === 'calibration' && (
-                                    <div className="space-y-3">
-                                        <div className="border rounded-lg p-3 bg-gray-50 space-y-2">
-                                            <p className="font-medium text-gray-900">Import / Export Configuration</p>
-                                            <p className="text-xs text-gray-600">Export all bank presets and printer profiles to a JSON file for sharing or backup.</p>
-                                            <div className="flex flex-wrap gap-2">
-                                                <button className={BUTTON_SECONDARY} onClick={downloadSettingsExport}>Export Presets & Profiles</button>
-                                                <label className={`${BUTTON_SECONDARY} cursor-pointer`}>
-                                                    Import Presets & Profiles
-                                                    <input type="file" accept="application/json" className="hidden" onChange={importSettingsFile} />
-                                                </label>
-                                            </div>
-                                        </div>
-                                        <p className="text-gray-600">Save profile offsets to match your printer's physical output alignment.</p>
-                                        <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
-                                            <input
-                                                className={INPUT_BASE}
-                                                placeholder="Profile name"
-                                                value={draftProfile.profile_name}
-                                                onChange={(e) => setDraftProfile((prev) => ({ ...prev, profile_name: e.target.value }))}
-                                            />
-                                            <select
-                                                className={INPUT_BASE}
-                                                value={draftProfile.feed_type || 'native'}
-                                                onChange={(e) => setDraftProfile((prev) => ({ ...prev, feed_type: e.target.value }))}
-                                            >
-                                                <option value="native">Native (Custom Paper Size)</option>
-                                                <option value="letter_center">Letter Size (Center Feed)</option>
-                                                <option value="letter_left">Letter Size (Left Feed)</option>
-                                                <option value="letter_right">Letter Size (Right Feed)</option>
-                                            </select>
-                                            <input
-                                                type="number"
-                                                step="0.1"
-                                                className={INPUT_BASE}
-                                                placeholder="Offset X"
-                                                value={draftProfile.offset_x}
-                                                onChange={(e) => setDraftProfile((prev) => ({ ...prev, offset_x: Number(e.target.value) || 0 }))}
-                                            />
-                                            <input
-                                                type="number"
-                                                step="0.1"
-                                                className={INPUT_BASE}
-                                                placeholder="Offset Y"
-                                                value={draftProfile.offset_y}
-                                                onChange={(e) => setDraftProfile((prev) => ({ ...prev, offset_y: Number(e.target.value) || 0 }))}
-                                            />
-                                        </div>
-                                        <p className="text-xs text-gray-500">If your printer rejects custom 8x3 paper sizes, select your manual tray&apos;s feed alignment. The system will print on a Letter canvas to bypass the error.</p>
-                                        <label className="flex items-center gap-2">
-                                            <input
-                                                type="checkbox"
-                                                checked={Boolean(draftProfile.is_default)}
-                                                onChange={(e) => setDraftProfile((prev) => ({ ...prev, is_default: e.target.checked }))}
-                                            />
-                                            Set as default profile
-                                        </label>
-                                        <div className="flex gap-2">
-                                            <button className={BUTTON_PRIMARY} onClick={() => upsertProfile(draftProfile)}><Icon path={ICONS.settings} className="h-4 w-4" />{selectedProfile ? 'Save Profile' : 'Create Profile'}</button>
-                                            {!selectedProfile && (
-                                                <button className={BUTTON_SECONDARY} onClick={() => setDraftProfile({ profile_name: `Profile ${printerProfiles.length + 1}`, feed_type: 'native', offset_x: 0, offset_y: 0, is_default: false })}><Icon path={ICONS.edit} className="h-4 w-4" />Quick Fill</button>
-                                            )}
-                                        </div>
-                                    </div>
-                                )}
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            )}
-
-            {historyOpen && (
-                <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
-                    <div className="bg-white rounded-xl border w-full max-w-6xl max-h-[90vh] overflow-hidden flex flex-col">
-                        <div className="p-4 border-b flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-                            <div>
-                                <h3 className="font-semibold text-gray-900">Cheque History</h3>
-                                <p className="text-xs text-gray-500">Review past cheque records and reprint as needed.</p>
-                            </div>
-                            <button className={BUTTON_SECONDARY} onClick={() => setHistoryOpen(false)}><Icon path={ICONS.close} className="h-4 w-4" />Close</button>
-                        </div>
-
-                        <div className="p-4 border-b bg-gray-50/60 grid grid-cols-1 md:grid-cols-3 gap-3">
+            <Modal isOpen={historyOpen} onClose={() => setHistoryOpen(false)} title="Cheque History" maxWidth="max-w-6xl">
+                <div className="space-y-4">
+                    <p className="text-xs text-gray-500 dark:text-slate-400 -mt-2">Review past cheque records and reprint as needed.</p>
+                    <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+                        <div className="relative">
+                            <Icon path={ICONS.search} className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400 dark:text-slate-500" />
                             <input
-                                className={INPUT_BASE}
+                                className={`${INPUT_BASE} pl-9`}
                                 placeholder="Search payee, memo, amount or bank"
                                 value={historyQuery}
                                 onChange={(e) => setHistoryQuery(e.target.value)}
                             />
-                            <select
-                                className={INPUT_BASE}
-                                value={historyBankFilter}
-                                onChange={(e) => setHistoryBankFilter(e.target.value)}
-                            >
-                                <option value="all">All banks</option>
-                                {historyBankOptions.map((bank) => (
-                                    <option key={bank} value={bank}>{bank}</option>
-                                ))}
-                            </select>
-                            <div className="text-sm text-gray-600 flex items-center md:justify-end">{filteredHistory.length} of {history.length} records</div>
                         </div>
+                        <select
+                            className={INPUT_BASE}
+                            value={historyBankFilter}
+                            onChange={(e) => setHistoryBankFilter(e.target.value)}
+                        >
+                            <option value="all">All banks</option>
+                            {historyBankOptions.map((bank) => (
+                                <option key={bank} value={bank}>{bank}</option>
+                            ))}
+                        </select>
+                        <div className="text-sm text-gray-600 dark:text-slate-400 flex items-center md:justify-end">{filteredHistory.length} of {history.length} records</div>
+                    </div>
 
-                        <div className="max-h-[65vh] overflow-auto">
-                            <table className="w-full text-sm">
-                                <thead className="bg-gray-50 sticky top-0">
-                                    <tr>
-                                        <th className="p-2 text-left">Created</th>
-                                        <th className="p-2 text-left">Payee</th>
-                                        <th className="p-2 text-left">Amount</th>
-                                        <th className="p-2 text-left">Bank</th>
-                                        <th className="p-2 text-left">Date Issued</th>
-                                        <th className="p-2 text-right">Actions</th>
+                    <div className="max-h-[55vh] overflow-auto border border-gray-200 dark:border-slate-700 rounded-lg">
+                        <table className="w-full text-sm">
+                            <thead className="bg-gray-50 dark:bg-slate-900/50 sticky top-0">
+                                <tr className="text-gray-700 dark:text-slate-300">
+                                    <th className="p-2 text-left">Created</th>
+                                    <th className="p-2 text-left">Payee</th>
+                                    <th className="p-2 text-left">Amount</th>
+                                    <th className="p-2 text-left">Bank</th>
+                                    <th className="p-2 text-left">Date Issued</th>
+                                    <th className="p-2 text-right">Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody className="text-gray-700 dark:text-slate-300">
+                                {filteredHistory.map((entry) => (
+                                    <tr key={entry.id} className="border-t border-gray-200 dark:border-slate-700 hover:bg-gray-50 dark:hover:bg-slate-700/40">
+                                        <td className="p-2 whitespace-nowrap">{format(new Date(entry.created_at), 'yyyy-MM-dd HH:mm')}</td>
+                                        <td className="p-2">{entry.payee}</td>
+                                        <td className="p-2">{entry.amount}</td>
+                                        <td className="p-2">{entry.bank_preset || '-'}</td>
+                                        <td className="p-2 whitespace-nowrap">{entry.cheque_date ? format(new Date(entry.cheque_date), 'yyyy-MM-dd') : '-'}</td>
+                                        <td className="p-2 text-right space-x-2 whitespace-nowrap">
+                                            <button className={BUTTON_PRIMARY} onClick={() => handleEditFromHistory(entry)}><Icon path={ICONS.edit} className="h-4 w-4" />Edit</button>
+                                            <button className={BUTTON_SECONDARY} onClick={() => handleReprint(entry)}><Icon path={ICONS.history} className="h-4 w-4" />Reprint</button>
+                                            <button className={BUTTON_DANGER} onClick={() => handleDelete(entry.id)}><Icon path={ICONS.trash} className="h-4 w-4" />Delete</button>
+                                        </td>
                                     </tr>
-                                </thead>
-                                <tbody>
-                                    {filteredHistory.map((entry) => (
-                                        <tr key={entry.id} className="border-t hover:bg-gray-50/70">
-                                            <td className="p-2 whitespace-nowrap">{format(new Date(entry.created_at), 'yyyy-MM-dd HH:mm')}</td>
-                                            <td className="p-2">{entry.payee}</td>
-                                            <td className="p-2">{entry.amount}</td>
-                                            <td className="p-2">{entry.bank_preset || '-'}</td>
-                                            <td className="p-2 whitespace-nowrap">{entry.cheque_date ? format(new Date(entry.cheque_date), 'yyyy-MM-dd') : '-'}</td>
-                                            <td className="p-2 text-right space-x-2 whitespace-nowrap">
-                                                <button className={BUTTON_PRIMARY} onClick={() => handleEditFromHistory(entry)}><Icon path={ICONS.edit} className="h-4 w-4" />Edit</button>
-                                                <button className={BUTTON_SECONDARY} onClick={() => handleReprint(entry)}><Icon path={ICONS.history} className="h-4 w-4" />Reprint</button>
-                                                <button className={BUTTON_DANGER} onClick={() => handleDelete(entry.id)}><Icon path={ICONS.trash} className="h-4 w-4" />Delete</button>
-                                            </td>
-                                        </tr>
-                                    ))}
-                                </tbody>
-                            </table>
-                            {!filteredHistory.length && (
-                                <div className="py-10 text-center text-sm text-gray-500">No cheque history matches the current filters.</div>
-                            )}
-                        </div>
+                                ))}
+                            </tbody>
+                        </table>
+                        {!filteredHistory.length && (
+                            <div className="py-10 text-center text-sm text-gray-500 dark:text-slate-400">No cheque history matches the current filters.</div>
+                        )}
                     </div>
                 </div>
-            )}
+            </Modal>
 
-            {pendingHistoryEntry && (
-                <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-[60] p-4">
-                    <div className="bg-white rounded-xl border w-full max-w-lg overflow-hidden">
-                        <div className="p-4 border-b">
-                            <h3 className="font-semibold text-gray-900">Load cheque from history</h3>
-                            <p className="text-sm text-gray-600 mt-1">You already have entries in the editor. Would you like to overwrite them or append this history entry?</p>
-                        </div>
-                        <div className="p-4 flex flex-wrap gap-2 justify-end">
-                            <button className={BUTTON_SECONDARY} onClick={() => setPendingHistoryEntry(null)}>Cancel</button>
-                            <button className={BUTTON_SECONDARY} onClick={() => applyHistoryEntryToEditor(pendingHistoryEntry, 'append')}>Append</button>
-                            <button className={BUTTON_PRIMARY} onClick={() => applyHistoryEntryToEditor(pendingHistoryEntry, 'overwrite')}>Overwrite</button>
-                        </div>
+            <Modal isOpen={Boolean(pendingHistoryEntry)} onClose={() => setPendingHistoryEntry(null)} title="Load cheque from history">
+                <div className="space-y-4">
+                    <p className="text-sm text-gray-600 dark:text-slate-400">You already have entries in the editor. Would you like to overwrite them or append this history entry?</p>
+                    <div className="flex flex-wrap gap-2 justify-end">
+                        <button className={BUTTON_SECONDARY} onClick={() => setPendingHistoryEntry(null)}>Cancel</button>
+                        <button className={BUTTON_SECONDARY} onClick={() => applyHistoryEntryToEditor(pendingHistoryEntry, 'append')}>Append</button>
+                        <button className={BUTTON_PRIMARY} onClick={() => applyHistoryEntryToEditor(pendingHistoryEntry, 'overwrite')}>Overwrite</button>
                     </div>
                 </div>
-            )}
+            </Modal>
         </div>
     );
 };

--- a/packages/web/src/pages/ChequePrintingPage.jsx
+++ b/packages/web/src/pages/ChequePrintingPage.jsx
@@ -4,42 +4,16 @@ import toast from 'react-hot-toast';
 import api from '../api';
 // eslint-disable-next-line no-unused-vars
 import Icon from '../components/ui/Icon';
+import Modal from '../components/ui/Modal';
 import { ICONS } from '../constants';
 
 const blankRow = () => ({ date: format(new Date(), 'yyyy-MM-dd'), payee: '', amount: '', memo: '' });
-const DEFAULT_TEMPLATE = {
-    date: { x: 426, y: 178, alignment: 'left', fontSize: 11, mode: 'boxed', charSpacing: 14 },
-    payee: { x: 72, y: 136, alignment: 'left', fontSize: 12, maxWidth: 380, minFontSize: 8 },
-    amountNumeric: { x: 534, y: 136, alignment: 'right', fontSize: 12 },
-    amountWords: { x: 72, y: 104, alignment: 'left', fontSize: 11, maxWidth: 420 },
-    memo: { x: 72, y: 84, alignment: 'left', fontSize: 10, maxWidth: 220 },
-    currency: { x: 474, y: 136, alignment: 'left', fontSize: 11 }
-};
-
-const SETTINGS_TABS = [
-    { id: 'layout', label: 'Layout' },
-    { id: 'date', label: 'Date' },
-    { id: 'amount', label: 'Amount' },
-    { id: 'currency', label: 'Currency' },
-    { id: 'paper', label: 'Paper' },
-    { id: 'text', label: 'Text' },
-    { id: 'calibration', label: 'Calibration' }
-];
-
-const FIELD_LABELS = {
-    date: 'Date',
-    payee: 'Payee',
-    amountNumeric: 'Amount in figures',
-    amountWords: 'Amount in words',
-    memo: 'Memo',
-    currency: 'Currency symbol'
-};
 
 const BUTTON_BASE = 'inline-flex items-center justify-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50';
-const BUTTON_SECONDARY = `${BUTTON_BASE} border border-gray-300 bg-white text-gray-700 hover:bg-gray-50`;
-const BUTTON_PRIMARY = `${BUTTON_BASE} bg-blue-600 text-white hover:bg-blue-700`;
-const BUTTON_DANGER = `${BUTTON_BASE} border border-red-200 bg-white text-red-600 hover:bg-red-50`;
-const INPUT_BASE = 'w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100';
+const BUTTON_SECONDARY = `${BUTTON_BASE} border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-700 dark:text-slate-200 hover:bg-gray-50 dark:hover:bg-slate-700`;
+const BUTTON_PRIMARY = `${BUTTON_BASE} bg-primary-600 text-white hover:bg-primary-700`;
+const BUTTON_DANGER = `${BUTTON_BASE} border border-danger-200 dark:border-danger-900/50 bg-white dark:bg-slate-800 text-danger-600 dark:text-danger-400 hover:bg-danger-50 dark:hover:bg-danger-900/20`;
+const INPUT_BASE = 'w-full rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-100 px-3 py-2 text-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-100 dark:focus:ring-primary-900/30';
 
 const ChequePrintingPage = () => {
     const [templates, setTemplates] = useState([]);
@@ -49,18 +23,14 @@ const ChequePrintingPage = () => {
     const [rows, setRows] = useState([blankRow()]);
     const [history, setHistory] = useState([]);
     const [historyOpen, setHistoryOpen] = useState(false);
-    const [settingsOpen, setSettingsOpen] = useState(false);
-    const [activeTab, setActiveTab] = useState('layout');
     const [saving, setSaving] = useState(false);
     const [persistRecords, setPersistRecords] = useState(true);
     const [testPrintMode, setTestPrintMode] = useState(false);
     const [historyQuery, setHistoryQuery] = useState('');
     const [historyBankFilter, setHistoryBankFilter] = useState('all');
     const [pendingHistoryEntry, setPendingHistoryEntry] = useState(null);
-    const [draftProfile, setDraftProfile] = useState({ profile_name: '', feed_type: 'native', offset_x: 0, offset_y: 0, is_default: false });
 
     const selectedTemplate = useMemo(() => templates.find((tpl) => String(tpl.id) === String(selectedTemplateId)), [templates, selectedTemplateId]);
-    const selectedProfile = useMemo(() => printerProfiles.find((profile) => String(profile.id) === String(selectedProfileId)), [printerProfiles, selectedProfileId]);
 
     const loadData = async () => {
         try {
@@ -81,19 +51,6 @@ const ChequePrintingPage = () => {
     };
 
     useEffect(() => { loadData(); }, []);
-    useEffect(() => {
-        if (!selectedProfile) {
-            setDraftProfile({ profile_name: '', feed_type: 'native', offset_x: 0, offset_y: 0, is_default: false });
-            return;
-        }
-        setDraftProfile({
-            profile_name: selectedProfile.profile_name || '',
-            feed_type: selectedProfile.feed_type || 'native',
-            offset_x: Number(selectedProfile.offset_x || 0),
-            offset_y: Number(selectedProfile.offset_y || 0),
-            is_default: Boolean(selectedProfile.is_default)
-        });
-    }, [selectedProfileId]);
 
     const updateRow = (idx, field, value) => {
         setRows((prev) => {
@@ -261,110 +218,6 @@ const ChequePrintingPage = () => {
         applyHistoryEntryToEditor(entry, 'overwrite');
     };
 
-    const updateTemplate = async (patch) => {
-        if (!selectedTemplate) return;
-        try {
-            const response = await api.put(`/cheques/templates/${selectedTemplate.id}`, {
-                ...selectedTemplate,
-                ...patch
-            });
-            setTemplates((prev) => prev.map((template) => (template.id === response.data.id ? response.data : template)));
-        } catch (error) {
-            toast.error(error?.response?.data?.message || 'Template update failed.');
-        }
-    };
-
-    const upsertProfile = async (patch) => {
-        try {
-            if (!selectedProfile) {
-                const created = await api.post('/cheques/printer-profiles', {
-                    profile_name: patch.profile_name || `Profile ${printerProfiles.length + 1}`,
-                    feed_type: patch.feed_type || 'native',
-                    offset_x: patch.offset_x || 0,
-                    offset_y: patch.offset_y || 0,
-                    is_default: patch.is_default || false
-                });
-                setPrinterProfiles((prev) => [...prev, created.data]);
-                setSelectedProfileId(String(created.data.id));
-                return;
-            }
-
-            const response = await api.put(`/cheques/printer-profiles/${selectedProfile.id}`, {
-                ...selectedProfile,
-                ...patch
-            });
-
-            setPrinterProfiles((prev) => prev.map((profile) => (profile.id === response.data.id ? response.data : profile)));
-        } catch (error) {
-            toast.error(error?.response?.data?.message || 'Printer profile update failed.');
-        }
-    };
-
-    const createTemplateFromCurrent = async () => {
-        const baseName = selectedTemplate?.bank_name || 'New Bank Preset';
-        const bankName = window.prompt('Enter name for bank preset:', selectedTemplate ? `${baseName} Copy` : baseName);
-        if (!bankName?.trim()) return;
-        try {
-            const res = await api.post('/cheques/templates', {
-                ...(selectedTemplate || {}),
-                bank_name: bankName.trim()
-                ,
-                field_positions: selectedTemplate?.field_positions || DEFAULT_TEMPLATE
-            });
-            setTemplates((prev) => [...prev, res.data].sort((a, b) => a.bank_name.localeCompare(b.bank_name)));
-            setSelectedTemplateId(String(res.data.id));
-            toast.success(selectedTemplate ? 'Bank preset duplicated.' : 'Bank preset created.');
-        } catch (error) {
-            toast.error(error?.response?.data?.message || 'Failed to save bank preset.');
-        }
-    };
-
-    const deleteCurrentTemplate = async () => {
-        if (!selectedTemplate) return;
-        if (!window.confirm(`Delete bank preset "${selectedTemplate.bank_name}"?`)) return;
-        try {
-            await api.delete(`/cheques/templates/${selectedTemplate.id}`);
-            toast.success('Bank preset deleted.');
-            await loadData();
-            setSelectedTemplateId('');
-        } catch (error) {
-            toast.error(error?.response?.data?.message || 'Failed to delete bank preset.');
-        }
-    };
-
-    const duplicateCurrentProfile = async () => {
-        if (!selectedProfile) return;
-        const profileName = window.prompt('Enter name for duplicated printer profile:', `${selectedProfile.profile_name} Copy`);
-        if (!profileName?.trim()) return;
-        try {
-            const created = await api.post('/cheques/printer-profiles', {
-                profile_name: profileName.trim(),
-                feed_type: selectedProfile.feed_type || 'native',
-                offset_x: Number(selectedProfile.offset_x || 0),
-                offset_y: Number(selectedProfile.offset_y || 0),
-                is_default: false
-            });
-            setPrinterProfiles((prev) => [...prev, created.data]);
-            setSelectedProfileId(String(created.data.id));
-            toast.success('Printer profile duplicated.');
-        } catch (error) {
-            toast.error(error?.response?.data?.message || 'Failed to duplicate printer profile.');
-        }
-    };
-
-    const deleteCurrentProfile = async () => {
-        if (!selectedProfile) return;
-        if (!window.confirm(`Delete printer profile "${selectedProfile.profile_name}"?`)) return;
-        try {
-            await api.delete(`/cheques/printer-profiles/${selectedProfile.id}`);
-            toast.success('Printer profile deleted.');
-            await loadData();
-            setSelectedProfileId('');
-        } catch (error) {
-            toast.error(error?.response?.data?.message || 'Failed to delete printer profile.');
-        }
-    };
-
     const onRowKeyDown = (event, rowIndex, fieldIndex) => {
         if (event.key !== 'Enter') return;
         event.preventDefault();
@@ -373,52 +226,15 @@ const ChequePrintingPage = () => {
         if (next) next.focus();
     };
 
-    const downloadSettingsExport = async () => {
-        try {
-            const response = await api.get('/cheques/settings-export', { responseType: 'blob' });
-            const blobUrl = window.URL.createObjectURL(new Blob([response.data], { type: 'application/json' }));
-            const link = document.createElement('a');
-            link.href = blobUrl;
-            link.setAttribute('download', `cheque-settings-${format(new Date(), 'yyyy-MM-dd')}.json`);
-            document.body.appendChild(link);
-            link.click();
-            link.remove();
-            window.URL.revokeObjectURL(blobUrl);
-            toast.success('Cheque settings exported.');
-        } catch (error) {
-            toast.error(error?.response?.data?.message || 'Failed to export cheque settings.');
-        }
-    };
-
-    const importSettingsFile = async (event) => {
-        const file = event.target.files?.[0];
-        if (!file) return;
-        try {
-            const payload = JSON.parse(await file.text());
-            const overwrite = window.confirm('Overwrite existing presets/profiles with matching names? Click Cancel to append only.');
-            await api.post('/cheques/settings-import', { ...payload, overwrite });
-            toast.success('Cheque settings imported.');
-            await loadData();
-        } catch (error) {
-            toast.error(error?.response?.data?.message || 'Failed to import cheque settings file.');
-        } finally {
-            event.target.value = '';
-        }
-    };
-
     return (
         <div className="space-y-4 pb-4">
-            <div className="bg-white border rounded-xl p-4 md:p-5">
+            <div className="bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-xl p-4 md:p-5">
                 <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
                     <div>
-                        <h1 className="text-lg md:text-xl font-semibold text-gray-900">Cheque Printing</h1>
-                        <p className="text-sm text-gray-500 mt-1">Prepare cheques, manage print calibration, and review printed cheque history in one place.</p>
+                        <h2 className="text-lg md:text-xl font-semibold text-gray-900 dark:text-slate-100">Print Cheques</h2>
+                        <p className="text-sm text-gray-500 dark:text-slate-400 mt-1">Prepare cheques for printing and review printed cheque history. Bank presets and printer profiles are managed under the Templates &amp; Settings tab.</p>
                     </div>
                     <div className="flex flex-wrap gap-2">
-                        <button className={BUTTON_SECONDARY} onClick={() => setSettingsOpen(true)}>
-                            <Icon path={ICONS.settings} className="h-4 w-4" />
-                            Open Settings
-                        </button>
                         <button className={BUTTON_SECONDARY} onClick={() => setHistoryOpen(true)}>
                             <Icon path={ICONS.history} className="h-4 w-4" />
                             View History
@@ -432,9 +248,9 @@ const ChequePrintingPage = () => {
             </div>
 
             <div className="grid grid-cols-1 xl:grid-cols-3 gap-4">
-                <div className="xl:col-span-2 bg-white border rounded-xl p-4 space-y-4">
-                    <h2 className="text-sm font-semibold text-gray-700 uppercase tracking-wide">Print Queue</h2>
-                    <div className="hidden md:grid grid-cols-[120px_1fr_160px_1fr_80px] gap-3 px-2 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                <div className="xl:col-span-2 bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-xl p-4 space-y-4">
+                    <h2 className="text-sm font-semibold text-gray-700 dark:text-slate-300 uppercase tracking-wide">Print Queue</h2>
+                    <div className="hidden md:grid grid-cols-[120px_1fr_160px_1fr_80px] gap-3 px-2 text-xs font-semibold text-gray-500 dark:text-slate-400 uppercase tracking-wide">
                         <span>Date</span>
                         <span>Payee</span>
                         <span>Amount</span>
@@ -445,7 +261,7 @@ const ChequePrintingPage = () => {
                     {rows.map((row, idx) => {
                         const isTrailingBlank = idx === rows.length - 1 && !row.payee && !row.amount && !row.memo;
                         return (
-                            <div key={idx} className="bg-gray-50/70 border rounded-xl p-3 grid grid-cols-1 md:grid-cols-[120px_1fr_160px_1fr_80px] gap-3 items-start">
+                            <div key={idx} className="bg-gray-50/70 dark:bg-slate-900/40 border border-gray-200 dark:border-slate-700 rounded-xl p-3 grid grid-cols-1 md:grid-cols-[120px_1fr_160px_1fr_80px] gap-3 items-start">
                                 {[
                                     { field: 'date', placeholder: 'Date' },
                                     { field: 'payee', placeholder: 'Payee' },
@@ -453,7 +269,7 @@ const ChequePrintingPage = () => {
                                     { field: 'memo', placeholder: 'Memo' }
                                 ].map((column, fieldIndex) => (
                                     <div key={column.field} className="space-y-1">
-                                        <label className="md:hidden text-xs font-semibold text-gray-500 uppercase tracking-wide">{column.placeholder}</label>
+                                        <label className="md:hidden text-xs font-semibold text-gray-500 dark:text-slate-400 uppercase tracking-wide">{column.placeholder}</label>
                                         <input
                                             type={column.field === 'date' ? 'date' : 'text'}
                                             className={INPUT_BASE}
@@ -481,495 +297,121 @@ const ChequePrintingPage = () => {
                     })}
                 </div>
 
-                <div className="bg-white border rounded-xl p-4 space-y-4">
-                    <h2 className="text-sm font-semibold text-gray-700 uppercase tracking-wide">Print Controls</h2>
+                <div className="bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-xl p-4 space-y-4">
+                    <h2 className="text-sm font-semibold text-gray-700 dark:text-slate-300 uppercase tracking-wide">Print Controls</h2>
                     <div className="space-y-3">
                         <div>
-                            <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">Bank preset</label>
+                            <label className="block text-xs font-semibold text-gray-500 dark:text-slate-400 uppercase tracking-wide mb-1">Bank preset</label>
                             <select className={INPUT_BASE} value={selectedTemplateId} onChange={(e) => setSelectedTemplateId(e.target.value)}>
                                 {!templates.length && <option value="">No bank preset yet</option>}
                                 {templates.map((template) => <option key={template.id} value={template.id}>{template.bank_name}</option>)}
                             </select>
-                            <div className="flex gap-2 mt-2">
-                                <button className={BUTTON_SECONDARY} onClick={createTemplateFromCurrent}>{selectedTemplate ? 'Duplicate Preset' : 'Create Preset'}</button>
-                                <button className={BUTTON_DANGER} onClick={deleteCurrentTemplate} disabled={!selectedTemplate || templates.length <= 1}>Delete Preset</button>
-                            </div>
                         </div>
                         <div>
-                            <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">Printer profile</label>
+                            <label className="block text-xs font-semibold text-gray-500 dark:text-slate-400 uppercase tracking-wide mb-1">Printer profile</label>
                             <select className={INPUT_BASE} value={selectedProfileId} onChange={(e) => setSelectedProfileId(e.target.value)}>
                                 <option value="">{printerProfiles.length ? 'None' : 'No printer profile yet'}</option>
                                 {printerProfiles.map((profile) => <option key={profile.id} value={profile.id}>{profile.profile_name}{profile.is_default ? ' (Default)' : ''}</option>)}
                             </select>
-                            <div className="flex gap-2 mt-2">
-                                <button className={BUTTON_SECONDARY} onClick={duplicateCurrentProfile} disabled={!selectedProfile}>Duplicate Profile</button>
-                                <button className={BUTTON_DANGER} onClick={deleteCurrentProfile} disabled={!selectedProfile}>Delete Profile</button>
-                            </div>
                         </div>
                     </div>
 
-                    <div className="space-y-2 border-t pt-3">
+                    <div className="space-y-2 border-t border-gray-200 dark:border-slate-700 pt-3">
                         {!templates.length && (
-                            <div className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded-lg p-2">
-                                No bank preset found. Create one in Settings or import presets before generating cheques.
+                            <div className="text-xs text-warning-700 dark:text-warning-400 bg-warning-50 dark:bg-warning-900/20 border border-warning-200 dark:border-warning-900/40 rounded-lg p-2">
+                                No bank preset found. Create one in the Templates &amp; Settings tab before generating cheques.
                             </div>
                         )}
                         {!printerProfiles.length && (
-                            <div className="text-xs text-blue-700 bg-blue-50 border border-blue-200 rounded-lg p-2">
+                            <div className="text-xs text-primary-700 dark:text-primary-400 bg-primary-50 dark:bg-primary-900/20 border border-primary-200 dark:border-primary-900/40 rounded-lg p-2">
                                 No printer profile found. You can still generate a PDF, but creating a profile is recommended for proper alignment.
                             </div>
                         )}
-                        <label className="flex items-center gap-2 text-sm">
+                        <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-slate-300">
                             <input type="checkbox" checked={persistRecords} onChange={(e) => setPersistRecords(e.target.checked)} />
                             Save generated cheques to history
                         </label>
-                        <label className="flex items-center gap-2 text-sm">
+                        <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-slate-300">
                             <input type="checkbox" checked={testPrintMode} onChange={(e) => setTestPrintMode(e.target.checked)} />
                             Test print mode
                         </label>
                     </div>
 
-                    <div className="text-xs text-gray-500 bg-blue-50 border border-blue-100 rounded-lg p-3">
+                    <div className="text-xs text-gray-500 dark:text-slate-400 bg-primary-50 dark:bg-primary-900/20 border border-primary-100 dark:border-primary-900/40 rounded-lg p-3">
                         Tip: Use <span className="font-semibold">100% print scale</span> for proper cheque alignment.
                     </div>
                 </div>
             </div>
 
-            {settingsOpen && (
-                <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
-                    <div className="bg-white rounded-xl border w-full max-w-6xl max-h-[90vh] overflow-hidden flex flex-col">
-                        <div className="p-4 border-b flex items-center justify-between">
-                            <div>
-                                <h3 className="font-semibold text-gray-900">Cheque Settings</h3>
-                                <p className="text-xs text-gray-500 mt-0.5">Preset: {selectedTemplate?.bank_name || 'None selected'}</p>
-                            </div>
-                            <button className={BUTTON_SECONDARY} onClick={() => setSettingsOpen(false)}><Icon path={ICONS.close} className="h-4 w-4" />Close</button>
-                        </div>
-
-                        <div className="min-h-0 flex-1 flex flex-col">
-                            <div className="border-b px-4 md:px-5 overflow-x-auto">
-                                <div className="flex items-center gap-5 min-w-max">
-                                    {SETTINGS_TABS.map((tab) => (
-                                        <button
-                                            key={tab.id}
-                                            type="button"
-                                            className={`py-3 px-1 border-b-2 font-medium text-sm ${activeTab === tab.id ? 'border-blue-600 text-blue-600' : 'border-transparent text-gray-500 hover:border-gray-300'}`}
-                                            onClick={() => setActiveTab(tab.id)}
-                                        >
-                                            {tab.label}
-                                        </button>
-                                    ))}
-                                </div>
-                            </div>
-
-                            <div className="p-4 md:p-5 overflow-auto text-sm space-y-4">
-                                {activeTab === 'layout' && selectedTemplate && (
-                                    <div className="space-y-3">
-                                        <div className="flex flex-wrap items-center justify-between gap-2 border rounded-lg bg-gray-50 p-3">
-                                            <div>
-                                                <p className="font-medium text-gray-900">Bank preset details</p>
-                                                <p className="text-xs text-gray-500">Save and share this bank preset including cheque layout variables.</p>
-                                            </div>
-                                            <button className={BUTTON_PRIMARY} onClick={() => updateTemplate({ ...selectedTemplate })}>
-                                                <Icon path={ICONS.settings} className="h-4 w-4" />
-                                                Save Bank Preset
-                                            </button>
-                                        </div>
-                                        <div>
-                                            <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">Bank preset name</label>
-                                            <input className={INPUT_BASE} value={selectedTemplate.bank_name || ''} onChange={(e) => updateTemplate({ bank_name: e.target.value })} />
-                                        </div>
-                                        <p className="text-gray-600">Fine-tune field placements and sizes for this cheque template.</p>
-                                        <div className="grid grid-cols-4 lg:grid-cols-6 gap-2 text-xs font-semibold text-gray-500 uppercase tracking-wide">
-                                            <span>Field</span>
-                                            <span>X Position</span>
-                                            <span>Y Position</span>
-                                            <span>Font Size</span>
-                                            <span className="hidden lg:block">Max Width</span>
-                                            <span className="hidden lg:block">Min Font</span>
-                                        </div>
-                                        {Object.entries(selectedTemplate.field_positions || {}).map(([field, cfg]) => {
-                                            const showExtras = ['payee', 'amountWords', 'memo'].includes(field);
-                                            return (
-                                                <div key={field} className="grid grid-cols-4 lg:grid-cols-6 gap-2 items-center border rounded-lg p-2">
-                                                    <span className="font-medium truncate" title={FIELD_LABELS[field] || field}>{FIELD_LABELS[field] || field}</span>
-                                                    <input type="number" className={INPUT_BASE} aria-label={`${field} X`} value={cfg.x ?? 0} onChange={(e) => updateTemplate({ field_positions: { ...selectedTemplate.field_positions, [field]: { ...cfg, x: Number(e.target.value) } } })} />
-                                                    <input type="number" className={INPUT_BASE} aria-label={`${field} Y`} value={cfg.y ?? 0} onChange={(e) => updateTemplate({ field_positions: { ...selectedTemplate.field_positions, [field]: { ...cfg, y: Number(e.target.value) } } })} />
-                                                    <input type="number" className={INPUT_BASE} aria-label={`${field} Font`} value={cfg.fontSize ?? 11} onChange={(e) => updateTemplate({ field_positions: { ...selectedTemplate.field_positions, [field]: { ...cfg, fontSize: Number(e.target.value) } } })} />
-                                                    {showExtras ? (
-                                                        <>
-                                                            <input type="number" className={`${INPUT_BASE} col-span-2 lg:col-span-1`} aria-label={`${field} Max Width`} placeholder="Max Width" value={cfg.maxWidth ?? ''} onChange={(e) => updateTemplate({ field_positions: { ...selectedTemplate.field_positions, [field]: { ...cfg, maxWidth: e.target.value ? Number(e.target.value) : null } } })} />
-                                                            <input type="number" className={`${INPUT_BASE} col-span-2 lg:col-span-1`} aria-label={`${field} Min Font`} placeholder="Min Font" value={cfg.minFontSize ?? ''} onChange={(e) => updateTemplate({ field_positions: { ...selectedTemplate.field_positions, [field]: { ...cfg, minFontSize: e.target.value ? Number(e.target.value) : null } } })} />
-                                                        </>
-                                                    ) : (
-                                                        <div className="hidden lg:block lg:col-span-2"></div>
-                                                    )}
-                                                </div>
-                                            );
-                                        })}
-                                    </div>
-                                )}
-                                {activeTab === 'layout' && !selectedTemplate && (
-                                    <div className="space-y-3">
-                                        <p className="text-gray-600">No bank preset exists yet. Create one or import settings to begin configuring cheque layout.</p>
-                                        <div className="flex gap-2">
-                                            <button className={BUTTON_PRIMARY} onClick={createTemplateFromCurrent}>Create Bank Preset</button>
-                                            <label className={`${BUTTON_SECONDARY} cursor-pointer`}>
-                                                Import Presets & Profiles
-                                                <input type="file" accept="application/json" className="hidden" onChange={importSettingsFile} />
-                                            </label>
-                                        </div>
-                                    </div>
-                                )}
-
-                                {activeTab === 'date' && (
-                                    <div className="space-y-3">
-                                        <div>
-                                            <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">Date output format</label>
-                                            <select className={INPUT_BASE} value={selectedTemplate.date_format || 'MM-dd-yyyy'} onChange={(e) => updateTemplate({ date_format: e.target.value })}>
-                                                <option value="MM-dd-yyyy">MM-DD-YYYY</option>
-                                                <option value="MM/dd/yyyy">MM/dd/yyyy</option>
-                                                <option value="dd/MM/yyyy">dd/MM/yyyy</option>
-                                                <option value="MMM dd, yyyy">MMM dd, yyyy</option>
-                                            </select>
-                                        </div>
-                                        <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
-                                            <div>
-                                                <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">Date Mode</label>
-                                                <select
-                                                    className={INPUT_BASE}
-                                                    value={selectedTemplate.field_positions?.date?.mode || 'single'}
-                                                    onChange={(e) => updateTemplate({
-                                                        field_positions: {
-                                                            ...selectedTemplate.field_positions,
-                                                            date: { ...(selectedTemplate.field_positions?.date || {}), mode: e.target.value }
-                                                        }
-                                                    })}
-                                                >
-                                                    <option value="single">Single-line date mode</option>
-                                                    <option value="boxed">Boxed date mode (MMDDYYYY without separators)</option>
-                                                </select>
-                                            </div>
-                                            <div className="flex gap-2">
-                                                <div className="flex-1">
-                                                    <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">Char Spacing</label>
-                                                    <input
-                                                        type="number"
-                                                        step="0.5"
-                                                        className={INPUT_BASE}
-                                                        placeholder="Character spacing"
-                                                        title="Character spacing"
-                                                        value={selectedTemplate.field_positions?.date?.charSpacing ?? 0}
-                                                        onChange={(e) => updateTemplate({
-                                                            field_positions: {
-                                                                ...selectedTemplate.field_positions,
-                                                                date: { ...(selectedTemplate.field_positions?.date || {}), charSpacing: Number(e.target.value) || 0 }
-                                                            }
-                                                        })}
-                                                    />
-                                                </div>
-                                                {selectedTemplate.field_positions?.date?.mode === 'boxed' && (
-                                                    <div className="flex-1">
-                                                        <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">Block Spacing</label>
-                                                        <input
-                                                            type="number"
-                                                            step="0.5"
-                                                            className={INPUT_BASE}
-                                                            placeholder="Block Spacing (pt)"
-                                                            title="Block Spacing (pt)"
-                                                            value={selectedTemplate.field_positions?.date?.blockSpacing ?? selectedTemplate.field_positions?.date?.charSpacing ?? 0}
-                                                            onChange={(e) => updateTemplate({
-                                                                field_positions: {
-                                                                    ...selectedTemplate.field_positions,
-                                                                    date: { ...(selectedTemplate.field_positions?.date || {}), blockSpacing: Number(e.target.value) || 0 }
-                                                                }
-                                                            })}
-                                                        />
-                                                    </div>
-                                                )}
-                                            </div>
-                                        </div>
-                                    </div>
-                                )}
-
-                                {activeTab === 'amount' && (
-                                    <div className="space-y-3">
-                                        <div>
-                                            <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">Amount words casing</label>
-                                            <select className={INPUT_BASE} value={selectedTemplate.amount_format || 'title_case'} onChange={(e) => updateTemplate({ amount_format: e.target.value })}>
-                                                <option value="title_case">Title Case</option>
-                                                <option value="upper">UPPER CASE</option>
-                                            </select>
-                                        </div>
-                                        <div>
-                                            <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">Amount suffix</label>
-                                            <input
-                                                className={INPUT_BASE}
-                                                placeholder="pesos"
-                                                value={selectedTemplate.amount_words_settings?.suffix || 'pesos'}
-                                                onChange={(e) => updateTemplate({
-                                                    amount_words_settings: {
-                                                        ...(selectedTemplate.amount_words_settings || {}),
-                                                        suffix: e.target.value
-                                                    }
-                                                })}
-                                            />
-                                            <p className="text-xs text-gray-500 mt-1">Whole numbers render as “&lt;amount&gt; suffix only”. Decimal amounts render as “&lt;amount&gt; suffix and xx/100”.</p>
-                                        </div>
-                                    </div>
-                                )}
-
-                                {activeTab === 'currency' && (
-                                    <div className="space-y-2">
-                                        <label className="flex items-center gap-2"><input type="checkbox" checked={selectedTemplate.currency_settings?.enabled !== false} onChange={(e) => updateTemplate({ currency_settings: { ...selectedTemplate.currency_settings, enabled: e.target.checked } })} /> Show currency label</label>
-                                        <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide">Symbol outside amount box</label>
-                                        <input className={INPUT_BASE} value={selectedTemplate.currency_settings?.label || ''} onChange={(e) => updateTemplate({ currency_settings: { ...selectedTemplate.currency_settings, label: e.target.value } })} />
-                                    </div>
-                                )}
-
-                                {activeTab === 'paper' && (
-                                    <div className="space-y-3">
-                                        <p className="text-gray-600">Paper size is stored in the selected bank preset.</p>
-                                        <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
-                                            <div>
-                                                <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">Width (inches)</label>
-                                                <input
-                                                    type="number"
-                                                    min="1"
-                                                    step="0.1"
-                                                    className={INPUT_BASE}
-                                                    value={selectedTemplate.paper_settings?.widthIn ?? 8}
-                                                    onChange={(e) => updateTemplate({ paper_settings: { ...(selectedTemplate.paper_settings || {}), widthIn: Number(e.target.value) || 8, unit: 'in' } })}
-                                                />
-                                            </div>
-                                            <div>
-                                                <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1">Height (inches)</label>
-                                                <input
-                                                    type="number"
-                                                    min="1"
-                                                    step="0.1"
-                                                    className={INPUT_BASE}
-                                                    value={selectedTemplate.paper_settings?.heightIn ?? 3}
-                                                    onChange={(e) => updateTemplate({ paper_settings: { ...(selectedTemplate.paper_settings || {}), heightIn: Number(e.target.value) || 3, unit: 'in' } })}
-                                                />
-                                            </div>
-                                        </div>
-                                        <p className="text-xs text-gray-500">Recommended standardized size: 8" x 3".</p>
-                                    </div>
-                                )}
-
-                                {activeTab === 'text' && (
-                                    <div className="space-y-3">
-                                        <p className="text-gray-600">Payee overflow mitigation uses template font size and width values; no line wrapping is applied.</p>
-                                        <div className="border rounded-lg p-3 space-y-2 bg-gray-50">
-                                            <label className="flex items-center gap-2">
-                                                <input
-                                                    type="checkbox"
-                                                    checked={Boolean(selectedTemplate.text_settings?.payeeFillerEnabled)}
-                                                    onChange={(e) => updateTemplate({
-                                                        text_settings: {
-                                                            ...(selectedTemplate.text_settings || {}),
-                                                            payeeFillerEnabled: e.target.checked
-                                                        }
-                                                    })}
-                                                />
-                                                Add filler at both ends of payee text
-                                            </label>
-                                            <input
-                                                className={INPUT_BASE}
-                                                placeholder="***"
-                                                value={selectedTemplate.text_settings?.payeeFiller || '***'}
-                                                onChange={(e) => updateTemplate({
-                                                    text_settings: {
-                                                        ...(selectedTemplate.text_settings || {}),
-                                                        payeeFiller: e.target.value
-                                                    }
-                                                })}
-                                            />
-                                        </div>
-                                        <div className="border rounded-lg p-3 space-y-2 bg-gray-50">
-                                            <label className="flex items-center gap-2">
-                                                <input
-                                                    type="checkbox"
-                                                    checked={Boolean(selectedTemplate.text_settings?.amountWordsFillerEnabled)}
-                                                    onChange={(e) => updateTemplate({
-                                                        text_settings: {
-                                                            ...(selectedTemplate.text_settings || {}),
-                                                            amountWordsFillerEnabled: e.target.checked
-                                                        }
-                                                    })}
-                                                />
-                                                Add filler at both ends of amount-in-words
-                                            </label>
-                                            <input
-                                                className={INPUT_BASE}
-                                                placeholder="***"
-                                                value={selectedTemplate.text_settings?.amountWordsFiller || '***'}
-                                                onChange={(e) => updateTemplate({
-                                                    text_settings: {
-                                                        ...(selectedTemplate.text_settings || {}),
-                                                        amountWordsFiller: e.target.value
-                                                    }
-                                                })}
-                                            />
-                                        </div>
-                                    </div>
-                                )}
-
-                                {activeTab === 'calibration' && (
-                                    <div className="space-y-3">
-                                        <div className="border rounded-lg p-3 bg-gray-50 space-y-2">
-                                            <p className="font-medium text-gray-900">Import / Export Configuration</p>
-                                            <p className="text-xs text-gray-600">Export all bank presets and printer profiles to a JSON file for sharing or backup.</p>
-                                            <div className="flex flex-wrap gap-2">
-                                                <button className={BUTTON_SECONDARY} onClick={downloadSettingsExport}>Export Presets & Profiles</button>
-                                                <label className={`${BUTTON_SECONDARY} cursor-pointer`}>
-                                                    Import Presets & Profiles
-                                                    <input type="file" accept="application/json" className="hidden" onChange={importSettingsFile} />
-                                                </label>
-                                            </div>
-                                        </div>
-                                        <p className="text-gray-600">Save profile offsets to match your printer's physical output alignment.</p>
-                                        <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
-                                            <input
-                                                className={INPUT_BASE}
-                                                placeholder="Profile name"
-                                                value={draftProfile.profile_name}
-                                                onChange={(e) => setDraftProfile((prev) => ({ ...prev, profile_name: e.target.value }))}
-                                            />
-                                            <select
-                                                className={INPUT_BASE}
-                                                value={draftProfile.feed_type || 'native'}
-                                                onChange={(e) => setDraftProfile((prev) => ({ ...prev, feed_type: e.target.value }))}
-                                            >
-                                                <option value="native">Native (Custom Paper Size)</option>
-                                                <option value="letter_center">Letter Size (Center Feed)</option>
-                                                <option value="letter_left">Letter Size (Left Feed)</option>
-                                                <option value="letter_right">Letter Size (Right Feed)</option>
-                                            </select>
-                                            <input
-                                                type="number"
-                                                step="0.1"
-                                                className={INPUT_BASE}
-                                                placeholder="Offset X"
-                                                value={draftProfile.offset_x}
-                                                onChange={(e) => setDraftProfile((prev) => ({ ...prev, offset_x: Number(e.target.value) || 0 }))}
-                                            />
-                                            <input
-                                                type="number"
-                                                step="0.1"
-                                                className={INPUT_BASE}
-                                                placeholder="Offset Y"
-                                                value={draftProfile.offset_y}
-                                                onChange={(e) => setDraftProfile((prev) => ({ ...prev, offset_y: Number(e.target.value) || 0 }))}
-                                            />
-                                        </div>
-                                        <p className="text-xs text-gray-500">If your printer rejects custom 8x3 paper sizes, select your manual tray&apos;s feed alignment. The system will print on a Letter canvas to bypass the error.</p>
-                                        <label className="flex items-center gap-2">
-                                            <input
-                                                type="checkbox"
-                                                checked={Boolean(draftProfile.is_default)}
-                                                onChange={(e) => setDraftProfile((prev) => ({ ...prev, is_default: e.target.checked }))}
-                                            />
-                                            Set as default profile
-                                        </label>
-                                        <div className="flex gap-2">
-                                            <button className={BUTTON_PRIMARY} onClick={() => upsertProfile(draftProfile)}><Icon path={ICONS.settings} className="h-4 w-4" />{selectedProfile ? 'Save Profile' : 'Create Profile'}</button>
-                                            {!selectedProfile && (
-                                                <button className={BUTTON_SECONDARY} onClick={() => setDraftProfile({ profile_name: `Profile ${printerProfiles.length + 1}`, feed_type: 'native', offset_x: 0, offset_y: 0, is_default: false })}><Icon path={ICONS.edit} className="h-4 w-4" />Quick Fill</button>
-                                            )}
-                                        </div>
-                                    </div>
-                                )}
-                            </div>
-                        </div>
+            <Modal isOpen={historyOpen} onClose={() => setHistoryOpen(false)} title="Cheque History" maxWidth="max-w-6xl">
+                <div className="space-y-4">
+                    <p className="text-xs text-gray-500 dark:text-slate-400 -mt-2">Review past cheque records and reprint as needed.</p>
+                    <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+                        <input
+                            className={INPUT_BASE}
+                            placeholder="Search payee, memo, amount or bank"
+                            value={historyQuery}
+                            onChange={(e) => setHistoryQuery(e.target.value)}
+                        />
+                        <select
+                            className={INPUT_BASE}
+                            value={historyBankFilter}
+                            onChange={(e) => setHistoryBankFilter(e.target.value)}
+                        >
+                            <option value="all">All banks</option>
+                            {historyBankOptions.map((bank) => (
+                                <option key={bank} value={bank}>{bank}</option>
+                            ))}
+                        </select>
+                        <div className="text-sm text-gray-600 dark:text-slate-400 flex items-center md:justify-end">{filteredHistory.length} of {history.length} records</div>
                     </div>
-                </div>
-            )}
 
-            {historyOpen && (
-                <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
-                    <div className="bg-white rounded-xl border w-full max-w-6xl max-h-[90vh] overflow-hidden flex flex-col">
-                        <div className="p-4 border-b flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-                            <div>
-                                <h3 className="font-semibold text-gray-900">Cheque History</h3>
-                                <p className="text-xs text-gray-500">Review past cheque records and reprint as needed.</p>
-                            </div>
-                            <button className={BUTTON_SECONDARY} onClick={() => setHistoryOpen(false)}><Icon path={ICONS.close} className="h-4 w-4" />Close</button>
-                        </div>
-
-                        <div className="p-4 border-b bg-gray-50/60 grid grid-cols-1 md:grid-cols-3 gap-3">
-                            <input
-                                className={INPUT_BASE}
-                                placeholder="Search payee, memo, amount or bank"
-                                value={historyQuery}
-                                onChange={(e) => setHistoryQuery(e.target.value)}
-                            />
-                            <select
-                                className={INPUT_BASE}
-                                value={historyBankFilter}
-                                onChange={(e) => setHistoryBankFilter(e.target.value)}
-                            >
-                                <option value="all">All banks</option>
-                                {historyBankOptions.map((bank) => (
-                                    <option key={bank} value={bank}>{bank}</option>
-                                ))}
-                            </select>
-                            <div className="text-sm text-gray-600 flex items-center md:justify-end">{filteredHistory.length} of {history.length} records</div>
-                        </div>
-
-                        <div className="max-h-[65vh] overflow-auto">
-                            <table className="w-full text-sm">
-                                <thead className="bg-gray-50 sticky top-0">
-                                    <tr>
-                                        <th className="p-2 text-left">Created</th>
-                                        <th className="p-2 text-left">Payee</th>
-                                        <th className="p-2 text-left">Amount</th>
-                                        <th className="p-2 text-left">Bank</th>
-                                        <th className="p-2 text-left">Date Issued</th>
-                                        <th className="p-2 text-right">Actions</th>
+                    <div className="max-h-[55vh] overflow-auto border border-gray-200 dark:border-slate-700 rounded-lg">
+                        <table className="w-full text-sm">
+                            <thead className="bg-gray-50 dark:bg-slate-900/50 sticky top-0">
+                                <tr className="text-gray-700 dark:text-slate-300">
+                                    <th className="p-2 text-left">Created</th>
+                                    <th className="p-2 text-left">Payee</th>
+                                    <th className="p-2 text-left">Amount</th>
+                                    <th className="p-2 text-left">Bank</th>
+                                    <th className="p-2 text-left">Date Issued</th>
+                                    <th className="p-2 text-right">Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody className="text-gray-700 dark:text-slate-300">
+                                {filteredHistory.map((entry) => (
+                                    <tr key={entry.id} className="border-t border-gray-200 dark:border-slate-700 hover:bg-gray-50 dark:hover:bg-slate-700/40">
+                                        <td className="p-2 whitespace-nowrap">{format(new Date(entry.created_at), 'yyyy-MM-dd HH:mm')}</td>
+                                        <td className="p-2">{entry.payee}</td>
+                                        <td className="p-2">{entry.amount}</td>
+                                        <td className="p-2">{entry.bank_preset || '-'}</td>
+                                        <td className="p-2 whitespace-nowrap">{entry.cheque_date ? format(new Date(entry.cheque_date), 'yyyy-MM-dd') : '-'}</td>
+                                        <td className="p-2 text-right space-x-2 whitespace-nowrap">
+                                            <button className={BUTTON_PRIMARY} onClick={() => handleEditFromHistory(entry)}><Icon path={ICONS.edit} className="h-4 w-4" />Edit</button>
+                                            <button className={BUTTON_SECONDARY} onClick={() => handleReprint(entry)}><Icon path={ICONS.history} className="h-4 w-4" />Reprint</button>
+                                            <button className={BUTTON_DANGER} onClick={() => handleDelete(entry.id)}><Icon path={ICONS.trash} className="h-4 w-4" />Delete</button>
+                                        </td>
                                     </tr>
-                                </thead>
-                                <tbody>
-                                    {filteredHistory.map((entry) => (
-                                        <tr key={entry.id} className="border-t hover:bg-gray-50/70">
-                                            <td className="p-2 whitespace-nowrap">{format(new Date(entry.created_at), 'yyyy-MM-dd HH:mm')}</td>
-                                            <td className="p-2">{entry.payee}</td>
-                                            <td className="p-2">{entry.amount}</td>
-                                            <td className="p-2">{entry.bank_preset || '-'}</td>
-                                            <td className="p-2 whitespace-nowrap">{entry.cheque_date ? format(new Date(entry.cheque_date), 'yyyy-MM-dd') : '-'}</td>
-                                            <td className="p-2 text-right space-x-2 whitespace-nowrap">
-                                                <button className={BUTTON_PRIMARY} onClick={() => handleEditFromHistory(entry)}><Icon path={ICONS.edit} className="h-4 w-4" />Edit</button>
-                                                <button className={BUTTON_SECONDARY} onClick={() => handleReprint(entry)}><Icon path={ICONS.history} className="h-4 w-4" />Reprint</button>
-                                                <button className={BUTTON_DANGER} onClick={() => handleDelete(entry.id)}><Icon path={ICONS.trash} className="h-4 w-4" />Delete</button>
-                                            </td>
-                                        </tr>
-                                    ))}
-                                </tbody>
-                            </table>
-                            {!filteredHistory.length && (
-                                <div className="py-10 text-center text-sm text-gray-500">No cheque history matches the current filters.</div>
-                            )}
-                        </div>
+                                ))}
+                            </tbody>
+                        </table>
+                        {!filteredHistory.length && (
+                            <div className="py-10 text-center text-sm text-gray-500 dark:text-slate-400">No cheque history matches the current filters.</div>
+                        )}
                     </div>
                 </div>
-            )}
+            </Modal>
 
-            {pendingHistoryEntry && (
-                <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-[60] p-4">
-                    <div className="bg-white rounded-xl border w-full max-w-lg overflow-hidden">
-                        <div className="p-4 border-b">
-                            <h3 className="font-semibold text-gray-900">Load cheque from history</h3>
-                            <p className="text-sm text-gray-600 mt-1">You already have entries in the editor. Would you like to overwrite them or append this history entry?</p>
-                        </div>
-                        <div className="p-4 flex flex-wrap gap-2 justify-end">
-                            <button className={BUTTON_SECONDARY} onClick={() => setPendingHistoryEntry(null)}>Cancel</button>
-                            <button className={BUTTON_SECONDARY} onClick={() => applyHistoryEntryToEditor(pendingHistoryEntry, 'append')}>Append</button>
-                            <button className={BUTTON_PRIMARY} onClick={() => applyHistoryEntryToEditor(pendingHistoryEntry, 'overwrite')}>Overwrite</button>
-                        </div>
+            <Modal isOpen={Boolean(pendingHistoryEntry)} onClose={() => setPendingHistoryEntry(null)} title="Load cheque from history">
+                <div className="space-y-4">
+                    <p className="text-sm text-gray-600 dark:text-slate-400">You already have entries in the editor. Would you like to overwrite them or append this history entry?</p>
+                    <div className="flex flex-wrap gap-2 justify-end">
+                        <button className={BUTTON_SECONDARY} onClick={() => setPendingHistoryEntry(null)}>Cancel</button>
+                        <button className={BUTTON_SECONDARY} onClick={() => applyHistoryEntryToEditor(pendingHistoryEntry, 'append')}>Append</button>
+                        <button className={BUTTON_PRIMARY} onClick={() => applyHistoryEntryToEditor(pendingHistoryEntry, 'overwrite')}>Overwrite</button>
                     </div>
                 </div>
-            )}
+            </Modal>
         </div>
     );
 };

--- a/packages/web/src/pages/ChequesTreasuryPage.jsx
+++ b/packages/web/src/pages/ChequesTreasuryPage.jsx
@@ -1,0 +1,59 @@
+import { useMemo, useState } from 'react';
+import { useAuth } from '../contexts/AuthContext';
+import SegmentedTabs from '../components/ui/SegmentedTabs';
+import ChequePrintingPage from './ChequePrintingPage';
+import PdcTreasuryPage from './PdcTreasuryPage';
+import BankAccountsPage from './BankAccountsPage';
+import ChequeSettingsPanel from '../components/cheques/ChequeSettingsPanel';
+
+const ChequesTreasuryPage = () => {
+    const { hasPermission } = useAuth();
+
+    const sections = useMemo(() => ([
+        { key: 'print', label: 'Print Cheques', permission: 'cheques:view', Component: ChequePrintingPage },
+        { key: 'treasury', label: 'Treasury Desk', permission: ['pdc:view', 'ar:view', 'ap-pdc:view'], Component: PdcTreasuryPage },
+        { key: 'bank_accounts', label: 'Bank Accounts', permission: 'ap-pdc:view', Component: BankAccountsPage },
+        { key: 'settings', label: 'Templates & Settings', permission: 'cheques:view', Component: ChequeSettingsPanel },
+    ]), []);
+
+    const visibleSections = useMemo(
+        () => sections.filter((section) => hasPermission(section.permission)),
+        [sections, hasPermission]
+    );
+
+    const [activeSection, setActiveSection] = useState(() => visibleSections[0]?.key);
+
+    const current = visibleSections.find((section) => section.key === activeSection) || visibleSections[0];
+
+    return (
+        <div className="space-y-6">
+            <div>
+                <h1 className="text-2xl md:text-3xl font-bold text-gray-900 dark:text-slate-100">Cheques &amp; Treasury</h1>
+                <p className="text-sm text-gray-500 dark:text-slate-400 mt-1">
+                    Print cheques, monitor post-dated cheque clearance, manage bank accounts, and configure print templates in one place.
+                </p>
+            </div>
+
+            {visibleSections.length > 0 ? (
+                <>
+                    <div className="border-b border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 rounded-xl shadow-xs px-4 pt-2 overflow-x-auto">
+                        <SegmentedTabs
+                            tabs={visibleSections.map(({ key, label }) => ({ key, label }))}
+                            active={current?.key}
+                            onChange={setActiveSection}
+                        />
+                    </div>
+
+                    {current && <current.Component />}
+                </>
+            ) : (
+                <div className="bg-white dark:bg-slate-800 p-12 rounded-xl border border-gray-200 dark:border-slate-700 text-center shadow-xs space-y-2">
+                    <div className="text-4xl">🔒</div>
+                    <p className="text-sm text-gray-600 dark:text-slate-400">You do not have permission to view any cheque or treasury features.</p>
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default ChequesTreasuryPage;

--- a/packages/web/src/pages/PdcTreasuryPage.jsx
+++ b/packages/web/src/pages/PdcTreasuryPage.jsx
@@ -9,6 +9,8 @@ import PdcClearanceDeskTable from '../components/accounts-receivable/PdcClearanc
 import PdcOutboundDeskTable from '../components/accounts-payable/PdcOutboundDeskTable';
 import IssueOutboundChequeModal from '../components/accounts-payable/IssueOutboundChequeModal';
 import Modal from '../components/ui/Modal';
+import SegmentedTabs from '../components/ui/SegmentedTabs';
+import StatusBadge from '../components/ui/StatusBadge';
 
 const emptyStats = {
     held_in_safe_count: 0, held_in_safe_total: 0,
@@ -20,6 +22,17 @@ const emptyOutboundStats = {
     due_today_count: 0, due_today_total: 0,
     cleared_month_total: 0, bounced_count: 0, bounced_total: 0,
 };
+
+const HISTORY_ACTION_TONE = {
+    CLEARED: 'success',
+    BOUNCED: 'danger',
+    REDEPOSITED: 'info',
+    VOID: 'neutral',
+    REPLACED: 'warning',
+};
+
+const LABEL_CLASS = 'block text-xs font-semibold text-gray-700 dark:text-slate-300 mb-1';
+const TEXT_INPUT_CLASS = 'w-full text-xs p-2 border border-gray-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-800 text-gray-900 dark:text-slate-100';
 
 const PdcTreasuryPage = () => {
     const { hasPermission } = useAuth();
@@ -370,24 +383,29 @@ const PdcTreasuryPage = () => {
     const heldTotal = activeTab === 'outbound' ? activeStats.held_for_release_total : activeStats.held_in_safe_total;
     const heldCount = activeTab === 'outbound' ? activeStats.held_for_release_count : activeStats.held_in_safe_count;
 
+    const desksTabs = [
+        { key: 'inbound', label: '📥 Customer Cheques (Inbound / AR)' },
+        ...(canViewOutbound ? [{ key: 'outbound', label: '📤 Outbound Cheques (Supplier / Loan / Rent / Other)' }] : []),
+    ];
+
     return (
         <div className="space-y-6">
             <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
                 <div>
-                    <h1 className="text-3xl font-bold text-gray-900">PDC &amp; Treasury Desk</h1>
-                    <p className="text-sm text-gray-500 mt-1">
+                    <h1 className="text-2xl font-bold text-gray-900 dark:text-slate-100">PDC &amp; Treasury Desk</h1>
+                    <p className="text-sm text-gray-500 dark:text-slate-400 mt-1">
                         Centralized vault custody, post-dated cheque monitoring, bank clearance, and bounce reversals
                     </p>
                 </div>
                 <div className="flex items-center gap-2">
                     {activeTab === 'outbound' && canManageOutbound && (
                         <button type="button" onClick={() => setIssueModalOpen(true)}
-                            className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-xl text-xs font-bold shadow-xs flex items-center gap-2 cursor-pointer">
+                            className="px-4 py-2 bg-primary-600 hover:bg-primary-700 text-white rounded-xl text-xs font-bold shadow-xs flex items-center gap-2 cursor-pointer">
                             <span>+</span> Issue Cheque
                         </button>
                     )}
                     <button type="button" onClick={refreshAll}
-                        className="px-4 py-2 bg-white border border-gray-300 hover:bg-gray-50 text-gray-700 rounded-xl text-xs font-semibold shadow-xs flex items-center gap-2 cursor-pointer">
+                        className="px-4 py-2 bg-white dark:bg-slate-800 border border-gray-300 dark:border-slate-600 hover:bg-gray-50 dark:hover:bg-slate-700 text-gray-700 dark:text-slate-200 rounded-xl text-xs font-semibold shadow-xs flex items-center gap-2 cursor-pointer">
                         <span>🔄</span> Refresh Treasury Data
                     </button>
                 </div>
@@ -395,11 +413,11 @@ const PdcTreasuryPage = () => {
 
             {/* Due-today / replacement-needed reminder banner */}
             {(reminderSummary.inboundDueToday + reminderSummary.outboundDueToday + reminderSummary.needsReplacement) > 0 && (
-                <div className="bg-amber-50 border border-amber-200 rounded-xl px-4 py-3 text-xs text-amber-900 flex flex-wrap items-center gap-x-4 gap-y-1">
+                <div className="bg-warning-50 dark:bg-warning-900/20 border border-warning-200 dark:border-warning-900/40 rounded-xl px-4 py-3 text-xs text-warning-900 dark:text-warning-300 flex flex-wrap items-center gap-x-4 gap-y-1">
                     <span className="font-bold">⏰ Attention:</span>
                     {reminderSummary.inboundDueToday > 0 && <span>{reminderSummary.inboundDueToday} inbound cheque{reminderSummary.inboundDueToday === 1 ? '' : 's'} due today</span>}
                     {reminderSummary.outboundDueToday > 0 && <span>{reminderSummary.outboundDueToday} outbound cheque{reminderSummary.outboundDueToday === 1 ? '' : 's'} due today</span>}
-                    {reminderSummary.needsReplacement > 0 && <span className="text-rose-700 font-semibold">{reminderSummary.needsReplacement} outbound cheque{reminderSummary.needsReplacement === 1 ? '' : 's'} need replacement</span>}
+                    {reminderSummary.needsReplacement > 0 && <span className="text-danger-700 dark:text-danger-400 font-semibold">{reminderSummary.needsReplacement} outbound cheque{reminderSummary.needsReplacement === 1 ? '' : 's'} need replacement</span>}
                 </div>
             )}
 
@@ -414,17 +432,8 @@ const PdcTreasuryPage = () => {
                     subtitle={`${activeStats.bounced_count} bounced cheque${activeStats.bounced_count === 1 ? '' : 's'} logged`} icon="⚠️" color="rose" loading={activeStatsLoading} />
             </div>
 
-            <div className="border-b border-gray-200 bg-white rounded-xl shadow-xs px-4 pt-2">
-                <div className="flex space-x-8">
-                    <button type="button" onClick={() => setActiveTab('inbound')}
-                        className={`py-3 px-1 border-b-2 font-bold text-sm transition-all cursor-pointer ${activeTab === 'inbound' ? 'border-blue-600 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'}`}>
-                        📥 Customer Cheques (Inbound / AR)
-                    </button>
-                    <button type="button" onClick={() => setActiveTab('outbound')}
-                        className={`py-3 px-1 border-b-2 font-bold text-sm transition-all cursor-pointer ${activeTab === 'outbound' ? 'border-blue-600 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'}`}>
-                        📤 Outbound Cheques (Supplier / Loan / Rent / Other)
-                    </button>
-                </div>
+            <div className="border-b border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 rounded-xl shadow-xs px-4 pt-2">
+                <SegmentedTabs tabs={desksTabs} active={activeTab} onChange={setActiveTab} />
             </div>
 
             {activeTab === 'inbound' && (
@@ -460,9 +469,9 @@ const PdcTreasuryPage = () => {
                         onViewHistory={(item) => handleViewHistory(item, 'outbound')}
                     />
                 ) : (
-                    <div className="bg-white p-12 rounded-xl border border-gray-200 text-center shadow-xs space-y-2">
+                    <div className="bg-white dark:bg-slate-800 p-12 rounded-xl border border-gray-200 dark:border-slate-700 text-center shadow-xs space-y-2">
                         <div className="text-4xl">🔒</div>
-                        <p className="text-sm text-gray-600">You do not have permission to view outbound cheques.</p>
+                        <p className="text-sm text-gray-600 dark:text-slate-400">You do not have permission to view outbound cheques.</p>
                     </div>
                 )
             )}
@@ -477,8 +486,8 @@ const PdcTreasuryPage = () => {
             <Modal isOpen={actionModalType === 'clear'} onClose={closeModal} title="Verify Cheque Clearance">
                 {selectedItem && (
                     <div className="space-y-4">
-                        <div className="p-4 bg-emerald-50 border border-emerald-200 rounded-xl space-y-2 text-xs text-emerald-900">
-                            <p className="font-bold text-emerald-950 text-sm">Confirm Bank Clearance</p>
+                        <div className="p-4 bg-success-50 dark:bg-success-900/20 border border-success-200 dark:border-success-900/40 rounded-xl space-y-2 text-xs text-success-900 dark:text-success-300">
+                            <p className="font-bold text-success-950 dark:text-success-200 text-sm">Confirm Bank Clearance</p>
                             <p>You are marking this cheque payment as <strong>CLEARED</strong> by the bank:</p>
                             <ul className="list-disc pl-4 space-y-1 font-mono">
                                 <li>{selectedItem.direction === 'outbound' ? 'Payee' : 'Customer'}: <strong>{selectedItem.company_name || selectedItem.payee || selectedItem.first_name}</strong></li>
@@ -486,13 +495,13 @@ const PdcTreasuryPage = () => {
                                 <li>Amount: <strong>{formatCurrency(selectedItem.amount)}</strong></li>
                             </ul>
                         </div>
-                        <p className="text-xs text-gray-600">
-                            This will post a <code className="bg-gray-100 px-1 py-0.5 rounded text-blue-700">PAYMENT_SETTLED</code> entry to the {selectedItem.direction === 'outbound' ? "supplier's AP ledger" : "customer's AR ledger"} and update the cash balance.
+                        <p className="text-xs text-gray-600 dark:text-slate-400">
+                            This will post a <code className="bg-gray-100 dark:bg-slate-700 px-1 py-0.5 rounded text-primary-700 dark:text-primary-400">PAYMENT_SETTLED</code> entry to the {selectedItem.direction === 'outbound' ? "supplier's AP ledger" : "customer's AR ledger"} and update the cash balance.
                         </p>
                         <div className="flex justify-end gap-3 pt-2">
-                            <button type="button" onClick={closeModal} className="px-4 py-2 text-xs font-semibold text-gray-600 bg-gray-100 hover:bg-gray-200 rounded-lg cursor-pointer">Cancel</button>
+                            <button type="button" onClick={closeModal} className="px-4 py-2 text-xs font-semibold text-gray-600 dark:text-slate-300 bg-gray-100 dark:bg-slate-700 hover:bg-gray-200 dark:hover:bg-slate-600 rounded-lg cursor-pointer">Cancel</button>
                             <button type="button" disabled={submittingAction} onClick={confirmVerifyClearance}
-                                className="px-4 py-2 text-xs font-bold text-white bg-emerald-600 hover:bg-emerald-700 rounded-lg shadow-xs cursor-pointer disabled:opacity-50">
+                                className="px-4 py-2 text-xs font-bold text-white bg-success-600 hover:bg-success-700 rounded-lg shadow-xs cursor-pointer disabled:opacity-50">
                                 {submittingAction ? 'Processing...' : 'Confirm Clearance'}
                             </button>
                         </div>
@@ -504,32 +513,32 @@ const PdcTreasuryPage = () => {
             <Modal isOpen={actionModalType === 'bounce'} onClose={closeModal} title="Process Bounced Cheque (NSF)">
                 {selectedItem && (
                     <div className="space-y-4">
-                        <div className="p-4 bg-rose-50 border border-rose-200 rounded-xl space-y-2 text-xs text-rose-900">
-                            <p className="font-bold text-rose-950 text-sm">⚠️ Automated Reversal Warning</p>
+                        <div className="p-4 bg-danger-50 dark:bg-danger-900/20 border border-danger-200 dark:border-danger-900/40 rounded-xl space-y-2 text-xs text-danger-900 dark:text-danger-300">
+                            <p className="font-bold text-danger-950 dark:text-danger-200 text-sm">⚠️ Automated Reversal Warning</p>
                             <p>Bouncing this cheque will automatically:</p>
                             <ul className="list-disc pl-4 space-y-1">
                                 <li>Reverse <strong>{formatCurrency(selectedItem.amount)}</strong> back onto {selectedItem.direction === 'outbound' ? 'open bills' : 'open invoices'}.</li>
-                                <li>Post a <code className="bg-rose-100 px-1 py-0.5 rounded font-mono">PDC_BOUNCED_REVERSAL</code> entry to the {selectedItem.direction === 'outbound' ? 'AP' : 'AR'} ledger.</li>
+                                <li>Post a <code className="bg-danger-100 dark:bg-danger-900/40 px-1 py-0.5 rounded font-mono">PDC_BOUNCED_REVERSAL</code> entry to the {selectedItem.direction === 'outbound' ? 'AP' : 'AR'} ledger.</li>
                                 <li>Place {selectedItem.direction === 'outbound' ? 'supplier' : 'customer'} <strong>{selectedItem.company_name || selectedItem.payee}</strong> on <strong>{selectedItem.direction === 'outbound' ? 'Payment Hold' : 'Credit Hold'}</strong>.</li>
                             </ul>
                         </div>
                         <div className="space-y-3">
                             <div>
-                                <label className="block text-xs font-semibold text-gray-700 mb-1">Bounce Reason:</label>
+                                <label className={LABEL_CLASS}>Bounce Reason:</label>
                                 <input type="text" value={bounceReasonInput} onChange={(e) => setBounceReasonInput(e.target.value)}
-                                    className="w-full text-xs p-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-rose-500"
+                                    className={`${TEXT_INPUT_CLASS} focus:ring-2 focus:ring-danger-500`}
                                     placeholder="e.g. NSF / Insufficient Funds, Account Closed" />
                             </div>
                             <div>
-                                <label className="block text-xs font-semibold text-gray-700 mb-1">Bank Penalty Fee (₱):</label>
+                                <label className={LABEL_CLASS}>Bank Penalty Fee (₱):</label>
                                 <input type="number" step="0.01" value={bounceFeeInput} onChange={(e) => setBounceFeeInput(e.target.value)}
-                                    className="w-full text-xs p-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-rose-500 font-mono" />
+                                    className={`${TEXT_INPUT_CLASS} focus:ring-2 focus:ring-danger-500 font-mono`} />
                             </div>
                         </div>
                         <div className="flex justify-end gap-3 pt-2">
-                            <button type="button" onClick={closeModal} className="px-4 py-2 text-xs font-semibold text-gray-600 bg-gray-100 hover:bg-gray-200 rounded-lg cursor-pointer">Cancel</button>
+                            <button type="button" onClick={closeModal} className="px-4 py-2 text-xs font-semibold text-gray-600 dark:text-slate-300 bg-gray-100 dark:bg-slate-700 hover:bg-gray-200 dark:hover:bg-slate-600 rounded-lg cursor-pointer">Cancel</button>
                             <button type="button" disabled={submittingAction} onClick={confirmMarkBounced}
-                                className="px-4 py-2 text-xs font-bold text-white bg-rose-600 hover:bg-rose-700 rounded-lg shadow-xs cursor-pointer disabled:opacity-50">
+                                className="px-4 py-2 text-xs font-bold text-white bg-danger-600 hover:bg-danger-700 rounded-lg shadow-xs cursor-pointer disabled:opacity-50">
                                 {submittingAction ? 'Processing...' : 'Confirm Cheque Bounce'}
                             </button>
                         </div>
@@ -541,25 +550,25 @@ const PdcTreasuryPage = () => {
             <Modal isOpen={actionModalType === 'redeposit'} onClose={closeModal} title="Re-deposit Bounced Cheque">
                 {selectedItem && (
                     <div className="space-y-4">
-                        <p className="text-xs text-gray-600">
+                        <p className="text-xs text-gray-600 dark:text-slate-400">
                             Re-presenting cheque <strong>#{selectedItem.cheque_number || selectedItem.reference_number || selectedItem.payment_id}</strong> for bank clearance attempt.
                         </p>
                         <div className="space-y-3">
                             <div>
-                                <label className="block text-xs font-semibold text-gray-700 mb-1">Re-deposit Notes:</label>
+                                <label className={LABEL_CLASS}>Re-deposit Notes:</label>
                                 <input type="text" value={redepositNotesInput} onChange={(e) => setRedepositNotesInput(e.target.value)}
-                                    className="w-full text-xs p-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500" />
+                                    className={`${TEXT_INPUT_CLASS} focus:ring-2 focus:ring-primary-500`} />
                             </div>
-                            <label className="flex items-center gap-2 text-xs text-gray-700 cursor-pointer">
+                            <label className="flex items-center gap-2 text-xs text-gray-700 dark:text-slate-300 cursor-pointer">
                                 <input type="checkbox" checked={liftHoldInput} onChange={(e) => setLiftHoldInput(e.target.checked)}
-                                    className="rounded text-blue-600 focus:ring-blue-500" />
+                                    className="rounded text-primary-600 focus:ring-primary-500" />
                                 <span>Lift {selectedItem.direction === 'outbound' ? 'payment' : 'credit'} hold upon re-deposit</span>
                             </label>
                         </div>
                         <div className="flex justify-end gap-3 pt-2">
-                            <button type="button" onClick={closeModal} className="px-4 py-2 text-xs font-semibold text-gray-600 bg-gray-100 hover:bg-gray-200 rounded-lg cursor-pointer">Cancel</button>
+                            <button type="button" onClick={closeModal} className="px-4 py-2 text-xs font-semibold text-gray-600 dark:text-slate-300 bg-gray-100 dark:bg-slate-700 hover:bg-gray-200 dark:hover:bg-slate-600 rounded-lg cursor-pointer">Cancel</button>
                             <button type="button" disabled={submittingAction} onClick={confirmRedeposit}
-                                className="px-4 py-2 text-xs font-bold text-white bg-blue-600 hover:bg-blue-700 rounded-lg shadow-xs cursor-pointer disabled:opacity-50">
+                                className="px-4 py-2 text-xs font-bold text-white bg-primary-600 hover:bg-primary-700 rounded-lg shadow-xs cursor-pointer disabled:opacity-50">
                                 {submittingAction ? 'Processing...' : 'Confirm Re-deposit'}
                             </button>
                         </div>
@@ -571,18 +580,18 @@ const PdcTreasuryPage = () => {
             <Modal isOpen={actionModalType === 'void'} onClose={closeModal} title="Void Cheque">
                 {selectedItem && (
                     <div className="space-y-4">
-                        <div className="p-4 bg-gray-50 border border-gray-200 rounded-xl text-xs text-gray-700">
+                        <div className="p-4 bg-gray-50 dark:bg-slate-700/50 border border-gray-200 dark:border-slate-600 rounded-xl text-xs text-gray-700 dark:text-slate-300">
                             Voiding cheque <strong>#{selectedItem.cheque_number}</strong> marks it as spoiled/never issued. This keeps the cheque-number sequence explainable — the number will never be reused.
                         </div>
                         <div>
-                            <label className="block text-xs font-semibold text-gray-700 mb-1">Reason (required):</label>
+                            <label className={LABEL_CLASS}>Reason (required):</label>
                             <input type="text" value={voidReasonInput} onChange={(e) => setVoidReasonInput(e.target.value)}
-                                className="w-full text-xs p-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-gray-500" placeholder="e.g. Writing mistake, misprint" />
+                                className={`${TEXT_INPUT_CLASS} focus:ring-2 focus:ring-gray-500`} placeholder="e.g. Writing mistake, misprint" />
                         </div>
                         <div className="flex justify-end gap-3 pt-2">
-                            <button type="button" onClick={closeModal} className="px-4 py-2 text-xs font-semibold text-gray-600 bg-gray-100 hover:bg-gray-200 rounded-lg cursor-pointer">Cancel</button>
+                            <button type="button" onClick={closeModal} className="px-4 py-2 text-xs font-semibold text-gray-600 dark:text-slate-300 bg-gray-100 dark:bg-slate-700 hover:bg-gray-200 dark:hover:bg-slate-600 rounded-lg cursor-pointer">Cancel</button>
                             <button type="button" disabled={submittingAction} onClick={confirmVoid}
-                                className="px-4 py-2 text-xs font-bold text-white bg-gray-700 hover:bg-gray-800 rounded-lg shadow-xs cursor-pointer disabled:opacity-50">
+                                className="px-4 py-2 text-xs font-bold text-white bg-gray-700 hover:bg-gray-800 dark:bg-slate-600 dark:hover:bg-slate-500 rounded-lg shadow-xs cursor-pointer disabled:opacity-50">
                                 {submittingAction ? 'Processing...' : 'Confirm Void'}
                             </button>
                         </div>
@@ -594,30 +603,30 @@ const PdcTreasuryPage = () => {
             <Modal isOpen={actionModalType === 'replace'} onClose={closeModal} title="Replace Cheque">
                 {selectedItem && (
                     <div className="space-y-4">
-                        <div className="p-4 bg-amber-50 border border-amber-200 rounded-xl text-xs text-amber-900">
+                        <div className="p-4 bg-warning-50 dark:bg-warning-900/20 border border-warning-200 dark:border-warning-900/40 rounded-xl text-xs text-warning-900 dark:text-warning-300">
                             Cheque <strong>#{selectedItem.cheque_number}</strong> is no longer usable. A new cheque will be issued for the same obligation, linked back to this one for a continuous audit trail.
                         </div>
                         <div className="grid grid-cols-2 gap-3">
                             <div>
-                                <label className="block text-xs font-semibold text-gray-700 mb-1">New Cheque Number:</label>
+                                <label className={LABEL_CLASS}>New Cheque Number:</label>
                                 <input type="text" value={replaceChequeNumberInput} onChange={(e) => setReplaceChequeNumberInput(e.target.value)}
-                                    className="w-full text-xs p-2 border border-gray-300 rounded-lg font-mono focus:ring-2 focus:ring-amber-500" />
+                                    className={`${TEXT_INPUT_CLASS} font-mono focus:ring-2 focus:ring-warning-500`} />
                             </div>
                             <div>
-                                <label className="block text-xs font-semibold text-gray-700 mb-1">New Cheque Date:</label>
+                                <label className={LABEL_CLASS}>New Cheque Date:</label>
                                 <input type="date" value={replaceChequeDateInput} onChange={(e) => setReplaceChequeDateInput(e.target.value)}
-                                    className="w-full text-xs p-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500" />
+                                    className={`${TEXT_INPUT_CLASS} focus:ring-2 focus:ring-warning-500`} />
                             </div>
                         </div>
                         <div>
-                            <label className="block text-xs font-semibold text-gray-700 mb-1">Reason:</label>
+                            <label className={LABEL_CLASS}>Reason:</label>
                             <input type="text" value={replaceReasonInput} onChange={(e) => setReplaceReasonInput(e.target.value)}
-                                className="w-full text-xs p-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500" placeholder="e.g. Bounced twice, gone stale" />
+                                className={`${TEXT_INPUT_CLASS} focus:ring-2 focus:ring-warning-500`} placeholder="e.g. Bounced twice, gone stale" />
                         </div>
                         <div className="flex justify-end gap-3 pt-2">
-                            <button type="button" onClick={closeModal} className="px-4 py-2 text-xs font-semibold text-gray-600 bg-gray-100 hover:bg-gray-200 rounded-lg cursor-pointer">Cancel</button>
+                            <button type="button" onClick={closeModal} className="px-4 py-2 text-xs font-semibold text-gray-600 dark:text-slate-300 bg-gray-100 dark:bg-slate-700 hover:bg-gray-200 dark:hover:bg-slate-600 rounded-lg cursor-pointer">Cancel</button>
                             <button type="button" disabled={submittingAction} onClick={confirmReplace}
-                                className="px-4 py-2 text-xs font-bold text-white bg-amber-600 hover:bg-amber-700 rounded-lg shadow-xs cursor-pointer disabled:opacity-50">
+                                className="px-4 py-2 text-xs font-bold text-white bg-warning-600 hover:bg-warning-700 rounded-lg shadow-xs cursor-pointer disabled:opacity-50">
                                 {submittingAction ? 'Processing...' : 'Issue Replacement'}
                             </button>
                         </div>
@@ -629,41 +638,33 @@ const PdcTreasuryPage = () => {
             <Modal isOpen={actionModalType === 'history'} onClose={closeModal} title="Cheque Audit & Clearance History">
                 {selectedItem && (
                     <div className="space-y-4">
-                        <div className="p-3 bg-gray-50 rounded-lg border border-gray-200 flex justify-between items-center text-xs">
+                        <div className="p-3 bg-gray-50 dark:bg-slate-700/50 rounded-lg border border-gray-200 dark:border-slate-600 flex justify-between items-center text-xs">
                             <div>
-                                <span className="font-bold text-gray-900">{selectedItem.company_name || selectedItem.payee || selectedItem.first_name}</span>
-                                <span className="text-gray-400 ml-2 font-mono">Ref: #{selectedItem.cheque_number || selectedItem.reference_number || selectedItem.payment_id}</span>
+                                <span className="font-bold text-gray-900 dark:text-slate-100">{selectedItem.company_name || selectedItem.payee || selectedItem.first_name}</span>
+                                <span className="text-gray-400 dark:text-slate-500 ml-2 font-mono">Ref: #{selectedItem.cheque_number || selectedItem.reference_number || selectedItem.payment_id}</span>
                             </div>
-                            <span className="font-bold font-mono text-blue-900">{formatCurrency(selectedItem.amount)}</span>
+                            <span className="font-bold font-mono text-primary-900 dark:text-primary-400">{formatCurrency(selectedItem.amount)}</span>
                         </div>
                         {historyLoading ? (
-                            <div className="text-center py-6 text-xs text-gray-500 animate-pulse">Loading history timeline...</div>
+                            <div className="text-center py-6 text-xs text-gray-500 dark:text-slate-400 animate-pulse">Loading history timeline...</div>
                         ) : clearanceHistory.length === 0 ? (
-                            <div className="text-center py-6 text-xs text-gray-400">No log entries found for this cheque.</div>
+                            <div className="text-center py-6 text-xs text-gray-400 dark:text-slate-500">No log entries found for this cheque.</div>
                         ) : (
                             <div className="space-y-3 max-h-80 overflow-y-auto pr-1">
                                 {clearanceHistory.map((log) => (
-                                    <div key={log.log_id} className="p-3 bg-white border border-gray-200 rounded-lg shadow-2xs space-y-1 text-xs">
+                                    <div key={log.log_id} className="p-3 bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-lg shadow-2xs space-y-1 text-xs">
                                         <div className="flex justify-between items-center">
-                                            <span className={`px-2 py-0.5 rounded text-[10px] font-bold uppercase ${
-                                                log.action === 'CLEARED' ? 'bg-emerald-100 text-emerald-800' :
-                                                log.action === 'BOUNCED' ? 'bg-rose-100 text-rose-800' :
-                                                log.action === 'REDEPOSITED' ? 'bg-blue-100 text-blue-800' :
-                                                log.action === 'VOID' ? 'bg-gray-200 text-gray-700' :
-                                                log.action === 'REPLACED' ? 'bg-amber-100 text-amber-800' : 'bg-gray-100 text-gray-700'
-                                            }`}>
-                                                {log.action} (Attempt #{log.attempt_number || 1})
-                                            </span>
-                                            <span className="text-[10px] text-gray-400">{new Date(log.created_at).toLocaleString()}</span>
+                                            <StatusBadge tone={HISTORY_ACTION_TONE[log.action] || 'neutral'} label={`${log.action} (Attempt #${log.attempt_number || 1})`} pill={false} className="text-[10px]" />
+                                            <span className="text-[10px] text-gray-400 dark:text-slate-500">{new Date(log.created_at).toLocaleString()}</span>
                                         </div>
-                                        {log.notes && <p className="text-gray-700 font-medium">{log.notes}</p>}
-                                        {log.bounce_reason && <p className="text-rose-600 font-mono text-[11px]">Reason: {log.bounce_reason}</p>}
+                                        {log.notes && <p className="text-gray-700 dark:text-slate-300 font-medium">{log.notes}</p>}
+                                        {log.bounce_reason && <p className="text-danger-600 dark:text-danger-400 font-mono text-[11px]">Reason: {log.bounce_reason}</p>}
                                     </div>
                                 ))}
                             </div>
                         )}
                         <div className="flex justify-end pt-2">
-                            <button type="button" onClick={closeModal} className="px-4 py-2 text-xs font-semibold text-gray-600 bg-gray-100 hover:bg-gray-200 rounded-lg cursor-pointer">Close</button>
+                            <button type="button" onClick={closeModal} className="px-4 py-2 text-xs font-semibold text-gray-600 dark:text-slate-300 bg-gray-100 dark:bg-slate-700 hover:bg-gray-200 dark:hover:bg-slate-600 rounded-lg cursor-pointer">Close</button>
                         </div>
                     </div>
                 )}


### PR DESCRIPTION
## Summary
Adds robust numeric amount formatting to cheque PDF generation to ensure amounts are consistently displayed with proper thousand separators and two decimal places, regardless of input format or currency symbols.

## Key Changes
- **New `formatNumericAmount()` helper function** in `chequePdf.js`:
  - Strips currency symbols and non-numeric characters from input
  - Handles null, undefined, and empty string inputs gracefully
  - Formats output with thousand separators and exactly 2 decimal places using `toLocaleString()`
  - Returns '0.00' for invalid inputs

- **Applied formatting in both PDF renderers**:
  - Fallback PDF renderer: formats `row.amount` before drawing to PDF
  - Main PDF renderer: formats `row.amount` before drawing to PDF

- **Enhanced `amountToWords()` in `chequeAmountWords.js`**:
  - Now strips currency symbols and non-numeric characters from amount input
  - Ensures consistent numeric parsing regardless of input format

- **Added comprehensive test coverage** in `chequePdf.test.js`:
  - Tests formatting of numeric amounts with proper thousand separators
  - Tests stripping of currency symbols (₱, $) and extra characters
  - Tests edge cases (zero, decimals, large numbers)

- **Exported `formatNumericAmount`** for external use and testing

## Implementation Details
The formatting function uses a regex pattern `/[^0-9.-]/g` to strip all non-numeric characters except periods and hyphens, then validates the result before formatting. This approach handles various input formats (strings, numbers, pre-formatted amounts with symbols) uniformly and prevents invalid data from being rendered in cheques.

https://claude.ai/code/session_01HYmBep3KvH9e6ZtbJ9CA6D