### PR TITLE
Add AP monitoring dashboard with aging, supplier summary, and bill management

### DIFF
--- a/database/migrations/20260813_01_add_supplier_payment_terms_and_bill_indexes.sql
+++ b/database/migrations/20260813_01_add_supplier_payment_terms_and_bill_indexes.sql
@@ -1,0 +1,13 @@
+-- Migration: 20260813_01_add_supplier_payment_terms_and_bill_indexes.sql
+-- Description: Adds supplier.payment_terms_days (mirrors invoice.payment_terms_days)
+--              so bill due dates can be computed from agreed terms, plus aging/due-date
+--              indexes on supplier_bill to support the new AP monitoring queries.
+
+BEGIN;
+
+ALTER TABLE supplier ADD COLUMN IF NOT EXISTS payment_terms_days integer;
+
+CREATE INDEX IF NOT EXISTS idx_supplier_bill_due_date ON supplier_bill(due_date) WHERE status != 'Paid';
+CREATE INDEX IF NOT EXISTS idx_supplier_bill_bill_date ON supplier_bill(bill_date);
+
+COMMIT;

--- a/database/migrations/20260813_02_create_supplier_bill_due_date_log.sql
+++ b/database/migrations/20260813_02_create_supplier_bill_due_date_log.sql
@@ -1,0 +1,24 @@
+-- Migration: 20260813_02_create_supplier_bill_due_date_log.sql
+-- Description: Audit trail for supplier_bill due date edits, mirroring the AR
+--              due_date_log table so AP due-date changes are traceable the same way.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.supplier_bill_due_date_log (
+    log_id serial PRIMARY KEY,
+    bill_id integer NOT NULL REFERENCES public.supplier_bill(bill_id) ON DELETE CASCADE,
+    old_due_date date,
+    new_due_date date NOT NULL,
+    days_adjustment integer,
+    edited_by integer NOT NULL REFERENCES public.employee(employee_id) ON DELETE RESTRICT,
+    edited_on timestamptz DEFAULT CURRENT_TIMESTAMP,
+    reason text
+);
+
+CREATE INDEX IF NOT EXISTS idx_supplier_bill_due_date_log_bill_id ON public.supplier_bill_due_date_log(bill_id);
+CREATE INDEX IF NOT EXISTS idx_supplier_bill_due_date_log_edited_by ON public.supplier_bill_due_date_log(edited_by);
+
+COMMENT ON TABLE public.supplier_bill_due_date_log IS 'Audit log for all supplier_bill due date changes';
+COMMENT ON COLUMN public.supplier_bill_due_date_log.days_adjustment IS 'Number of days adjusted: positive for extension, negative for reduction';
+
+COMMIT;

--- a/database/migrations/20260813_03_seed_ap_monitoring_permissions_and_settings.sql
+++ b/database/migrations/20260813_03_seed_ap_monitoring_permissions_and_settings.sql
@@ -1,0 +1,28 @@
+-- Migration: 20260813_03_seed_ap_monitoring_permissions_and_settings.sql
+-- Description: Seed ap:view / ap:manage permissions for the new AP monitoring
+--              dashboard (aging, balances, supplier ledger) — kept separate from
+--              ap-pdc:* so monitoring access doesn't imply cheque-issuing rights.
+--              Also seeds the AP due-date reminder cron schedule.
+
+BEGIN;
+
+INSERT INTO permission (permission_key, description, category)
+VALUES
+  ('ap:view',   'View Accounts Payable monitoring dashboard (aging, balances, supplier ledger)', 'Finance & Treasury'),
+  ('ap:manage', 'Manage Accounts Payable records: bill due dates, supplier payment holds', 'Finance & Treasury')
+ON CONFLICT (permission_key) DO NOTHING;
+
+INSERT INTO role_permission (permission_level_id, permission_id)
+SELECT pl.permission_level_id, p.permission_id
+FROM permission_level pl
+CROSS JOIN permission p
+WHERE pl.level_name IN ('Admin', 'Manager', 'Super Admin')
+  AND p.permission_key IN ('ap:view', 'ap:manage')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO settings (setting_key, setting_value, description)
+VALUES
+  ('AP_DUE_DATE_REMINDER_SCHEDULE', '0 7 * * *', 'Cron schedule for the daily supplier bill due-date reminder scan')
+ON CONFLICT (setting_key) DO NOTHING;
+
+COMMIT;

--- a/database/migrations/20260813_04_add_grn_supplier_bill_idempotency.sql
+++ b/database/migrations/20260813_04_add_grn_supplier_bill_idempotency.sql
@@ -1,0 +1,12 @@
+-- Migration: 20260813_04_add_grn_supplier_bill_idempotency.sql
+-- Description: One auto-generated bill per goods receipt — a partial unique index
+--              on supplier_bill.grn_id so the GRN finalization flow can safely
+--              be re-triggered (e.g. retries) without ever double-billing a supplier.
+
+BEGIN;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_supplier_bill_grn_id
+    ON supplier_bill(grn_id)
+    WHERE grn_id IS NOT NULL;
+
+COMMIT;

--- a/database/migrations/20260813_05_add_goods_receipt_bill_link.sql
+++ b/database/migrations/20260813_05_add_goods_receipt_bill_link.sql
@@ -1,0 +1,15 @@
+-- Migration: 20260813_05_add_goods_receipt_bill_link.sql
+-- Description: Optional link from goods_receipt to a pre-existing supplier_bill,
+--              so items can be "attached" (with real stock-in) to a manually-created
+--              payable after the fact, instead of only via the automatic
+--              GRN-posts-a-bill flow (which uses supplier_bill.grn_id, a single-bill
+--              link, and stays untouched). Unlike that single-link column, one manual
+--              bill can accumulate items from multiple goods receipts over time, so
+--              this is a plain FK on goods_receipt rather than a unique constraint.
+
+BEGIN;
+
+ALTER TABLE goods_receipt ADD COLUMN IF NOT EXISTS bill_id integer REFERENCES supplier_bill(bill_id);
+CREATE INDEX IF NOT EXISTS idx_goods_receipt_bill_id ON goods_receipt(bill_id) WHERE bill_id IS NOT NULL;
+
+COMMIT;

--- a/database/migrations/20260813_06_backfill_goods_receipt_bill_id.sql
+++ b/database/migrations/20260813_06_backfill_goods_receipt_bill_id.sql
@@ -1,0 +1,16 @@
+-- Migration: 20260813_06_backfill_goods_receipt_bill_id.sql
+-- Description: Backfills goods_receipt.bill_id for receipts whose auto-created
+--              supplier_bill already links back via supplier_bill.grn_id. Without
+--              this, GET /ap/supplier-bills/:billId/items finds nothing for bills
+--              created before goodsReceiptRoutes.js started setting bill_id itself,
+--              even though the stock-in already happened.
+
+BEGIN;
+
+UPDATE goods_receipt gr
+SET bill_id = sb.bill_id
+FROM supplier_bill sb
+WHERE sb.grn_id = gr.grn_id
+  AND gr.bill_id IS NULL;
+
+COMMIT;

--- a/packages/api/index.js
+++ b/packages/api/index.js
@@ -11,6 +11,7 @@ const { startWorker: startDedupeScanWorker, runScanCycle } = require('./dedupe-s
 global.runDeduplicationScan = runScanCycle;
 const { startCycleCountEngine } = require('./services/cycleCountService');
 const { startPdcReminderEngine } = require('./services/pdcReminderService');
+const { startApDueDateReminderEngine } = require('./services/apDueDateReminderService');
 const { startLedgerReconciliationEngine } = require('./services/ledgerReconciliationService');
 
 // Set default timezone to Philippine Time
@@ -83,6 +84,7 @@ registerRoute('/api', './routes/taxReportRoutes');
 registerRoute('/api', './routes/expenseCategoryRoutes');
 registerRoute('/api', './routes/expenseRoutes');
 registerRoute('/api', './routes/apPdcRoutes');
+registerRoute('/api', './routes/apRoutes');
 
 // Admin & System Modules
 registerRoute('/api', './routes/employeeRoutes');
@@ -188,5 +190,6 @@ app.listen(PORT, async () => {
   }
   startCycleCountEngine();
   startPdcReminderEngine();
+  startApDueDateReminderEngine();
   startLedgerReconciliationEngine();
 });

--- a/packages/api/routes/apPdcRoutes.js
+++ b/packages/api/routes/apPdcRoutes.js
@@ -32,10 +32,16 @@ router.post('/ap/outbound-clearance/issue', protect, hasPermission(['ap-pdc:mana
     const {
         bank_account_id, cheque_number, cheque_date, purpose_type, amount, payee, memo,
         template_id, supplier_id, bill_ids, expense_category_id, reference_number,
+        override_payment_hold,
     } = req.body;
 
     if (!bank_account_id || !cheque_number || !cheque_date || !purpose_type || !amount || !payee) {
         return res.status(400).json({ message: 'bank_account_id, cheque_number, cheque_date, purpose_type, amount, and payee are required' });
+    }
+
+    const isAdminBypass = Number(req.user?.permission_level_id) === 10;
+    if (override_payment_hold && !isAdminBypass && !(req.user?.permissions || []).includes('ap:manage')) {
+        return res.status(403).json({ message: 'ap:manage permission is required to override a supplier payment hold' });
     }
 
     const client = await db.getClient();
@@ -69,12 +75,16 @@ router.post('/ap/outbound-clearance/issue', protect, hasPermission(['ap-pdc:mana
             referenceNumber: reference_number,
             employeeId: req.user?.employee_id,
             userId: req.user?.employee_id,
+            overridePaymentHold: Boolean(override_payment_hold),
         });
         await client.query('COMMIT');
         res.status(201).json({ success: true, message: 'Outbound cheque issued', ...result, templateId: resolvedTemplateId });
     } catch (err) {
         await client.query('ROLLBACK');
         console.error('AP Issue Outbound Cheque Error:', err.message);
+        if (err.code === 'PAYMENT_HOLD_BLOCKED') {
+            return res.status(409).json({ message: err.message, code: err.code });
+        }
         if (err.code === '23505') {
             return res.status(409).json({ message: 'This cheque number has already been recorded for this bank account' });
         }
@@ -279,10 +289,12 @@ router.get('/ap/supplier-bills', protect, hasPermission(['ap-pdc:view']), async 
         const params = [];
         let where = 'WHERE 1=1';
         if (supplier_id) { params.push(supplier_id); where += ` AND sb.supplier_id = $${params.length}`; }
-        if (status) { params.push(status); where += ` AND sb.status = $${params.length}`; }
-        else { where += ` AND sb.status != 'Paid'`; }
+        if (status && status !== 'all') { params.push(status); where += ` AND sb.status = $${params.length}`; }
+        else if (!status) { where += ` AND sb.status != 'Paid'`; }
         const { rows } = await db.query(
-            `SELECT sb.*, s.supplier_name FROM supplier_bill sb
+            `SELECT sb.*, s.supplier_name,
+                    GREATEST(EXTRACT(days FROM (CURRENT_DATE - COALESCE(sb.due_date, sb.bill_date))), 0) AS days_overdue
+             FROM supplier_bill sb
              JOIN supplier s ON s.supplier_id = sb.supplier_id
              ${where} ORDER BY sb.due_date NULLS LAST, sb.bill_date`,
             params

--- a/packages/api/routes/apPdcRoutes.js
+++ b/packages/api/routes/apPdcRoutes.js
@@ -293,7 +293,7 @@ router.get('/ap/supplier-bills', protect, hasPermission(['ap-pdc:view']), async 
         else if (!status) { where += ` AND sb.status != 'Paid'`; }
         const { rows } = await db.query(
             `SELECT sb.*, s.supplier_name,
-                    GREATEST(EXTRACT(days FROM (CURRENT_DATE - COALESCE(sb.due_date, sb.bill_date))), 0) AS days_overdue
+                    GREATEST(CURRENT_DATE - COALESCE(sb.due_date, sb.bill_date), 0) AS days_overdue
              FROM supplier_bill sb
              JOIN supplier s ON s.supplier_id = sb.supplier_id
              ${where} ORDER BY sb.due_date NULLS LAST, sb.bill_date`,

--- a/packages/api/routes/apPdcRoutes.js
+++ b/packages/api/routes/apPdcRoutes.js
@@ -2,6 +2,8 @@ const express = require('express');
 const db = require('../db');
 const { protect, hasPermission } = require('../middleware/authMiddleware');
 const apPdcService = require('../services/apPdcService');
+const apLedgerService = require('../services/apLedgerService');
+const { getNextDocumentNumber } = require('../helpers/documentNumberGenerator');
 const router = express.Router();
 
 // GET /ap/pdc/summary-stats - KPI summary metrics for outbound Treasury Desk header cards
@@ -283,7 +285,7 @@ router.get('/ap/cheque-register', protect, hasPermission(['ap-pdc:view']), async
 
 // ── Supplier bills (minimal — header-only, just enough to attach outbound cheques to a real liability) ──
 
-router.get('/ap/supplier-bills', protect, hasPermission(['ap-pdc:view']), async (req, res) => {
+router.get('/ap/supplier-bills', protect, hasPermission(['ap-pdc:view', 'ap:view']), async (req, res) => {
     try {
         const { supplier_id, status } = req.query;
         const params = [];
@@ -306,21 +308,64 @@ router.get('/ap/supplier-bills', protect, hasPermission(['ap-pdc:view']), async 
     }
 });
 
-router.post('/ap/supplier-bills', protect, hasPermission(['ap-pdc:manage']), async (req, res) => {
+// POST /ap/supplier-bills - Create a payable directly against a supplier (no PO/GRN
+// required). Auto-generates a bill_number when none is supplied, and posts the
+// BILL_POSTED ap_ledger entry in the same transaction so the new liability shows up
+// in AP balances/aging immediately, exactly like the automatic GRN-triggered path does.
+router.post('/ap/supplier-bills', protect, hasPermission(['ap:manage']), async (req, res) => {
+    const { supplier_id, po_id, grn_id, bill_number, bill_date, due_date, total_amount, notes } = req.body;
+    const parsedAmount = parseFloat(total_amount);
+    if (!supplier_id || !parsedAmount || parsedAmount <= 0) {
+        return res.status(400).json({ message: 'supplier_id and a positive total_amount are required' });
+    }
+
+    const client = await db.getClient();
     try {
-        const { supplier_id, po_id, grn_id, bill_number, bill_date, due_date, total_amount, notes } = req.body;
-        if (!supplier_id || !total_amount) {
-            return res.status(400).json({ message: 'supplier_id and total_amount are required' });
+        await client.query('BEGIN');
+
+        let resolvedDueDate = due_date || null;
+        if (!resolvedDueDate) {
+            const { rows: [supplier] } = await client.query(
+                'SELECT payment_terms_days FROM supplier WHERE supplier_id = $1', [supplier_id]
+            );
+            if (supplier?.payment_terms_days) {
+                const { rows: [computed] } = await client.query(
+                    `SELECT (COALESCE($1::date, CURRENT_DATE) + ($2::int || ' days')::interval)::date AS due_date`,
+                    [bill_date || null, supplier.payment_terms_days]
+                );
+                resolvedDueDate = computed.due_date;
+            }
         }
-        const { rows: [row] } = await db.query(
+
+        const resolvedBillNumber = bill_number || await getNextDocumentNumber(client, 'BILL');
+
+        const { rows: [bill] } = await client.query(
             `INSERT INTO supplier_bill (supplier_id, po_id, grn_id, bill_number, bill_date, due_date, total_amount, notes, created_by)
              VALUES ($1, $2, $3, $4, COALESCE($5, CURRENT_DATE), $6, $7, $8, $9) RETURNING *`,
-            [supplier_id, po_id || null, grn_id || null, bill_number || null, bill_date, due_date || null, total_amount, notes || null, req.user?.employee_id]
+            [supplier_id, po_id || null, grn_id || null, resolvedBillNumber, bill_date || null, resolvedDueDate, parsedAmount, notes || null, req.user?.employee_id]
         );
-        res.status(201).json({ success: true, data: row });
+
+        await apLedgerService.appendEntry(client, {
+            supplierId: supplier_id,
+            billId: bill.bill_id,
+            entryType: 'BILL_POSTED',
+            amount: parsedAmount,
+            referenceNo: resolvedBillNumber,
+            notes: notes || `Manually recorded payable ${resolvedBillNumber}`,
+            createdBy: req.user?.employee_id,
+        });
+
+        await client.query('COMMIT');
+        res.status(201).json({ success: true, data: bill });
     } catch (err) {
+        await client.query('ROLLBACK');
         console.error('Create Supplier Bill Error:', err.message);
+        if (err.code === '23505') {
+            return res.status(409).json({ message: 'A bill with this number already exists.' });
+        }
         res.status(500).json({ message: 'Failed to create supplier bill' });
+    } finally {
+        client.release();
     }
 });
 

--- a/packages/api/routes/apRoutes.js
+++ b/packages/api/routes/apRoutes.js
@@ -1,0 +1,351 @@
+const express = require('express');
+const db = require('../db');
+const { protect, hasPermission } = require('../middleware/authMiddleware');
+const { parsePaginationQuery, paginatedResponse } = require('../helpers/pagination');
+const router = express.Router();
+
+// GET /ap/aging-summary - Open supplier_bill balances bucketed by age (mirrors /ar/aging-summary)
+router.get('/ap/aging-summary', protect, hasPermission('ap:view'), async (req, res) => {
+    try {
+        const query = `
+            WITH aging_buckets AS (
+                SELECT
+                    CASE
+                        WHEN COALESCE(sb.due_date, sb.bill_date) >= CURRENT_DATE THEN 'Current'
+                        WHEN COALESCE(sb.due_date, sb.bill_date) >= CURRENT_DATE - INTERVAL '30 days' THEN '1-30 Days'
+                        WHEN COALESCE(sb.due_date, sb.bill_date) >= CURRENT_DATE - INTERVAL '60 days' THEN '31-60 Days'
+                        WHEN COALESCE(sb.due_date, sb.bill_date) >= CURRENT_DATE - INTERVAL '90 days' THEN '61-90 Days'
+                        ELSE '90+ Days'
+                    END as bucket_name,
+                    COALESCE(SUM(GREATEST(sb.total_amount - sb.amount_paid, 0)), 0) as bucket_value
+                FROM supplier_bill sb
+                WHERE sb.status IN ('Unpaid', 'Partially Paid')
+                GROUP BY
+                    CASE
+                        WHEN COALESCE(sb.due_date, sb.bill_date) >= CURRENT_DATE THEN 'Current'
+                        WHEN COALESCE(sb.due_date, sb.bill_date) >= CURRENT_DATE - INTERVAL '30 days' THEN '1-30 Days'
+                        WHEN COALESCE(sb.due_date, sb.bill_date) >= CURRENT_DATE - INTERVAL '60 days' THEN '31-60 Days'
+                        WHEN COALESCE(sb.due_date, sb.bill_date) >= CURRENT_DATE - INTERVAL '90 days' THEN '61-90 Days'
+                        ELSE '90+ Days'
+                    END
+            )
+            SELECT bucket_name as name, bucket_value as value
+            FROM aging_buckets
+            ORDER BY
+                CASE bucket_name
+                    WHEN 'Current' THEN 1
+                    WHEN '1-30 Days' THEN 2
+                    WHEN '31-60 Days' THEN 3
+                    WHEN '61-90 Days' THEN 4
+                    ELSE 5
+                END;
+        `;
+
+        const { rows } = await db.query(query);
+
+        const allBuckets = ['Current', '1-30 Days', '31-60 Days', '61-90 Days', '90+ Days'];
+        const agingData = allBuckets.map(bucket => {
+            const existing = rows.find(row => row.name === bucket);
+            return { name: bucket, value: existing ? parseFloat(existing.value) : 0 };
+        });
+
+        res.json(agingData);
+    } catch (err) {
+        console.error('AP Aging Summary Error:', err.message);
+        res.status(500).json({ message: 'Failed to fetch AP aging summary' });
+    }
+});
+
+// GET /ap/summary-stats - KPI header cards for the AP monitoring dashboard
+router.get('/ap/summary-stats', protect, hasPermission('ap:view'), async (req, res) => {
+    try {
+        const [totalPayablesRes, overdueRes, dueSoonRes, holdRes] = await Promise.all([
+            db.query(`SELECT COALESCE(SUM(ledger_balance), 0) AS total_payables FROM vw_supplier_ap_balance WHERE ledger_balance > 0`),
+            db.query(`
+                SELECT COUNT(*)::int AS overdue_count, COALESCE(SUM(GREATEST(total_amount - amount_paid, 0)), 0) AS overdue_amount
+                FROM supplier_bill
+                WHERE status IN ('Unpaid', 'Partially Paid') AND COALESCE(due_date, bill_date) < CURRENT_DATE
+            `),
+            db.query(`
+                SELECT
+                    COUNT(*) FILTER (WHERE COALESCE(due_date, bill_date) BETWEEN CURRENT_DATE AND CURRENT_DATE + INTERVAL '7 days')::int AS due_next_7_count,
+                    COALESCE(SUM(GREATEST(total_amount - amount_paid, 0)) FILTER (WHERE COALESCE(due_date, bill_date) BETWEEN CURRENT_DATE AND CURRENT_DATE + INTERVAL '7 days'), 0) AS due_next_7_amount,
+                    COUNT(*) FILTER (WHERE COALESCE(due_date, bill_date) BETWEEN CURRENT_DATE AND CURRENT_DATE + INTERVAL '30 days')::int AS due_next_30_count,
+                    COALESCE(SUM(GREATEST(total_amount - amount_paid, 0)) FILTER (WHERE COALESCE(due_date, bill_date) BETWEEN CURRENT_DATE AND CURRENT_DATE + INTERVAL '30 days'), 0) AS due_next_30_amount
+                FROM supplier_bill
+                WHERE status IN ('Unpaid', 'Partially Paid')
+            `),
+            db.query(`SELECT COUNT(*)::int AS suppliers_on_hold FROM supplier WHERE payment_hold = TRUE`),
+        ]);
+
+        res.json({
+            totalPayables: parseFloat(totalPayablesRes.rows[0].total_payables) || 0,
+            overdueCount: overdueRes.rows[0].overdue_count || 0,
+            overdueAmount: parseFloat(overdueRes.rows[0].overdue_amount) || 0,
+            dueNext7Count: dueSoonRes.rows[0].due_next_7_count || 0,
+            dueNext7Amount: parseFloat(dueSoonRes.rows[0].due_next_7_amount) || 0,
+            dueNext30Count: dueSoonRes.rows[0].due_next_30_count || 0,
+            dueNext30Amount: parseFloat(dueSoonRes.rows[0].due_next_30_amount) || 0,
+            suppliersOnHold: holdRes.rows[0].suppliers_on_hold || 0,
+        });
+    } catch (err) {
+        console.error('AP Summary Stats Error:', err.message);
+        res.status(500).json({ message: 'Failed to fetch AP summary stats' });
+    }
+});
+
+// GET /ap/supplier-summary - Supplier-level AP summary (balance, earliest due date, aging bucket)
+router.get('/ap/supplier-summary', protect, hasPermission('ap:view'), async (req, res) => {
+    try {
+        const { paginated, page, pageSize, offset, limit } = parsePaginationQuery(req.query);
+        const { search, status, sortBy, sortDir } = req.query;
+
+        const params = [];
+        let paramIdx = 1;
+        let searchWhere = '';
+        if (search && search.trim()) {
+            searchWhere = `AND (
+                LOWER(COALESCE(s.supplier_name, '')) LIKE $${paramIdx} OR
+                LOWER(COALESCE(s.contact_person, '')) LIKE $${paramIdx} OR
+                LOWER(COALESCE(s.phone, '')) LIKE $${paramIdx}
+            )`;
+            params.push(`%${search.trim().toLowerCase()}%`);
+            paramIdx++;
+        }
+
+        let havingClause = 'HAVING b.ledger_balance > 0';
+        if (status === 'PAYMENT_HOLD') {
+            searchWhere += ' AND s.payment_hold = TRUE';
+        } else if (status === 'CURRENT') {
+            havingClause += " AND MIN(COALESCE(sb.due_date, sb.bill_date)) >= CURRENT_DATE";
+        } else if (status === 'OVERDUE') {
+            havingClause += " AND MIN(COALESCE(sb.due_date, sb.bill_date)) < CURRENT_DATE";
+        }
+
+        let orderBy = 'ORDER BY bill_count DESC, earliest_due_date ASC, total_balance_due DESC';
+        if (sortBy) {
+            const dir = (sortDir || 'ASC').toUpperCase() === 'DESC' ? 'DESC' : 'ASC';
+            if (sortBy === 'supplier_name') {
+                orderBy = `ORDER BY s.supplier_name ${dir}`;
+            } else if (sortBy === 'bill_count') {
+                orderBy = `ORDER BY bill_count ${dir}`;
+            } else if (sortBy === 'earliest_due_date') {
+                orderBy = `ORDER BY earliest_due_date ${dir} NULLS LAST`;
+            } else if (sortBy === 'total_balance_due') {
+                orderBy = `ORDER BY total_balance_due ${dir}`;
+            } else if (sortBy === 'status') {
+                orderBy = `ORDER BY status ${dir}`;
+            }
+        }
+
+        const query = `
+            SELECT
+                s.supplier_id,
+                s.supplier_name,
+                s.contact_person,
+                s.phone,
+                s.payment_hold,
+                s.payment_hold_reason,
+                s.payment_terms_days,
+                b.ledger_balance                                     AS total_balance_due,
+                MIN(COALESCE(sb.due_date, sb.bill_date))            AS earliest_due_date,
+                COUNT(DISTINCT sb.bill_id)                           AS bill_count,
+                CASE
+                    WHEN MIN(COALESCE(sb.due_date, sb.bill_date)) >= CURRENT_DATE THEN 'Current'
+                    WHEN MIN(COALESCE(sb.due_date, sb.bill_date)) >= CURRENT_DATE - INTERVAL '30 days' THEN '1-30 Days'
+                    WHEN MIN(COALESCE(sb.due_date, sb.bill_date)) >= CURRENT_DATE - INTERVAL '60 days' THEN '31-60 Days'
+                    WHEN MIN(COALESCE(sb.due_date, sb.bill_date)) >= CURRENT_DATE - INTERVAL '90 days' THEN '61-90 Days'
+                    ELSE '90+ Days'
+                END as status
+            FROM supplier s
+            JOIN vw_supplier_ap_balance b ON b.supplier_id = s.supplier_id
+            LEFT JOIN supplier_bill sb ON s.supplier_id = sb.supplier_id AND sb.status IN ('Unpaid', 'Partially Paid')
+            WHERE b.ledger_balance > 0
+            ${searchWhere}
+            GROUP BY s.supplier_id, s.supplier_name, s.contact_person, s.phone, s.payment_hold, s.payment_hold_reason, s.payment_terms_days, b.ledger_balance
+            ${havingClause}
+            ${orderBy}
+            LIMIT $${paramIdx} OFFSET $${paramIdx + 1};
+        `;
+
+        const queryParams = [...params, limit, offset];
+        const { rows } = await db.query(query, queryParams);
+
+        if (!paginated) return res.json(rows);
+
+        const countQuery = `
+            SELECT COUNT(*)::int AS total
+            FROM (
+                SELECT s.supplier_id
+                FROM supplier s
+                JOIN vw_supplier_ap_balance b ON b.supplier_id = s.supplier_id
+                LEFT JOIN supplier_bill sb ON s.supplier_id = sb.supplier_id AND sb.status IN ('Unpaid', 'Partially Paid')
+                WHERE b.ledger_balance > 0
+                ${searchWhere}
+                GROUP BY s.supplier_id, b.ledger_balance
+                ${havingClause}
+            ) summary
+        `;
+        const countRes = await db.query(countQuery, params);
+        const total = countRes.rows[0]?.total || 0;
+        res.json(paginatedResponse({ data: rows, page, pageSize, total }));
+    } catch (err) {
+        console.error('AP Supplier Summary Error:', err.message);
+        res.status(500).json({ message: 'Failed to fetch supplier summary' });
+    }
+});
+
+// GET /ap/suppliers/:supplierId/ledger - Chronological ap_ledger history with running balance (SOA)
+router.get('/ap/suppliers/:supplierId/ledger', protect, hasPermission('ap:view'), async (req, res) => {
+    const supplierId = parseInt(req.params.supplierId, 10);
+    if (!supplierId) return res.status(400).json({ message: 'Invalid supplier ID' });
+    const { limit = 100, offset = 0 } = req.query;
+    try {
+        const { rows } = await db.query(`
+            SELECT
+                l.ledger_id, l.entry_type, l.amount, l.balance_after,
+                l.payment_channel, l.reference_no, l.notes, l.created_at,
+                l.bill_id, sb.bill_number,
+                l.payment_id, ap.reference_number AS payment_reference_number,
+                e.first_name || ' ' || COALESCE(e.last_name, '') AS created_by_name
+            FROM ap_ledger l
+            LEFT JOIN supplier_bill sb ON sb.bill_id = l.bill_id
+            LEFT JOIN ap_payment ap ON ap.payment_id = l.payment_id
+            LEFT JOIN employee e ON e.employee_id = l.created_by
+            WHERE l.supplier_id = $1
+            ORDER BY l.ledger_id ASC
+            LIMIT $2 OFFSET $3
+        `, [supplierId, parseInt(limit), parseInt(offset)]);
+        const { rows: [{ total }] } = await db.query(
+            'SELECT COUNT(*)::int AS total FROM ap_ledger WHERE supplier_id = $1', [supplierId]);
+        res.json({ rows, total });
+    } catch (err) {
+        console.error('AP Ledger fetch error:', err.message);
+        res.status(500).json({ message: 'Server error fetching AP ledger.' });
+    }
+});
+
+// GET /ap/suppliers/:supplierId/payments - Payment instruments issued to a supplier, with bill allocations
+router.get('/ap/suppliers/:supplierId/payments', protect, hasPermission('ap:view'), async (req, res) => {
+    const supplierId = parseInt(req.params.supplierId, 10);
+    if (!supplierId) return res.status(400).json({ message: 'Invalid supplier ID' });
+    try {
+        const { rows } = await db.query(`
+            SELECT
+                p.payment_id, p.payment_date, p.amount, p.reference_number, p.notes,
+                p.pdc_status, p.cheque_date, p.bank_account_id, ba.account_name,
+                pm.method_name,
+                COALESCE(
+                    json_agg(
+                        json_build_object('bill_id', a.bill_id, 'bill_number', sb.bill_number, 'amount_allocated', a.amount_allocated)
+                    ) FILTER (WHERE a.allocation_id IS NOT NULL), '[]'
+                ) AS allocations
+            FROM ap_payment p
+            LEFT JOIN bank_account ba ON ba.bank_account_id = p.bank_account_id
+            LEFT JOIN payment_methods pm ON pm.method_id = p.method_id
+            LEFT JOIN ap_payment_allocation a ON a.payment_id = p.payment_id
+            LEFT JOIN supplier_bill sb ON sb.bill_id = a.bill_id
+            WHERE p.supplier_id = $1
+            GROUP BY p.payment_id, ba.account_name, pm.method_name
+            ORDER BY p.payment_date DESC
+        `, [supplierId]);
+        res.json({ success: true, data: rows });
+    } catch (err) {
+        console.error('AP Supplier Payments Error:', err.message);
+        res.status(500).json({ message: 'Failed to fetch supplier payments' });
+    }
+});
+
+// PATCH /ap/suppliers/:supplierId/payment-hold - Toggle a supplier's payment hold flag
+router.patch('/ap/suppliers/:supplierId/payment-hold', protect, hasPermission('ap:manage'), async (req, res) => {
+    const supplierId = parseInt(req.params.supplierId, 10);
+    if (!supplierId) return res.status(400).json({ message: 'Invalid supplier ID' });
+    const { payment_hold, payment_hold_reason } = req.body;
+    if (typeof payment_hold !== 'boolean') {
+        return res.status(400).json({ message: 'payment_hold (boolean) is required' });
+    }
+    if (payment_hold && (!payment_hold_reason || !payment_hold_reason.trim())) {
+        return res.status(400).json({ message: 'payment_hold_reason is required when placing a supplier on hold' });
+    }
+    try {
+        const { rows: [row] } = await db.query(
+            `UPDATE supplier SET
+                payment_hold = $1,
+                payment_hold_reason = $2,
+                modified_by = $3,
+                date_modified = now()
+             WHERE supplier_id = $4 RETURNING supplier_id, supplier_name, payment_hold, payment_hold_reason`,
+            [payment_hold, payment_hold ? payment_hold_reason.trim() : null, req.user?.employee_id, supplierId]
+        );
+        if (!row) return res.status(404).json({ message: 'Supplier not found' });
+        res.json({ success: true, data: row });
+    } catch (err) {
+        console.error('AP Payment Hold Toggle Error:', err.message);
+        res.status(500).json({ message: 'Failed to update payment hold' });
+    }
+});
+
+// PATCH /ap/supplier-bills/:billId/due-date - Edit a bill's due date, with an audit log entry
+router.patch('/ap/supplier-bills/:billId/due-date', protect, hasPermission('ap:manage'), async (req, res) => {
+    const billId = parseInt(req.params.billId, 10);
+    if (!billId) return res.status(400).json({ message: 'Invalid bill ID' });
+    const { new_due_date, reason } = req.body;
+    if (!new_due_date) return res.status(400).json({ message: 'new_due_date is required' });
+
+    const client = await db.getClient();
+    try {
+        await client.query('BEGIN');
+        const { rows: [bill] } = await client.query(
+            'SELECT bill_id, due_date FROM supplier_bill WHERE bill_id = $1 FOR UPDATE', [billId]
+        );
+        if (!bill) {
+            await client.query('ROLLBACK');
+            return res.status(404).json({ message: 'Bill not found' });
+        }
+
+        const oldDueDate = bill.due_date;
+        let daysAdjustment = null;
+        if (oldDueDate) {
+            const diffMs = new Date(new_due_date).getTime() - new Date(oldDueDate).getTime();
+            daysAdjustment = Math.round(diffMs / (1000 * 60 * 60 * 24));
+        }
+
+        await client.query('UPDATE supplier_bill SET due_date = $1 WHERE bill_id = $2', [new_due_date, billId]);
+        await client.query(
+            `INSERT INTO supplier_bill_due_date_log (bill_id, old_due_date, new_due_date, days_adjustment, edited_by, reason)
+             VALUES ($1, $2, $3, $4, $5, $6)`,
+            [billId, oldDueDate, new_due_date, daysAdjustment, req.user?.employee_id, reason || null]
+        );
+
+        await client.query('COMMIT');
+        res.json({ success: true, message: 'Due date updated', bill_id: billId, old_due_date: oldDueDate, new_due_date });
+    } catch (err) {
+        await client.query('ROLLBACK');
+        console.error('AP Bill Due Date Edit Error:', err.message);
+        res.status(500).json({ message: 'Failed to update due date' });
+    } finally {
+        client.release();
+    }
+});
+
+// GET /ap/supplier-bills/:billId/due-date-history - Audit trail for a bill's due date changes
+router.get('/ap/supplier-bills/:billId/due-date-history', protect, hasPermission('ap:view'), async (req, res) => {
+    const billId = parseInt(req.params.billId, 10);
+    if (!billId) return res.status(400).json({ message: 'Invalid bill ID' });
+    try {
+        const { rows } = await db.query(`
+            SELECT ddl.log_id, ddl.old_due_date, ddl.new_due_date, ddl.days_adjustment, ddl.edited_on, ddl.reason,
+                   e.first_name, e.last_name
+            FROM supplier_bill_due_date_log ddl
+            JOIN employee e ON e.employee_id = ddl.edited_by
+            WHERE ddl.bill_id = $1
+            ORDER BY ddl.edited_on ASC
+        `, [billId]);
+        res.json({ success: true, data: rows });
+    } catch (err) {
+        console.error('AP Bill Due Date History Error:', err.message);
+        res.status(500).json({ message: 'Failed to fetch due date history' });
+    }
+});
+
+module.exports = router;

--- a/packages/api/routes/apRoutes.js
+++ b/packages/api/routes/apRoutes.js
@@ -234,7 +234,7 @@ router.get('/ap/suppliers/:supplierId/payments', protect, hasPermission('ap:view
             SELECT
                 p.payment_id, p.payment_date, p.amount, p.reference_number, p.notes,
                 p.pdc_status, p.cheque_date, p.bank_account_id, ba.account_name,
-                pm.method_name,
+                pm.name AS method_name,
                 COALESCE(
                     json_agg(
                         json_build_object('bill_id', a.bill_id, 'bill_number', sb.bill_number, 'amount_allocated', a.amount_allocated)
@@ -246,7 +246,7 @@ router.get('/ap/suppliers/:supplierId/payments', protect, hasPermission('ap:view
             LEFT JOIN ap_payment_allocation a ON a.payment_id = p.payment_id
             LEFT JOIN supplier_bill sb ON sb.bill_id = a.bill_id
             WHERE p.supplier_id = $1
-            GROUP BY p.payment_id, ba.account_name, pm.method_name
+            GROUP BY p.payment_id, ba.account_name, pm.name
             ORDER BY p.payment_date DESC
         `, [supplierId]);
         res.json({ success: true, data: rows });

--- a/packages/api/routes/apRoutes.js
+++ b/packages/api/routes/apRoutes.js
@@ -362,10 +362,32 @@ router.get('/ap/supplier-bills/:billId/items', protect, hasPermission('ap:view')
             SELECT
                 grl.grn_line_id, grl.grn_id, gr.grn_number, gr.receipt_date,
                 grl.part_id, grl.quantity, grl.cost_price,
-                p.internal_sku, p.detail
+                p.internal_sku, p.detail,
+                CASE
+                    WHEN pn.part_number IS NOT NULL THEN
+                        CASE
+                            WHEN g.group_name IS NOT NULL AND b.brand_name IS NOT NULL THEN CONCAT(g.group_name, ' (', b.brand_name, ') | ', pn.part_number)
+                            WHEN g.group_name IS NOT NULL THEN CONCAT(g.group_name, ' | ', pn.part_number)
+                            WHEN b.brand_name IS NOT NULL THEN CONCAT(b.brand_name, ' | ', pn.part_number)
+                            ELSE pn.part_number
+                        END
+                    ELSE
+                        CASE
+                            WHEN g.group_name IS NOT NULL AND b.brand_name IS NOT NULL THEN CONCAT(g.group_name, ' (', b.brand_name, ') | ', p.internal_sku)
+                            WHEN g.group_name IS NOT NULL THEN CONCAT(g.group_name, ' | ', p.internal_sku)
+                            WHEN b.brand_name IS NOT NULL THEN CONCAT(b.brand_name, ' | ', p.internal_sku)
+                            ELSE p.internal_sku
+                        END
+                END ||
+                CASE WHEN p.detail IS NOT NULL AND p.detail != '' THEN ' | ' || p.detail ELSE '' END AS display_name
             FROM goods_receipt gr
             JOIN goods_receipt_line grl ON grl.grn_id = gr.grn_id
             JOIN part p ON p.part_id = grl.part_id
+            LEFT JOIN brand b ON p.brand_id = b.brand_id
+            LEFT JOIN "group" g ON p.group_id = g.group_id
+            LEFT JOIN part_number pn ON pn.part_id = p.part_id AND pn.display_order = (
+                SELECT MIN(pn2.display_order) FROM part_number pn2 WHERE pn2.part_id = p.part_id
+            )
             WHERE gr.bill_id = $1
             ORDER BY gr.receipt_date ASC, grl.grn_line_id ASC
         `, [billId]);

--- a/packages/api/routes/apRoutes.js
+++ b/packages/api/routes/apRoutes.js
@@ -348,4 +348,40 @@ router.get('/ap/supplier-bills/:billId/due-date-history', protect, hasPermission
     }
 });
 
+// GET /ap/supplier-bills/:billId/items - Items attached to a manually-created bill via
+// one or more linked goods receipts (goods_receipt.bill_id), plus a variance check
+// against the bill's recorded total_amount.
+router.get('/ap/supplier-bills/:billId/items', protect, hasPermission('ap:view'), async (req, res) => {
+    const billId = parseInt(req.params.billId, 10);
+    if (!billId) return res.status(400).json({ message: 'Invalid bill ID' });
+    try {
+        const { rows: [bill] } = await db.query('SELECT bill_id, total_amount FROM supplier_bill WHERE bill_id = $1', [billId]);
+        if (!bill) return res.status(404).json({ message: 'Bill not found' });
+
+        const { rows } = await db.query(`
+            SELECT
+                grl.grn_line_id, grl.grn_id, gr.grn_number, gr.receipt_date,
+                grl.part_id, grl.quantity, grl.cost_price,
+                p.internal_sku, p.detail
+            FROM goods_receipt gr
+            JOIN goods_receipt_line grl ON grl.grn_id = gr.grn_id
+            JOIN part p ON p.part_id = grl.part_id
+            WHERE gr.bill_id = $1
+            ORDER BY gr.receipt_date ASC, grl.grn_line_id ASC
+        `, [billId]);
+
+        const itemsTotal = rows.reduce((sum, r) => sum + (parseFloat(r.quantity) * parseFloat(r.cost_price)), 0);
+        res.json({
+            success: true,
+            data: rows,
+            itemsTotal,
+            billTotal: parseFloat(bill.total_amount),
+            variance: parseFloat(bill.total_amount) - itemsTotal,
+        });
+    } catch (err) {
+        console.error('AP Bill Items Error:', err.message);
+        res.status(500).json({ message: 'Failed to fetch bill items' });
+    }
+});
+
 module.exports = router;

--- a/packages/api/routes/goodsReceiptRoutes.js
+++ b/packages/api/routes/goodsReceiptRoutes.js
@@ -141,7 +141,9 @@ router.get('/goods-receipts/:id/lines', protect, async (req, res) => {
 // POST /goods-receipts - Create a new Goods Receipt
 router.post('/goods-receipts', protect, hasPermission('goods_receipt:create'), async (req, res) => {
   // NEW: Added po_id to destructuring
-  const { supplier_id, received_by, lines, po_id } = req.body;
+  // bill_id: optional — attaches this receipt's stock-in to a pre-existing manually
+  // created supplier_bill (see AddPayableModal) instead of auto-generating a new bill.
+  const { supplier_id, received_by, lines, po_id, bill_id } = req.body;
 
   if (!supplier_id || !received_by || !lines || !Array.isArray(lines) || lines.length === 0) {
     return res.status(400).json({ message: 'Missing required fields.' });
@@ -152,14 +154,24 @@ router.post('/goods-receipts', protect, hasPermission('goods_receipt:create'), a
   try {
     await client.query('BEGIN');
 
+    if (bill_id) {
+      const { rows: [bill] } = await client.query(
+        `SELECT bill_id FROM supplier_bill WHERE bill_id = $1 AND supplier_id = $2 AND status != 'Paid'`,
+        [bill_id, supplier_id]
+      );
+      if (!bill) {
+        throw new Error('The selected payable was not found for this supplier, or is already fully paid.');
+      }
+    }
+
     const grn_number = await getNextDocumentNumber(client, 'GRN');
 
     const goodsReceiptQuery = `
-      INSERT INTO goods_receipt (grn_number, supplier_id, received_by)
-      VALUES ($1, $2, $3)
+      INSERT INTO goods_receipt (grn_number, supplier_id, received_by, bill_id)
+      VALUES ($1, $2, $3, $4)
       RETURNING grn_id;
     `;
-    const receiptResult = await client.query(goodsReceiptQuery, [grn_number, supplier_id, received_by]);
+    const receiptResult = await client.query(goodsReceiptQuery, [grn_number, supplier_id, received_by, bill_id || null]);
     const newGrnId = receiptResult.rows[0].grn_id;
 
     for (const line of lines) {
@@ -213,9 +225,11 @@ router.post('/goods-receipts', protect, hasPermission('goods_receipt:create'), a
     // --- Auto-create the supplier bill this receipt represents, so AP monitoring
     // reflects the liability immediately instead of waiting on manual bill entry.
     // The partial unique index on supplier_bill.grn_id (migration 20260813_04)
-    // makes this idempotent if the request is ever retried.
+    // makes this idempotent if the request is ever retried. Skipped entirely when
+    // bill_id was provided — the receipt is attaching items to an existing payable,
+    // not creating a new one.
     const totalAmount = lines.reduce((sum, l) => sum + (parseFloat(l.quantity) * parseFloat(l.cost_price)), 0);
-    if (totalAmount > 0) {
+    if (totalAmount > 0 && !bill_id) {
       const { rows: [supplier] } = await client.query(
         'SELECT payment_terms_days FROM supplier WHERE supplier_id = $1', [supplier_id]
       );
@@ -231,6 +245,12 @@ router.post('/goods-receipts', protect, hasPermission('goods_receipt:create'), a
       );
 
       if (bill) {
+        // Back-link the receipt to the bill it created (goods_receipt.bill_id is the
+        // authoritative "which items belong to this bill" pointer used by
+        // GET /ap/supplier-bills/:billId/items — without this, auto-created bills
+        // would show no attached items even though the stock-in already happened).
+        await client.query(`UPDATE goods_receipt SET bill_id = $1 WHERE grn_id = $2`, [bill.bill_id, newGrnId]);
+
         await apLedgerService.appendEntry(client, {
           supplierId: supplier_id,
           billId: bill.bill_id,

--- a/packages/api/routes/goodsReceiptRoutes.js
+++ b/packages/api/routes/goodsReceiptRoutes.js
@@ -3,6 +3,7 @@ const db = require('../db');
 const { getNextDocumentNumber } = require('../helpers/documentNumberGenerator');
 const { hasPermission, protect } = require('../middleware/authMiddleware');
 const { parsePaginationQuery, paginatedResponse } = require('../helpers/pagination');
+const apLedgerService = require('../services/apLedgerService');
 const router = express.Router();
 
 // GET /goods-receipts - Fetch list of posted GRNs with search and sorting
@@ -207,6 +208,39 @@ router.post('/goods-receipts', protect, hasPermission('goods_receipt:create'), a
         }
 
         await client.query(`UPDATE purchase_order SET status = $1 WHERE po_id = $2`, [newStatus, po_id]);
+    }
+
+    // --- Auto-create the supplier bill this receipt represents, so AP monitoring
+    // reflects the liability immediately instead of waiting on manual bill entry.
+    // The partial unique index on supplier_bill.grn_id (migration 20260813_04)
+    // makes this idempotent if the request is ever retried.
+    const totalAmount = lines.reduce((sum, l) => sum + (parseFloat(l.quantity) * parseFloat(l.cost_price)), 0);
+    if (totalAmount > 0) {
+      const { rows: [supplier] } = await client.query(
+        'SELECT payment_terms_days FROM supplier WHERE supplier_id = $1', [supplier_id]
+      );
+      const termsDays = supplier?.payment_terms_days || null;
+      const billNumber = await getNextDocumentNumber(client, 'BILL');
+
+      const { rows: [bill] } = await client.query(
+        `INSERT INTO supplier_bill (supplier_id, po_id, grn_id, bill_number, bill_date, due_date, total_amount, created_by)
+         VALUES ($1, $2, $3, $4, CURRENT_DATE, CASE WHEN $5::int IS NOT NULL THEN CURRENT_DATE + ($5::int || ' days')::interval ELSE NULL END, $6, $7)
+         ON CONFLICT (grn_id) WHERE grn_id IS NOT NULL DO NOTHING
+         RETURNING bill_id`,
+        [supplier_id, po_id || null, newGrnId, billNumber, termsDays, totalAmount, received_by]
+      );
+
+      if (bill) {
+        await apLedgerService.appendEntry(client, {
+          supplierId: supplier_id,
+          billId: bill.bill_id,
+          entryType: 'BILL_POSTED',
+          amount: totalAmount,
+          referenceNo: billNumber,
+          notes: `Auto-posted from goods receipt ${grn_number}`,
+          createdBy: received_by,
+        });
+      }
     }
 
     await client.query('COMMIT');

--- a/packages/api/routes/supplierRoutes.js
+++ b/packages/api/routes/supplierRoutes.js
@@ -64,15 +64,15 @@ router.get('/suppliers', protect, hasPermission('suppliers:view'), async (req, r
 
 // POST a new supplier
 router.post('/suppliers', protect, hasPermission('suppliers:edit'), async (req, res) => {
-    const { supplier_name, contact_person, phone, email, address, is_active } = req.body;
+    const { supplier_name, contact_person, phone, email, address, is_active, payment_terms_days } = req.body;
     if (!supplier_name) {
         return res.status(400).json({ message: 'Supplier name is required.' });
     }
     try {
         const supplier_code = await getNextDocumentNumber(db, 'SUPP');
         const newSupplier = await db.query(
-            'INSERT INTO supplier (supplier_code, supplier_name, contact_person, phone, email, address, is_active) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING *',
-            [supplier_code, supplier_name, contact_person, phone, email, address, is_active]
+            'INSERT INTO supplier (supplier_code, supplier_name, contact_person, phone, email, address, is_active, payment_terms_days) VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING *',
+            [supplier_code, supplier_name, contact_person, phone, email, address, is_active, payment_terms_days || null]
         );
         res.status(201).json(newSupplier.rows[0]);
     } catch (err) {
@@ -87,7 +87,7 @@ router.post('/suppliers', protect, hasPermission('suppliers:edit'), async (req, 
 // PUT - Update an existing supplier
 router.put('/suppliers/:id', protect, hasPermission('suppliers:edit'), async (req, res) => {
     const { id } = req.params;
-    const { supplier_name, contact_person, phone, email, address, is_active } = req.body;
+    const { supplier_name, contact_person, phone, email, address, is_active, payment_terms_days } = req.body;
 
     if (!supplier_name) {
         return res.status(400).json({ message: 'Supplier name is required' });
@@ -95,8 +95,8 @@ router.put('/suppliers/:id', protect, hasPermission('suppliers:edit'), async (re
 
     try {
         const updatedSupplier = await db.query(
-            'UPDATE supplier SET supplier_name = $1, contact_person = $2, phone = $3, email = $4, address = $5, is_active = $6 WHERE supplier_id = $7 RETURNING *',
-            [supplier_name, contact_person, phone, email, address, is_active, id]
+            'UPDATE supplier SET supplier_name = $1, contact_person = $2, phone = $3, email = $4, address = $5, is_active = $6, payment_terms_days = $7 WHERE supplier_id = $8 RETURNING *',
+            [supplier_name, contact_person, phone, email, address, is_active, payment_terms_days || null, id]
         );
 
         if (updatedSupplier.rows.length === 0) {

--- a/packages/api/services/apDueDateReminderService.js
+++ b/packages/api/services/apDueDateReminderService.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const cron = require('node-cron');
+const db = require('../db');
+
+let currentCronJob = null;
+
+/**
+ * Daily scan for supplier bills due today / overdue. Deliberately minimal, same
+ * philosophy as pdcReminderService.js: logs a structured summary rather than
+ * sending email/SMS — the AP monitoring page's in-app KPIs/aging view cover the
+ * UI side from data they already load.
+ */
+async function runApDueDateReminderScan() {
+    console.log('[ApDueDateReminderEngine] Starting daily AP due-date reminder scan...');
+    try {
+        const { rows: dueTodayRows } = await db.query(`
+            SELECT sb.bill_id, sb.bill_number, sb.total_amount - sb.amount_paid AS balance, s.supplier_name
+            FROM supplier_bill sb
+            JOIN supplier s ON s.supplier_id = sb.supplier_id
+            WHERE sb.status IN ('Unpaid', 'Partially Paid') AND COALESCE(sb.due_date, sb.bill_date) = CURRENT_DATE
+        `);
+        const { rows: overdueRows } = await db.query(`
+            SELECT sb.bill_id, sb.bill_number, sb.total_amount - sb.amount_paid AS balance, s.supplier_name
+            FROM supplier_bill sb
+            JOIN supplier s ON s.supplier_id = sb.supplier_id
+            WHERE sb.status IN ('Unpaid', 'Partially Paid') AND COALESCE(sb.due_date, sb.bill_date) < CURRENT_DATE
+        `);
+
+        console.log(`[ApDueDateReminderEngine] ${dueTodayRows.length} bill(s) due today, ${overdueRows.length} bill(s) overdue.`);
+
+        return {
+            dueToday: dueTodayRows.length,
+            overdue: overdueRows.length,
+        };
+    } catch (err) {
+        console.error('[ApDueDateReminderEngine] Error running reminder scan:', err.message);
+    }
+}
+
+async function startApDueDateReminderEngine() {
+    try {
+        const { rows } = await db.query("SELECT setting_value FROM settings WHERE setting_key = 'AP_DUE_DATE_REMINDER_SCHEDULE'");
+        const schedule = (rows.length > 0 && rows[0].setting_value) ? rows[0].setting_value : '0 7 * * *';
+
+        console.log(`[ApDueDateReminderEngine] Scheduling cron job with pattern: ${schedule}`);
+
+        if (currentCronJob) currentCronJob.stop();
+        currentCronJob = cron.schedule(schedule, () => { runApDueDateReminderScan(); });
+    } catch (err) {
+        console.error('[ApDueDateReminderEngine] Failed to start engine:', err.message);
+    }
+}
+
+module.exports = { startApDueDateReminderEngine, runApDueDateReminderScan };

--- a/packages/api/services/apPdcService.js
+++ b/packages/api/services/apPdcService.js
@@ -70,6 +70,7 @@ async function issueOutboundCheque(client, {
   referenceNumber = null,
   employeeId = null,
   userId = null,
+  overridePaymentHold = false,
 }) {
   if (!['SUPPLIER_PAYMENT', 'LOAN_PAYMENT', 'RENT', 'OTHER_EXPENSE'].includes(purposeType)) {
     throw new Error(`Invalid purpose_type: ${purposeType}`);
@@ -80,6 +81,19 @@ async function issueOutboundCheque(client, {
 
   if (purposeType === 'SUPPLIER_PAYMENT') {
     if (!supplierId) throw new Error('supplierId is required for SUPPLIER_PAYMENT cheques');
+
+    const { rows: [supplier] } = await client.query(
+      `SELECT payment_hold, payment_hold_reason FROM supplier WHERE supplier_id = $1`,
+      [supplierId]
+    );
+    if (supplier?.payment_hold && !overridePaymentHold) {
+      const err = new Error(
+        `Supplier is on payment hold${supplier.payment_hold_reason ? ': ' + supplier.payment_hold_reason : ''}. `
+        + 'Pass override_payment_hold=true with ap:manage permission to proceed anyway.'
+      );
+      err.code = 'PAYMENT_HOLD_BLOCKED';
+      throw err;
+    }
 
     const { rows: [payment] } = await client.query(
       `INSERT INTO ap_payment

--- a/packages/api/tests/goodsReceiptInventory.test.js
+++ b/packages/api/tests/goodsReceiptInventory.test.js
@@ -136,6 +136,10 @@ describe('Goods Receipt Inventory & Pricing Routes', () => {
                 .mockResolvedValueOnce({}) // UPDATE purchase_order_line
                 .mockResolvedValueOnce({ rows: [{ total_ordered: 10, total_received: 10 }] }) // SELECT PO sums
                 .mockResolvedValueOnce({}) // UPDATE purchase_order status
+                .mockResolvedValueOnce({ rows: [{ payment_terms_days: null }] }) // SELECT supplier.payment_terms_days
+                .mockResolvedValueOnce({ rows: [{ bill_id: 555 }] }) // INSERT supplier_bill RETURNING bill_id
+                .mockResolvedValueOnce({}) // UPDATE goods_receipt SET bill_id
+                .mockResolvedValueOnce({ rows: [{ ledger_id: 1 }] }) // apLedgerService.appendEntry -> append_ap_ledger_entry()
                 .mockResolvedValueOnce({}); // COMMIT
 
             const res = await request(app)

--- a/packages/web/src/components/SearchBar.jsx
+++ b/packages/web/src/components/SearchBar.jsx
@@ -22,7 +22,7 @@ const SearchBar = forwardRef(({
 
     return (
         <div className={`relative ${className}`}>
-            <svg className="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+            <svg className="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-gray-400 dark:text-slate-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor">
                 <path strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" d="M21 21l-4.35-4.35M10.5 18a7.5 7.5 0 1 1 0-15 7.5 7.5 0 0 1 0 15z" />
             </svg>
             <input
@@ -34,7 +34,7 @@ const SearchBar = forwardRef(({
                 onChange={e => onChange(e.target.value)}
                 placeholder={placeholder}
                 disabled={disabled}
-                className="w-full px-3 py-2 pl-10 pr-10 border border-gray-300 rounded-lg"
+                className="w-full px-3 py-2 pl-10 pr-10 border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100 placeholder:text-gray-400 dark:placeholder:text-slate-500 rounded-lg disabled:opacity-60 disabled:cursor-not-allowed"
                 {...rest}
             />
 
@@ -42,7 +42,7 @@ const SearchBar = forwardRef(({
                 type="button"
                 onClick={() => { onClear(); }}
                 aria-label="Clear search"
-                className={`absolute right-2 top-1/2 -translate-y-1/2 h-6 w-6 flex items-center justify-center rounded-md focus:outline-none ${showClear ? 'text-gray-600 hover:bg-gray-100' : 'hidden'}`}
+                className={`absolute right-2 top-1/2 -translate-y-1/2 h-6 w-6 flex items-center justify-center rounded-md focus:outline-none ${showClear ? 'text-gray-600 dark:text-slate-400 hover:bg-gray-100 dark:hover:bg-slate-700' : 'hidden'}`}
             >
                 {/* simple X icon */}
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">

--- a/packages/web/src/components/accounts-payable/AddPayableModal.jsx
+++ b/packages/web/src/components/accounts-payable/AddPayableModal.jsx
@@ -1,0 +1,128 @@
+import { useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
+import api from '../../api';
+import Modal from '../ui/Modal';
+import Combobox from '../ui/Combobox';
+
+const today = () => new Date().toISOString().slice(0, 10);
+
+const BLANK_FORM = { supplier_id: '', bill_number: '', bill_date: today(), due_date: '', total_amount: '', notes: '' };
+
+/**
+ * Creates a supplier_bill directly, without going through a Purchase Order or
+ * Goods Receipt — for invoices/bills that arrive before (or without) a formal
+ * stock-in, e.g. services, or paperwork that precedes the physical delivery.
+ * Items can be attached to the resulting bill later via AttachItemsModal, which
+ * performs the actual stock-in when the goods do arrive.
+ */
+const AddPayableModal = ({ isOpen, onClose, onCreated, presetSupplier = null }) => {
+    const [suppliers, setSuppliers] = useState([]);
+    const [form, setForm] = useState(BLANK_FORM);
+    const [saving, setSaving] = useState(false);
+
+    useEffect(() => {
+        if (!isOpen) return;
+        setForm({ ...BLANK_FORM, supplier_id: presetSupplier?.supplier_id || '' });
+        if (!presetSupplier) {
+            api.get('/suppliers', { params: { status: 'active' } })
+                .then(res => setSuppliers(res.data?.data || res.data || []))
+                .catch(() => toast.error('Failed to load suppliers'));
+        }
+    }, [isOpen, presetSupplier]);
+
+    const handleChange = (field, value) => setForm(prev => ({ ...prev, [field]: value }));
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        const amount = parseFloat(form.total_amount);
+        if (!form.supplier_id) { toast.error('Select a supplier'); return; }
+        if (!amount || amount <= 0) { toast.error('Enter a valid total amount'); return; }
+
+        setSaving(true);
+        try {
+            await api.post('/ap/supplier-bills', {
+                supplier_id: form.supplier_id,
+                bill_number: form.bill_number.trim() || undefined,
+                bill_date: form.bill_date || undefined,
+                due_date: form.due_date || undefined,
+                total_amount: amount,
+                notes: form.notes.trim() || undefined,
+            });
+            toast.success('Payable created');
+            onCreated && onCreated();
+            onClose();
+        } catch (err) {
+            toast.error(err.response?.data?.message || 'Failed to create payable');
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const inputClass = "w-full px-3 py-2 border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500";
+    const labelClass = "block text-sm font-medium text-gray-700 dark:text-slate-300 mb-1";
+
+    return (
+        <Modal isOpen={isOpen} onClose={onClose} title="New Payable" maxWidth="max-w-lg">
+            <form onSubmit={handleSubmit} className="space-y-4">
+                <div>
+                    <label className={labelClass}>Supplier</label>
+                    {presetSupplier ? (
+                        <div className="px-3 py-2 border border-gray-200 dark:border-slate-700 rounded-lg bg-gray-50 dark:bg-slate-900 text-gray-900 dark:text-slate-100 text-sm">
+                            {presetSupplier.supplier_name}
+                        </div>
+                    ) : (
+                        <Combobox
+                            options={suppliers.map(s => ({ value: s.supplier_id, label: s.supplier_name }))}
+                            value={form.supplier_id}
+                            onChange={(val) => handleChange('supplier_id', val)}
+                            placeholder="Select a Supplier"
+                        />
+                    )}
+                </div>
+
+                <div className="grid grid-cols-2 gap-4">
+                    <div>
+                        <label className={labelClass}>Bill Number</label>
+                        <input type="text" value={form.bill_number} onChange={(e) => handleChange('bill_number', e.target.value)}
+                            placeholder="Auto-generated if blank" className={inputClass} />
+                    </div>
+                    <div>
+                        <label className={labelClass}>Bill Date</label>
+                        <input type="date" value={form.bill_date} onChange={(e) => handleChange('bill_date', e.target.value)} className={inputClass} />
+                    </div>
+                </div>
+
+                <div className="grid grid-cols-2 gap-4">
+                    <div>
+                        <label className={labelClass}>Due Date</label>
+                        <input type="date" value={form.due_date} onChange={(e) => handleChange('due_date', e.target.value)} className={inputClass} />
+                        <p className="text-xs text-gray-500 dark:text-slate-400 mt-1">Leave blank to auto-compute from the supplier's payment terms.</p>
+                    </div>
+                    <div>
+                        <label className={labelClass}>Total Amount</label>
+                        <input type="number" step="0.01" min="0" required value={form.total_amount}
+                            onChange={(e) => handleChange('total_amount', e.target.value)} className={inputClass} />
+                    </div>
+                </div>
+
+                <div>
+                    <label className={labelClass}>Notes</label>
+                    <textarea value={form.notes} onChange={(e) => handleChange('notes', e.target.value)} rows={2} className={inputClass} />
+                </div>
+
+                <p className="text-xs text-gray-500 dark:text-slate-400">
+                    This records the payable immediately. Once the physical goods arrive, use <span className="font-medium">Attach Items</span> on the bill to receive stock against it.
+                </p>
+
+                <div className="flex justify-end gap-3 pt-2">
+                    <button type="button" onClick={onClose} className="px-4 py-2 bg-gray-200 dark:bg-slate-700 text-gray-800 dark:text-slate-100 rounded-lg hover:bg-gray-300 dark:hover:bg-slate-600">Cancel</button>
+                    <button type="submit" disabled={saving} className="px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 disabled:opacity-50">
+                        {saving ? 'Saving...' : 'Create Payable'}
+                    </button>
+                </div>
+            </form>
+        </Modal>
+    );
+};
+
+export default AddPayableModal;

--- a/packages/web/src/components/accounts-payable/AttachItemsModal.jsx
+++ b/packages/web/src/components/accounts-payable/AttachItemsModal.jsx
@@ -1,0 +1,178 @@
+import { useEffect, useRef, useState } from 'react';
+import toast from 'react-hot-toast';
+import api from '../../api';
+import Modal from '../ui/Modal';
+import Icon from '../ui/Icon';
+import { ICONS } from '../../constants';
+import { formatCurrency } from '../../utils/currency';
+import { enrichPartsArray } from '../../helpers/applicationCache';
+import { useAuth } from '../../contexts/AuthContext';
+
+/**
+ * Attaches items to a pre-existing (manually-created) supplier_bill by posting a
+ * real Goods Receipt against it — this is the point where a manual payable actually
+ * moves inventory, via the same POST /goods-receipts endpoint the main Goods Receipt
+ * page uses, just scoped with bill_id so it doesn't also auto-create a new bill.
+ */
+const AttachItemsModal = ({ isOpen, onClose, supplierId, supplierName, bill, onAttached }) => {
+    const { user } = useAuth();
+    const [searchTerm, setSearchTerm] = useState('');
+    const [searchResults, setSearchResults] = useState([]);
+    const [lines, setLines] = useState([]);
+    const [posting, setPosting] = useState(false);
+    const debounceRef = useRef(null);
+
+    useEffect(() => {
+        if (!isOpen) { setLines([]); setSearchTerm(''); setSearchResults([]); }
+    }, [isOpen]);
+
+    useEffect(() => {
+        if (!searchTerm.trim()) { setSearchResults([]); return; }
+        if (debounceRef.current) clearTimeout(debounceRef.current);
+        debounceRef.current = setTimeout(async () => {
+            try {
+                const { data } = await api.get('/power-search/parts', { params: { keyword: searchTerm } });
+                setSearchResults(await enrichPartsArray(data || []));
+            } catch {
+                toast.error('Search failed.');
+            }
+        }, 300);
+        return () => clearTimeout(debounceRef.current);
+    }, [searchTerm]);
+
+    const addPart = (part) => {
+        setLines((prev) => {
+            const existing = prev.find(l => l.part_id === part.part_id);
+            if (existing) {
+                return prev.map(l => l.part_id === part.part_id ? { ...l, quantity: l.quantity + 1 } : l);
+            }
+            return [...prev, {
+                part_id: part.part_id,
+                display_name: part.display_name,
+                quantity: 1,
+                cost_price: typeof part.last_cost !== 'undefined' ? part.last_cost : 0,
+            }];
+        });
+        setSearchTerm('');
+        setSearchResults([]);
+    };
+
+    const updateLine = (partId, field, value) => {
+        const numeric = parseFloat(value) || 0;
+        setLines(lines.map(l => l.part_id === partId ? { ...l, [field]: numeric } : l));
+    };
+
+    const removeLine = (partId) => setLines(lines.filter(l => l.part_id !== partId));
+
+    const itemsTotal = lines.reduce((sum, l) => sum + (parseFloat(l.quantity) || 0) * (parseFloat(l.cost_price) || 0), 0);
+
+    const handleSubmit = async () => {
+        if (lines.length === 0) { toast.error('Add at least one item'); return; }
+        setPosting(true);
+        try {
+            await api.post('/goods-receipts', {
+                supplier_id: supplierId,
+                received_by: user.employee_id,
+                bill_id: bill.bill_id,
+                lines: lines.map(l => ({ part_id: l.part_id, quantity: l.quantity, cost_price: l.cost_price, sale_price: l.cost_price })),
+            });
+            toast.success('Items attached — stock received');
+            onAttached && onAttached();
+            onClose();
+        } catch (err) {
+            toast.error(err.response?.data?.message || 'Failed to attach items');
+        } finally {
+            setPosting(false);
+        }
+    };
+
+    if (!bill) return null;
+
+    return (
+        <Modal isOpen={isOpen} onClose={onClose} title={`Attach Items — ${bill.bill_number || `Bill #${bill.bill_id}`}`} maxWidth="max-w-2xl">
+            <div className="space-y-4">
+                <p className="text-sm text-gray-500 dark:text-slate-400">
+                    Receiving items here creates a real goods receipt for <span className="font-medium text-gray-700 dark:text-slate-300">{supplierName}</span> and increases stock, linked to this payable.
+                </p>
+
+                <div className="relative">
+                    <input
+                        type="text"
+                        value={searchTerm}
+                        onChange={(e) => setSearchTerm(e.target.value)}
+                        placeholder="Search by part name or SKU..."
+                        className="w-full px-3 py-2 border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500"
+                    />
+                    {searchResults.length > 0 && (
+                        <ul className="absolute z-10 w-full bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-md mt-1 shadow-lg max-h-48 overflow-y-auto">
+                            {searchResults.map((part) => (
+                                <li key={part.part_id} onClick={() => addPart(part)}
+                                    className="px-4 py-2 cursor-pointer hover:bg-primary-50 dark:hover:bg-slate-700/60 text-sm text-gray-800 dark:text-slate-100 truncate">
+                                    {part.display_name}
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                </div>
+
+                <div className="border border-gray-200 dark:border-slate-700 rounded-lg overflow-hidden">
+                    <table className="w-full text-left text-sm">
+                        <thead className="bg-gray-50 dark:bg-slate-900/60 border-b border-gray-200 dark:border-slate-700">
+                            <tr>
+                                <th className="p-2 font-semibold text-gray-600 dark:text-slate-300">Part</th>
+                                <th className="p-2 font-semibold text-gray-600 dark:text-slate-300 w-20 text-center">Qty</th>
+                                <th className="p-2 font-semibold text-gray-600 dark:text-slate-300 w-28 text-center">Cost</th>
+                                <th className="p-2 font-semibold text-gray-600 dark:text-slate-300 w-24 text-right">Total</th>
+                                <th className="p-2 w-10"></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {lines.map((line) => (
+                                <tr key={line.part_id} className="border-b border-gray-100 dark:border-slate-700">
+                                    <td className="p-2 text-gray-800 dark:text-slate-100 truncate max-w-[10rem]">{line.display_name}</td>
+                                    <td className="p-2">
+                                        <input type="number" value={line.quantity} onFocus={(e) => e.target.select()}
+                                            onChange={(e) => updateLine(line.part_id, 'quantity', e.target.value)}
+                                            className="w-full h-8 px-1 text-center border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100 rounded" />
+                                    </td>
+                                    <td className="p-2">
+                                        <input type="number" step="0.01" value={line.cost_price} onFocus={(e) => e.target.select()}
+                                            onChange={(e) => updateLine(line.part_id, 'cost_price', e.target.value)}
+                                            className="w-full h-8 px-1 text-center border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100 rounded" />
+                                    </td>
+                                    <td className="p-2 text-right font-mono text-gray-900 dark:text-slate-100">
+                                        {formatCurrency((parseFloat(line.quantity) || 0) * (parseFloat(line.cost_price) || 0))}
+                                    </td>
+                                    <td className="p-2 text-center">
+                                        <button onClick={() => removeLine(line.part_id)} className="text-danger-500 dark:text-danger-400 hover:text-danger-700">
+                                            <Icon path={ICONS.trash} className="h-4 w-4" />
+                                        </button>
+                                    </td>
+                                </tr>
+                            ))}
+                            {lines.length === 0 && (
+                                <tr><td colSpan="5" className="p-4 text-center text-gray-500 dark:text-slate-400">No items added yet.</td></tr>
+                            )}
+                        </tbody>
+                    </table>
+                </div>
+
+                <div className="flex items-center justify-between text-sm border-t border-gray-200 dark:border-slate-700 pt-3">
+                    <div className="space-y-0.5">
+                        <div>Items Total: <span className="font-mono font-semibold text-gray-900 dark:text-slate-100">{formatCurrency(itemsTotal)}</span></div>
+                        <div>Bill Total: <span className="font-mono text-gray-600 dark:text-slate-400">{formatCurrency(bill.total_amount)}</span></div>
+                    </div>
+                    <div className="flex gap-2">
+                        <button onClick={onClose} className="px-4 py-2 bg-gray-200 dark:bg-slate-700 text-gray-800 dark:text-slate-100 rounded-lg hover:bg-gray-300 dark:hover:bg-slate-600">Cancel</button>
+                        <button onClick={handleSubmit} disabled={posting || lines.length === 0}
+                            className="px-4 py-2 bg-success-600 text-white rounded-lg hover:bg-success-700 disabled:opacity-50">
+                            {posting ? 'Receiving...' : 'Attach & Receive Stock'}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </Modal>
+    );
+};
+
+export default AttachItemsModal;

--- a/packages/web/src/components/accounts-payable/BillAgingSummaryChart.jsx
+++ b/packages/web/src/components/accounts-payable/BillAgingSummaryChart.jsx
@@ -1,0 +1,71 @@
+/**
+ * Supplier bill aging summary — horizontal stacked bar with color-coded
+ * age buckets (Current, 1-30, 31-60, 61-90, 90+ Days). Structural clone of
+ * InvoiceAgingSummaryChart.jsx (AR) with dark-mode classes added.
+ */
+import { exportToCSV } from '../../utils/csv';
+import { formatCurrency } from '../../utils/currency';
+
+const BillAgingSummaryChart = ({ agingData, loading = false, onBucketClick }) => {
+    if (loading) {
+        return (
+            <div className="bg-white dark:bg-slate-800 p-6 rounded-lg border border-gray-200 dark:border-slate-700 animate-pulse">
+                <div className="h-6 bg-gray-200 dark:bg-slate-700 rounded w-48 mb-4"></div>
+                <div className="w-full bg-gray-200 dark:bg-slate-700 rounded-full h-8 mb-4"></div>
+                <div className="flex justify-between">
+                    {[...Array(5)].map((_, i) => (
+                        <div key={i} className="flex items-center gap-x-2">
+                            <div className="w-3 h-3 rounded-full bg-gray-200 dark:bg-slate-700"></div>
+                            <div className="h-3 bg-gray-200 dark:bg-slate-700 rounded w-16"></div>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        );
+    }
+
+    const total = agingData.reduce((sum, item) => sum + item.value, 0);
+
+    const colors = {
+        'Current': 'bg-blue-500',
+        '1-30 Days': 'bg-blue-400',
+        '31-60 Days': 'bg-yellow-400',
+        '61-90 Days': 'bg-orange-400',
+        '90+ Days': 'bg-red-500',
+    };
+
+    return (
+        <div className="bg-white dark:bg-slate-800 p-6 rounded-lg border border-gray-200 dark:border-slate-700 mb-6">
+            <div className="flex items-center justify-between mb-4">
+                <h2 className="text-xl font-semibold text-gray-800 dark:text-slate-100">Supplier Bill Aging Summary</h2>
+                <button
+                    onClick={() => exportToCSV(agingData, 'ap-aging-summary.csv')}
+                    className="text-sm px-3 py-1 border border-gray-300 dark:border-slate-600 rounded-md text-gray-700 dark:text-slate-200 hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors"
+                >
+                    Export
+                </button>
+            </div>
+            <div className="w-full bg-gray-200 dark:bg-slate-700 rounded-full h-8 flex overflow-hidden">
+                {agingData.map(item => (
+                    <div
+                        key={item.name}
+                        className={`h-full ${colors[item.name]} transition-all duration-300 ease-in-out hover:opacity-80 cursor-pointer`}
+                        style={{ width: `${total > 0 ? (item.value / total) * 100 : 0}%` }}
+                        title={`${item.name}: ${formatCurrency(item.value)} (${total > 0 ? ((item.value / total) * 100).toFixed(1) : 0}%) - Click to view details`}
+                        onClick={() => onBucketClick && onBucketClick(item.name)}
+                    ></div>
+                ))}
+            </div>
+            <div className="flex justify-between text-sm text-gray-600 dark:text-slate-400 mt-4 flex-wrap gap-2">
+                {agingData.map(item => (
+                    <div key={item.name} className="flex items-center gap-x-2">
+                        <span className={`w-3 h-3 rounded-full ${colors[item.name]}`}></span>
+                        <span className="whitespace-nowrap">{item.name}: {formatCurrency(item.value)}</span>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+};
+
+export default BillAgingSummaryChart;

--- a/packages/web/src/components/accounts-payable/SupplierSummaryTable.jsx
+++ b/packages/web/src/components/accounts-payable/SupplierSummaryTable.jsx
@@ -1,0 +1,120 @@
+import { useEffect, useState } from 'react';
+import { formatCurrency } from '../../utils/currency';
+import SortableHeader from '../ui/SortableHeader';
+import StatusBadge from '../ui/StatusBadge';
+
+const STATUS_TONE = {
+    'Current': 'success',
+    '1-30 Days': 'info',
+    '31-60 Days': 'warning',
+    '61-90 Days': 'warning',
+    '90+ Days': 'danger',
+};
+
+const SupplierSummaryTable = ({
+    suppliers = [],
+    onSupplierClick,
+    loading = false,
+    searchTerm = '',
+    onSearchChange,
+    statusFilter = 'ALL',
+    onStatusFilterChange,
+    sortConfig = { key: 'bill_count', direction: 'DESC' },
+    onSortChange,
+}) => {
+    const [localSearch, setLocalSearch] = useState(searchTerm);
+
+    useEffect(() => { setLocalSearch(searchTerm); }, [searchTerm]);
+    useEffect(() => {
+        const timer = setTimeout(() => {
+            if (localSearch !== searchTerm && onSearchChange) onSearchChange(localSearch);
+        }, 300);
+        return () => clearTimeout(timer);
+    }, [localSearch, searchTerm, onSearchChange]);
+
+    const handleSort = (key, direction) => onSortChange && onSortChange({ key, direction });
+
+    return (
+        <div className="bg-white dark:bg-slate-800 rounded-lg border border-gray-200 dark:border-slate-700 overflow-hidden">
+            <div className="p-6 flex flex-col md:flex-row items-stretch md:items-center justify-between gap-4 border-b border-gray-100 dark:border-slate-700">
+                <div>
+                    <h2 className="text-xl font-semibold text-gray-800 dark:text-slate-100">Supplier Accounts Payable</h2>
+                    <p className="text-xs text-gray-500 dark:text-slate-400 mt-1">Balances, next due date, and payment-hold status per supplier</p>
+                </div>
+                <div className="flex flex-wrap items-center gap-3">
+                    <div className="relative w-48 sm:w-64">
+                        <input
+                            type="text"
+                            placeholder="Search name, contact, phone..."
+                            value={localSearch}
+                            onChange={(e) => setLocalSearch(e.target.value)}
+                            className="w-full pl-8 pr-3 py-1.5 text-sm border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
+                        />
+                        <svg className="w-4 h-4 text-gray-400 dark:text-slate-500 absolute left-2.5 top-1/2 -translate-y-1/2 pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                        </svg>
+                    </div>
+                    <select
+                        value={statusFilter}
+                        onChange={(e) => onStatusFilterChange && onStatusFilterChange(e.target.value)}
+                        className="px-3 py-1.5 text-sm border border-gray-300 dark:border-slate-600 rounded-md bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                    >
+                        <option value="ALL">All Statuses</option>
+                        <option value="CURRENT">Current / Good Standing</option>
+                        <option value="OVERDUE">Overdue Payables</option>
+                        <option value="PAYMENT_HOLD">Payment Hold Only</option>
+                    </select>
+                </div>
+            </div>
+
+            <div className="overflow-x-auto">
+                <table className="w-full text-sm text-left text-gray-500 dark:text-slate-400">
+                    <thead className="text-xs text-gray-700 dark:text-slate-300 uppercase bg-gray-50 dark:bg-slate-900/60 border-b border-gray-200 dark:border-slate-700">
+                        <tr>
+                            <SortableHeader column="supplier_name" sortConfig={sortConfig} onSort={handleSort}>Supplier</SortableHeader>
+                            <SortableHeader column="bill_count" sortConfig={sortConfig} onSort={handleSort}>Open Bills</SortableHeader>
+                            <SortableHeader column="earliest_due_date" sortConfig={sortConfig} onSort={handleSort}>Next Due Date</SortableHeader>
+                            <SortableHeader column="total_balance_due" sortConfig={sortConfig} onSort={handleSort}>Payable Due</SortableHeader>
+                            <SortableHeader column="status" sortConfig={sortConfig} onSort={handleSort}>Status</SortableHeader>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {suppliers.map((supplier, index) => (
+                            <tr
+                                key={supplier.supplier_id || index}
+                                onClick={() => onSupplierClick(supplier)}
+                                className="bg-white dark:bg-slate-800 border-b border-gray-100 dark:border-slate-700 hover:bg-gray-50 dark:hover:bg-slate-700/50 transition-colors cursor-pointer"
+                            >
+                                <td className="px-6 py-4 font-medium text-gray-900 dark:text-slate-100 whitespace-nowrap">
+                                    <div className="flex items-center gap-2">
+                                        <span>{supplier.supplier_name}</span>
+                                        {supplier.payment_hold && <StatusBadge tone="danger" label="ON HOLD" />}
+                                    </div>
+                                </td>
+                                <td className="px-6 py-4 text-center">{supplier.bill_count}</td>
+                                <td className="px-6 py-4">
+                                    {supplier.earliest_due_date ? new Date(supplier.earliest_due_date).toLocaleDateString() : 'N/A'}
+                                </td>
+                                <td className="px-6 py-4 font-mono font-medium text-gray-900 dark:text-slate-100">
+                                    {formatCurrency(supplier.total_balance_due)}
+                                </td>
+                                <td className="px-6 py-4">
+                                    <StatusBadge tone={STATUS_TONE[supplier.status] || 'neutral'} label={supplier.status} />
+                                </td>
+                            </tr>
+                        ))}
+                        {!loading && suppliers.length === 0 && (
+                            <tr>
+                                <td colSpan="5" className="px-6 py-8 text-center text-gray-500 dark:text-slate-400">
+                                    No matching supplier accounts found
+                                </td>
+                            </tr>
+                        )}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    );
+};
+
+export default SupplierSummaryTable;

--- a/packages/web/src/components/forms/SupplierForm.jsx
+++ b/packages/web/src/components/forms/SupplierForm.jsx
@@ -1,15 +1,14 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 
-const SupplierForm = ({ supplier, onSave, onCancel }) => {
-    const [formData, setFormData] = useState({
-        supplier_name: '', contact_person: '', phone: '', 
-        email: '', address: '', is_active: true 
-    });
+const BLANK_FORM = {
+    supplier_name: '', contact_person: '', phone: '',
+    email: '', address: '', payment_terms_days: '', is_active: true
+};
 
-    const initialFormData = useMemo(() => supplier ? { ...supplier } : { 
-        supplier_name: '', contact_person: '', phone: '', 
-        email: '', address: '', is_active: true 
-    }, [supplier]);
+const SupplierForm = ({ supplier, onSave, onCancel }) => {
+    const [formData, setFormData] = useState(BLANK_FORM);
+
+    const initialFormData = useMemo(() => supplier ? { ...BLANK_FORM, ...supplier } : BLANK_FORM, [supplier]);
 
     const isFormDirty = useMemo(() => {
         const keys = Object.keys(formData);
@@ -26,14 +25,7 @@ const SupplierForm = ({ supplier, onSave, onCancel }) => {
     };
 
     useEffect(() => {
-        if (supplier) {
-            setFormData(supplier);
-        } else {
-             setFormData({ 
-                supplier_name: '', contact_person: '', phone: '', 
-                email: '', address: '', is_active: true 
-            });
-        }
+        setFormData(supplier ? { ...BLANK_FORM, ...supplier } : BLANK_FORM);
     }, [supplier]);
 
     const handleChange = (e) => {
@@ -43,7 +35,10 @@ const SupplierForm = ({ supplier, onSave, onCancel }) => {
 
     const handleSubmit = useCallback((e) => {
         e.preventDefault();
-        onSave(formData);
+        onSave({
+            ...formData,
+            payment_terms_days: formData.payment_terms_days === '' ? null : parseInt(formData.payment_terms_days, 10),
+        });
     }, [formData, onSave]);
 
     useEffect(() => {
@@ -76,30 +71,55 @@ const SupplierForm = ({ supplier, onSave, onCancel }) => {
         return () => document.removeEventListener('keydown', handleKeyDown);
     }, [handleSubmit, onCancel, isFormDirty]);
 
+    const inputClass = "w-full px-3 py-2 border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100 rounded-lg";
+    const labelClass = "block text-sm font-medium text-gray-700 dark:text-slate-300 mb-1";
+
     return (
         <form onSubmit={handleSubmit} className="space-y-4">
             <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Supplier Name</label>
-                <input type="text" name="supplier_name" value={formData.supplier_name} onChange={handleChange} className="w-full px-3 py-2 border border-gray-300 rounded-lg" required />
+                <label className={labelClass}>Supplier Name</label>
+                <input type="text" name="supplier_name" value={formData.supplier_name} onChange={handleChange} className={inputClass} required />
             </div>
             <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Contact Person</label>
-                <input type="text" name="contact_person" value={formData.contact_person} onChange={handleChange} className="w-full px-3 py-2 border border-gray-300 rounded-lg" />
+                <label className={labelClass}>Contact Person</label>
+                <input type="text" name="contact_person" value={formData.contact_person || ''} onChange={handleChange} className={inputClass} />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+                <div>
+                    <label className={labelClass}>Phone</label>
+                    <input type="text" name="phone" value={formData.phone || ''} onChange={handleChange} className={inputClass} />
+                </div>
+                <div>
+                    <label className={labelClass}>Email</label>
+                    <input type="email" name="email" value={formData.email || ''} onChange={handleChange} className={inputClass} />
+                </div>
             </div>
             <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Phone</label>
-                <input type="text" name="phone" value={formData.phone} onChange={handleChange} className="w-full px-3 py-2 border border-gray-300 rounded-lg" />
+                <label className={labelClass}>Address</label>
+                <textarea name="address" value={formData.address || ''} onChange={handleChange} rows={2} className={inputClass} />
+            </div>
+            <div>
+                <label className={labelClass}>Payment Terms (days)</label>
+                <input
+                    type="number"
+                    name="payment_terms_days"
+                    min="0"
+                    placeholder="e.g. 30"
+                    value={formData.payment_terms_days ?? ''}
+                    onChange={handleChange}
+                    className={inputClass}
+                />
+                <p className="text-xs text-gray-500 dark:text-slate-400 mt-1">Used to auto-compute bill due dates when goods are received from this supplier.</p>
             </div>
 
-            {/* NEWLY ADDED */}
             <div className="flex items-center">
-                <input type="checkbox" name="is_active" checked={formData.is_active} onChange={handleChange} className="h-4 w-4 text-blue-600 border-gray-300 rounded" />
-                <label className="ml-2 block text-sm text-gray-900">Account is Active</label>
+                <input type="checkbox" name="is_active" checked={formData.is_active} onChange={handleChange} className="h-4 w-4 text-primary-600 border-gray-300 dark:border-slate-600 rounded" />
+                <label className="ml-2 block text-sm text-gray-900 dark:text-slate-100">Account is Active</label>
             </div>
 
             <div className="mt-6 flex justify-end space-x-4">
-                <button type="button" onClick={onCancel} className="px-4 py-2 bg-gray-200 text-gray-800 rounded-lg hover:bg-gray-300">Cancel</button>
-                <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700">Save</button>
+                <button type="button" onClick={onCancel} className="px-4 py-2 bg-gray-200 dark:bg-slate-700 text-gray-800 dark:text-slate-100 rounded-lg hover:bg-gray-300 dark:hover:bg-slate-600">Cancel</button>
+                <button type="submit" className="px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700">Save</button>
             </div>
         </form>
     );

--- a/packages/web/src/components/layout/MainLayout.jsx
+++ b/packages/web/src/components/layout/MainLayout.jsx
@@ -18,6 +18,7 @@ import SettingsPage from '../../pages/SettingsPage';
 import POSPage from '../../pages/POSPage';
 import PurchaseOrderPage from '../../pages/PurchaseOrderPage';
 import AccountsReceivablePage from '../../pages/AccountsReceivablePage';
+import AccountsPayablePage from '../../pages/AccountsPayablePage';
 import ChequesTreasuryPage from '../../pages/ChequesTreasuryPage';
 import SalesHistoryPage from '../../pages/SalesHistoryPage'; // <-- Import new page
 import DocumentsPage from '../../pages/DocumentsPage';
@@ -50,6 +51,7 @@ const MainLayout = ({ user, onLogout, onNavigate, currentPage, pageState, posLin
             case 'documents': return <DocumentsPage />;
             case 'purchase_orders': return <PurchaseOrderPage />;
             case 'ar': return <AccountsReceivablePage />;
+            case 'ap': return <AccountsPayablePage onNavigate={onNavigate} />;
             case 'cheques_treasury': return <ChequesTreasuryPage />;
             case 'soa_gen': return <SoaGenPage />;
             case 'staged_sales': return <CashierApprovalDesk onNavigate={onNavigate} />;

--- a/packages/web/src/components/layout/Sidebar.jsx
+++ b/packages/web/src/components/layout/Sidebar.jsx
@@ -58,6 +58,7 @@ const CATEGORIES = [
         title: 'Finance & Expenses',
         icon: ICONS.receipt,
         items: [
+            { name: 'A/P',                 icon: ICONS.truck,   page: 'ap',                 permission: 'ap:view' },
             { name: 'Cheques & Treasury', icon: ICONS.bank,    page: 'cheques_treasury',   permission: ['cheques:view', 'pdc:view', 'ar:view', 'ap-pdc:view'] },
             { name: 'Bulk SOA Generator', icon: ICONS.documents, page: 'soa_gen',          permission: 'ar:view' },
             { name: 'Expenses',           icon: ICONS.receipt, page: 'expenses',           permission: 'expenses:view' },

--- a/packages/web/src/components/suppliers/SupplierDetailDrawer.jsx
+++ b/packages/web/src/components/suppliers/SupplierDetailDrawer.jsx
@@ -118,7 +118,7 @@ const BillItemsPanel = ({ billId }) => {
         <div className="mt-2 border-t border-gray-100 dark:border-slate-700 pt-2 space-y-1">
             {items.data.map((item) => (
                 <div key={item.grn_line_id} className="flex items-center justify-between text-xs">
-                    <span className="text-gray-700 dark:text-slate-300 truncate max-w-[12rem]">{item.detail || item.internal_sku} · {item.grn_number}</span>
+                    <span className="text-gray-700 dark:text-slate-300 truncate max-w-[16rem]">{item.display_name || item.internal_sku}</span>
                     <span className="font-mono text-gray-600 dark:text-slate-400">{item.quantity} × {formatCurrency(item.cost_price)}</span>
                 </div>
             ))}

--- a/packages/web/src/components/suppliers/SupplierDetailDrawer.jsx
+++ b/packages/web/src/components/suppliers/SupplierDetailDrawer.jsx
@@ -1,13 +1,15 @@
 import { useCallback, useEffect, useState } from 'react';
 import toast from 'react-hot-toast';
 import api from '../../api';
-import Drawer from '../ui/Drawer';
+import Modal from '../ui/Modal';
 import SegmentedTabs from '../ui/SegmentedTabs';
 import StatusBadge from '../ui/StatusBadge';
 import Icon from '../ui/Icon';
 import { ICONS } from '../../constants';
 import { formatCurrency } from '../../utils/currency';
 import { useAuth } from '../../contexts/AuthContext';
+import AddPayableModal from '../accounts-payable/AddPayableModal';
+import AttachItemsModal from '../accounts-payable/AttachItemsModal';
 
 const BILL_STATUS_TONE = { 'Unpaid': 'danger', 'Partially Paid': 'warning', 'Paid': 'success' };
 
@@ -89,12 +91,57 @@ const ProfileTab = ({ supplier, onSupplierUpdated, canManage }) => {
     );
 };
 
-const BillsTab = ({ supplierId, canManage }) => {
+const BillItemsPanel = ({ billId }) => {
+    const [items, setItems] = useState(null);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        (async () => {
+            setLoading(true);
+            try {
+                const { data } = await api.get(`/ap/supplier-bills/${billId}/items`);
+                setItems(data);
+            } catch {
+                toast.error('Failed to load attached items');
+            } finally {
+                setLoading(false);
+            }
+        })();
+    }, [billId]);
+
+    if (loading) return <div className="mt-2 text-xs text-gray-500 dark:text-slate-400">Loading items...</div>;
+    if (!items || items.data.length === 0) {
+        return <div className="mt-2 text-xs text-gray-500 dark:text-slate-400">No items attached to this bill yet.</div>;
+    }
+
+    return (
+        <div className="mt-2 border-t border-gray-100 dark:border-slate-700 pt-2 space-y-1">
+            {items.data.map((item) => (
+                <div key={item.grn_line_id} className="flex items-center justify-between text-xs">
+                    <span className="text-gray-700 dark:text-slate-300 truncate max-w-[12rem]">{item.detail || item.internal_sku} · {item.grn_number}</span>
+                    <span className="font-mono text-gray-600 dark:text-slate-400">{item.quantity} × {formatCurrency(item.cost_price)}</span>
+                </div>
+            ))}
+            <div className="flex items-center justify-between text-xs font-semibold pt-1 border-t border-gray-100 dark:border-slate-700">
+                <span className="text-gray-700 dark:text-slate-300">Items Total vs Bill Total</span>
+                <span className={Math.abs(items.variance) < 0.01 ? 'text-success-600 dark:text-success-400' : 'text-warning-600 dark:text-warning-400'}>
+                    {formatCurrency(items.itemsTotal)} / {formatCurrency(items.billTotal)}
+                </span>
+            </div>
+        </div>
+    );
+};
+
+const BillsTab = ({ supplier, canManage }) => {
+    const supplierId = supplier.supplier_id;
     const [bills, setBills] = useState([]);
     const [loading, setLoading] = useState(true);
     const [editingBillId, setEditingBillId] = useState(null);
     const [newDueDate, setNewDueDate] = useState('');
     const [reason, setReason] = useState('');
+    const [isAddPayableOpen, setIsAddPayableOpen] = useState(false);
+    const [attachItemsBill, setAttachItemsBill] = useState(null);
+    const [expandedBillId, setExpandedBillId] = useState(null);
 
     const fetchBills = useCallback(async () => {
         setLoading(true);
@@ -132,6 +179,15 @@ const BillsTab = ({ supplierId, canManage }) => {
 
     return (
         <div className="p-4 space-y-3">
+            {canManage && (
+                <button
+                    onClick={() => setIsAddPayableOpen(true)}
+                    className="w-full px-3 py-2 text-sm font-semibold rounded-md border border-dashed border-primary-400 dark:border-primary-600 text-primary-600 dark:text-primary-400 hover:bg-primary-50 dark:hover:bg-primary-900/20 flex items-center justify-center gap-1.5"
+                >
+                    <Icon path={ICONS.plus} className="h-4 w-4" /> New Payable
+                </button>
+            )}
+
             {bills.length === 0 && <p className="text-sm text-gray-500 dark:text-slate-400">No bills recorded for this supplier.</p>}
             {bills.map((bill) => (
                 <div key={bill.bill_id} className="border border-gray-200 dark:border-slate-700 rounded-lg p-3">
@@ -166,8 +222,41 @@ const BillsTab = ({ supplierId, canManage }) => {
                             </div>
                         </div>
                     )}
+
+                    <div className="mt-2 flex items-center gap-3 border-t border-gray-100 dark:border-slate-700 pt-2">
+                        <button
+                            onClick={() => setExpandedBillId(expandedBillId === bill.bill_id ? null : bill.bill_id)}
+                            className="text-xs font-semibold text-gray-500 dark:text-slate-400 hover:underline"
+                        >
+                            {expandedBillId === bill.bill_id ? 'Hide Items' : 'View Items'}
+                        </button>
+                        {canManage && bill.status !== 'Paid' && (
+                            <button
+                                onClick={() => setAttachItemsBill(bill)}
+                                className="text-xs font-semibold text-success-600 dark:text-success-400 hover:underline"
+                            >
+                                Attach Items
+                            </button>
+                        )}
+                    </div>
+                    {expandedBillId === bill.bill_id && <BillItemsPanel billId={bill.bill_id} />}
                 </div>
             ))}
+
+            <AddPayableModal
+                isOpen={isAddPayableOpen}
+                onClose={() => setIsAddPayableOpen(false)}
+                onCreated={fetchBills}
+                presetSupplier={{ supplier_id: supplier.supplier_id, supplier_name: supplier.supplier_name }}
+            />
+            <AttachItemsModal
+                isOpen={!!attachItemsBill}
+                onClose={() => setAttachItemsBill(null)}
+                supplierId={supplierId}
+                supplierName={supplier.supplier_name}
+                bill={attachItemsBill}
+                onAttached={fetchBills}
+            />
         </div>
     );
 };
@@ -273,33 +362,27 @@ const SupplierDetailDrawer = ({ supplier, isOpen, onClose, onSupplierUpdated, in
         { key: 'ledger', label: 'Ledger' },
     ];
 
+    const modalTitle = (
+        <span className="flex items-center gap-2">
+            {supplier.supplier_name}
+            {supplier.payment_hold && <StatusBadge tone="danger" label="ON HOLD" />}
+        </span>
+    );
+
     return (
-        <Drawer
-            isOpen={isOpen}
-            onClose={onClose}
-            size="lg"
-            showHeader={false}
-            drawerClassName="bg-white dark:bg-slate-800"
-        >
-            <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-slate-700">
-                <div className="flex items-center gap-2">
-                    <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100">{supplier.supplier_name}</h2>
-                    {supplier.payment_hold && <StatusBadge tone="danger" label="ON HOLD" />}
-                </div>
-                <button onClick={onClose} className="p-1 rounded-md text-gray-400 dark:text-slate-500 hover:text-gray-600 dark:hover:text-slate-300 hover:bg-gray-100 dark:hover:bg-slate-700">
-                    <Icon path={ICONS.close} className="w-6 h-6" />
-                </button>
-            </div>
-            <div className="px-4 pt-3 border-b border-gray-200 dark:border-slate-700">
+        <Modal isOpen={isOpen} onClose={onClose} title={modalTitle} maxWidth="max-w-2xl">
+            <div className="-mt-2 mb-3">
                 <SegmentedTabs tabs={tabs} active={activeTab} onChange={setActiveTab} variant="pills" />
             </div>
-            {activeTab === 'profile' && (
-                <ProfileTab supplier={supplier} onSupplierUpdated={onSupplierUpdated} canManage={hasPermission('ap:manage')} />
-            )}
-            {activeTab === 'bills' && <BillsTab supplierId={supplier.supplier_id} canManage={hasPermission('ap:manage')} />}
-            {activeTab === 'payments' && <PaymentsTab supplierId={supplier.supplier_id} />}
-            {activeTab === 'ledger' && <LedgerTab supplierId={supplier.supplier_id} />}
-        </Drawer>
+            <div className="-mx-6">
+                {activeTab === 'profile' && (
+                    <ProfileTab supplier={supplier} onSupplierUpdated={onSupplierUpdated} canManage={hasPermission('ap:manage')} />
+                )}
+                {activeTab === 'bills' && <BillsTab supplier={supplier} canManage={hasPermission('ap:manage')} />}
+                {activeTab === 'payments' && <PaymentsTab supplierId={supplier.supplier_id} />}
+                {activeTab === 'ledger' && <LedgerTab supplierId={supplier.supplier_id} />}
+            </div>
+        </Modal>
     );
 };
 

--- a/packages/web/src/components/suppliers/SupplierDetailDrawer.jsx
+++ b/packages/web/src/components/suppliers/SupplierDetailDrawer.jsx
@@ -1,0 +1,306 @@
+import { useCallback, useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
+import api from '../../api';
+import Drawer from '../ui/Drawer';
+import SegmentedTabs from '../ui/SegmentedTabs';
+import StatusBadge from '../ui/StatusBadge';
+import Icon from '../ui/Icon';
+import { ICONS } from '../../constants';
+import { formatCurrency } from '../../utils/currency';
+import { useAuth } from '../../contexts/AuthContext';
+
+const BILL_STATUS_TONE = { 'Unpaid': 'danger', 'Partially Paid': 'warning', 'Paid': 'success' };
+
+const ProfileTab = ({ supplier, onSupplierUpdated, canManage }) => {
+    const [holdReason, setHoldReason] = useState('');
+    const [saving, setSaving] = useState(false);
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    useEffect(() => { setHoldReason(supplier?.payment_hold_reason || ''); }, [supplier?.supplier_id]);
+
+    const toggleHold = async (nextHold) => {
+        if (nextHold && !holdReason.trim()) {
+            toast.error('A reason is required to place a supplier on payment hold');
+            return;
+        }
+        setSaving(true);
+        try {
+            const { data } = await api.patch(`/ap/suppliers/${supplier.supplier_id}/payment-hold`, {
+                payment_hold: nextHold,
+                payment_hold_reason: nextHold ? holdReason.trim() : null,
+            });
+            toast.success(nextHold ? 'Supplier placed on payment hold' : 'Payment hold lifted');
+            onSupplierUpdated(data.data);
+        } catch (err) {
+            toast.error(err.response?.data?.message || 'Failed to update payment hold');
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    return (
+        <div className="p-4 space-y-4">
+            <div className="grid grid-cols-2 gap-3 text-sm">
+                <div><span className="text-gray-500 dark:text-slate-400">Contact Person</span><p className="text-gray-900 dark:text-slate-100">{supplier.contact_person || '—'}</p></div>
+                <div><span className="text-gray-500 dark:text-slate-400">Phone</span><p className="text-gray-900 dark:text-slate-100">{supplier.phone || '—'}</p></div>
+                <div><span className="text-gray-500 dark:text-slate-400">Email</span><p className="text-gray-900 dark:text-slate-100">{supplier.email || '—'}</p></div>
+                <div><span className="text-gray-500 dark:text-slate-400">Payment Terms</span><p className="text-gray-900 dark:text-slate-100">{supplier.payment_terms_days ? `Net ${supplier.payment_terms_days}` : '—'}</p></div>
+                <div className="col-span-2"><span className="text-gray-500 dark:text-slate-400">Address</span><p className="text-gray-900 dark:text-slate-100">{supplier.address || '—'}</p></div>
+            </div>
+
+            <div className="border-t border-gray-200 dark:border-slate-700 pt-4">
+                <div className="flex items-center justify-between mb-2">
+                    <h3 className="text-sm font-semibold text-gray-800 dark:text-slate-100">Payment Hold</h3>
+                    <StatusBadge tone={supplier.payment_hold ? 'danger' : 'success'} label={supplier.payment_hold ? 'ON HOLD' : 'CLEAR'} />
+                </div>
+                {supplier.payment_hold ? (
+                    <>
+                        <p className="text-sm text-gray-600 dark:text-slate-400 mb-3">{supplier.payment_hold_reason}</p>
+                        {canManage && (
+                            <button
+                                onClick={() => toggleHold(false)}
+                                disabled={saving}
+                                className="w-full px-3 py-2 text-sm font-semibold rounded-md bg-success-600 text-white hover:bg-success-700 disabled:opacity-50"
+                            >
+                                Lift Payment Hold
+                            </button>
+                        )}
+                    </>
+                ) : canManage && (
+                    <div className="space-y-2">
+                        <textarea
+                            value={holdReason}
+                            onChange={(e) => setHoldReason(e.target.value)}
+                            placeholder="Reason for placing this supplier on hold..."
+                            rows={2}
+                            className="w-full px-3 py-2 text-sm border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100 rounded-md"
+                        />
+                        <button
+                            onClick={() => toggleHold(true)}
+                            disabled={saving}
+                            className="w-full px-3 py-2 text-sm font-semibold rounded-md bg-danger-600 text-white hover:bg-danger-700 disabled:opacity-50"
+                        >
+                            Place On Payment Hold
+                        </button>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};
+
+const BillsTab = ({ supplierId, canManage }) => {
+    const [bills, setBills] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [editingBillId, setEditingBillId] = useState(null);
+    const [newDueDate, setNewDueDate] = useState('');
+    const [reason, setReason] = useState('');
+
+    const fetchBills = useCallback(async () => {
+        setLoading(true);
+        try {
+            const { data } = await api.get('/ap/supplier-bills', { params: { supplier_id: supplierId, status: 'all' } });
+            setBills(data?.data || []);
+        } catch {
+            toast.error('Failed to load bills');
+        } finally {
+            setLoading(false);
+        }
+    }, [supplierId]);
+
+    useEffect(() => { fetchBills(); }, [fetchBills]);
+
+    const startEdit = (bill) => {
+        setEditingBillId(bill.bill_id);
+        setNewDueDate(bill.due_date ? bill.due_date.slice(0, 10) : '');
+        setReason('');
+    };
+
+    const saveDueDate = async (billId) => {
+        if (!newDueDate) { toast.error('Select a due date'); return; }
+        try {
+            await api.patch(`/ap/supplier-bills/${billId}/due-date`, { new_due_date: newDueDate, reason: reason.trim() || null });
+            toast.success('Due date updated');
+            setEditingBillId(null);
+            fetchBills();
+        } catch (err) {
+            toast.error(err.response?.data?.message || 'Failed to update due date');
+        }
+    };
+
+    if (loading) return <div className="p-4 text-sm text-gray-500 dark:text-slate-400">Loading bills...</div>;
+
+    return (
+        <div className="p-4 space-y-3">
+            {bills.length === 0 && <p className="text-sm text-gray-500 dark:text-slate-400">No bills recorded for this supplier.</p>}
+            {bills.map((bill) => (
+                <div key={bill.bill_id} className="border border-gray-200 dark:border-slate-700 rounded-lg p-3">
+                    <div className="flex items-center justify-between">
+                        <span className="font-mono text-sm text-gray-900 dark:text-slate-100">{bill.bill_number || `Bill #${bill.bill_id}`}</span>
+                        <StatusBadge tone={BILL_STATUS_TONE[bill.status] || 'neutral'} label={bill.status} />
+                    </div>
+                    <div className="mt-1 text-sm text-gray-600 dark:text-slate-400 flex justify-between">
+                        <span>Total: {formatCurrency(bill.total_amount)}</span>
+                        <span>Paid: {formatCurrency(bill.amount_paid)}</span>
+                    </div>
+                    <div className="mt-1 flex items-center justify-between text-sm">
+                        <span className="text-gray-500 dark:text-slate-400">
+                            Due: {bill.due_date ? new Date(bill.due_date).toLocaleDateString() : 'Not set'}
+                            {bill.status !== 'Paid' && Number(bill.days_overdue) > 0 && (
+                                <span className="ml-2 text-danger-600 dark:text-danger-400 font-semibold">{Math.round(bill.days_overdue)}d overdue</span>
+                            )}
+                        </span>
+                        {canManage && bill.status !== 'Paid' && (
+                            <button onClick={() => startEdit(bill)} className="text-primary-600 dark:text-primary-400 text-xs font-semibold hover:underline">Edit Due Date</button>
+                        )}
+                    </div>
+                    {editingBillId === bill.bill_id && (
+                        <div className="mt-2 space-y-2 border-t border-gray-100 dark:border-slate-700 pt-2">
+                            <input type="date" value={newDueDate} onChange={(e) => setNewDueDate(e.target.value)}
+                                className="w-full px-2 py-1 text-sm border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100 rounded-md" />
+                            <input type="text" value={reason} onChange={(e) => setReason(e.target.value)} placeholder="Reason (optional)"
+                                className="w-full px-2 py-1 text-sm border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100 rounded-md" />
+                            <div className="flex gap-2">
+                                <button onClick={() => saveDueDate(bill.bill_id)} className="flex-1 px-2 py-1 text-xs font-semibold bg-primary-600 text-white rounded-md">Save</button>
+                                <button onClick={() => setEditingBillId(null)} className="flex-1 px-2 py-1 text-xs font-semibold border border-gray-300 dark:border-slate-600 rounded-md text-gray-700 dark:text-slate-200">Cancel</button>
+                            </div>
+                        </div>
+                    )}
+                </div>
+            ))}
+        </div>
+    );
+};
+
+const PaymentsTab = ({ supplierId }) => {
+    const [payments, setPayments] = useState([]);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        (async () => {
+            setLoading(true);
+            try {
+                const { data } = await api.get(`/ap/suppliers/${supplierId}/payments`);
+                setPayments(data?.data || []);
+            } catch {
+                toast.error('Failed to load payments');
+            } finally {
+                setLoading(false);
+            }
+        })();
+    }, [supplierId]);
+
+    if (loading) return <div className="p-4 text-sm text-gray-500 dark:text-slate-400">Loading payments...</div>;
+
+    return (
+        <div className="p-4 space-y-3">
+            {payments.length === 0 && <p className="text-sm text-gray-500 dark:text-slate-400">No payments recorded for this supplier.</p>}
+            {payments.map((p) => (
+                <div key={p.payment_id} className="border border-gray-200 dark:border-slate-700 rounded-lg p-3 text-sm">
+                    <div className="flex items-center justify-between">
+                        <span className="text-gray-900 dark:text-slate-100 font-medium">{formatCurrency(p.amount)}</span>
+                        <StatusBadge tone={p.pdc_status === 'CLEARED' ? 'success' : p.pdc_status === 'BOUNCED' ? 'danger' : 'info'} label={p.pdc_status} />
+                    </div>
+                    <div className="mt-1 text-gray-500 dark:text-slate-400">
+                        {new Date(p.payment_date).toLocaleDateString()} · {p.method_name || 'Unknown method'} {p.reference_number ? `· Ref ${p.reference_number}` : ''}
+                    </div>
+                    {p.allocations?.length > 0 && (
+                        <div className="mt-1 text-xs text-gray-500 dark:text-slate-500">
+                            Applied to: {p.allocations.map(a => a.bill_number || `Bill #${a.bill_id}`).join(', ')}
+                        </div>
+                    )}
+                </div>
+            ))}
+        </div>
+    );
+};
+
+const LedgerTab = ({ supplierId }) => {
+    const [rows, setRows] = useState([]);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        (async () => {
+            setLoading(true);
+            try {
+                const { data } = await api.get(`/ap/suppliers/${supplierId}/ledger`, { params: { limit: 200 } });
+                setRows(data?.rows || []);
+            } catch {
+                toast.error('Failed to load ledger');
+            } finally {
+                setLoading(false);
+            }
+        })();
+    }, [supplierId]);
+
+    if (loading) return <div className="p-4 text-sm text-gray-500 dark:text-slate-400">Loading ledger...</div>;
+
+    return (
+        <div className="p-4">
+            {rows.length === 0 && <p className="text-sm text-gray-500 dark:text-slate-400">No ledger activity for this supplier.</p>}
+            <div className="space-y-2">
+                {rows.map((r) => (
+                    <div key={r.ledger_id} className="flex items-center justify-between text-sm border-b border-gray-100 dark:border-slate-700 pb-2">
+                        <div>
+                            <p className="text-gray-900 dark:text-slate-100 font-medium">{r.entry_type.replace(/_/g, ' ')}</p>
+                            <p className="text-xs text-gray-500 dark:text-slate-400">{new Date(r.created_at).toLocaleString()} {r.bill_number ? `· ${r.bill_number}` : ''}</p>
+                        </div>
+                        <div className="text-right">
+                            <p className={`font-mono font-semibold ${Number(r.amount) >= 0 ? 'text-danger-600 dark:text-danger-400' : 'text-success-600 dark:text-success-400'}`}>
+                                {Number(r.amount) >= 0 ? '+' : ''}{formatCurrency(r.amount)}
+                            </p>
+                            <p className="text-xs text-gray-500 dark:text-slate-400">Bal: {formatCurrency(r.balance_after)}</p>
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+};
+
+const SupplierDetailDrawer = ({ supplier, isOpen, onClose, onSupplierUpdated, initialTab = 'profile' }) => {
+    const { hasPermission } = useAuth();
+    const [activeTab, setActiveTab] = useState(initialTab);
+
+    useEffect(() => { if (isOpen) setActiveTab(initialTab); }, [isOpen, initialTab, supplier?.supplier_id]);
+
+    if (!supplier) return null;
+
+    const tabs = [
+        { key: 'profile', label: 'Profile' },
+        { key: 'bills', label: 'Bills' },
+        { key: 'payments', label: 'Payments' },
+        { key: 'ledger', label: 'Ledger' },
+    ];
+
+    return (
+        <Drawer
+            isOpen={isOpen}
+            onClose={onClose}
+            size="lg"
+            showHeader={false}
+            drawerClassName="bg-white dark:bg-slate-800"
+        >
+            <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-slate-700">
+                <div className="flex items-center gap-2">
+                    <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100">{supplier.supplier_name}</h2>
+                    {supplier.payment_hold && <StatusBadge tone="danger" label="ON HOLD" />}
+                </div>
+                <button onClick={onClose} className="p-1 rounded-md text-gray-400 dark:text-slate-500 hover:text-gray-600 dark:hover:text-slate-300 hover:bg-gray-100 dark:hover:bg-slate-700">
+                    <Icon path={ICONS.close} className="w-6 h-6" />
+                </button>
+            </div>
+            <div className="px-4 pt-3 border-b border-gray-200 dark:border-slate-700">
+                <SegmentedTabs tabs={tabs} active={activeTab} onChange={setActiveTab} variant="pills" />
+            </div>
+            {activeTab === 'profile' && (
+                <ProfileTab supplier={supplier} onSupplierUpdated={onSupplierUpdated} canManage={hasPermission('ap:manage')} />
+            )}
+            {activeTab === 'bills' && <BillsTab supplierId={supplier.supplier_id} canManage={hasPermission('ap:manage')} />}
+            {activeTab === 'payments' && <PaymentsTab supplierId={supplier.supplier_id} />}
+            {activeTab === 'ledger' && <LedgerTab supplierId={supplier.supplier_id} />}
+        </Drawer>
+    );
+};
+
+export default SupplierDetailDrawer;

--- a/packages/web/src/components/ui/SortableHeader.jsx
+++ b/packages/web/src/components/ui/SortableHeader.jsx
@@ -16,10 +16,10 @@ const SortableHeader = ({ children, column, sortConfig, onSort, className = '' }
     };
 
     return (
-        <th className={`p-3 text-sm font-semibold text-gray-600 cursor-pointer hover:bg-gray-50 select-none ${className}`} onClick={() => onSort(column, getNextDirection())}>
+        <th className={`p-3 text-sm font-semibold text-gray-600 dark:text-slate-300 cursor-pointer hover:bg-gray-50 dark:hover:bg-slate-700/50 select-none ${className}`} onClick={() => onSort(column, getNextDirection())}>
             <div className="flex items-center justify-between gap-1 min-w-0">
                 <span className="truncate">{children}</span>
-                <Icon path={getIcon()} className={`h-4 w-4 shrink-0 ${isSorted ? 'text-blue-600' : 'text-gray-300'}`} />
+                <Icon path={getIcon()} className={`h-4 w-4 shrink-0 ${isSorted ? 'text-primary-600 dark:text-primary-400' : 'text-gray-300 dark:text-slate-600'}`} />
             </div>
         </th>
     );

--- a/packages/web/src/hooks/useAPOverviewData.js
+++ b/packages/web/src/hooks/useAPOverviewData.js
@@ -1,0 +1,108 @@
+import { useCallback, useEffect, useState } from 'react';
+import api from '../api';
+
+/**
+ * Data + handlers for the AP page's Overview & Aging tab: KPI stats, the aging
+ * bucket chart, and the paginated/searchable/sortable supplier summary table.
+ * Structural mirror of useAROverviewData.js, pointed at the /ap/* endpoints.
+ */
+const useAPOverviewData = ({ hasPermission }) => {
+    const [loading, setLoading] = useState(true);
+    const [overviewError, setOverviewError] = useState('');
+    const [kpiData, setKpiData] = useState(null);
+    const [agingData, setAgingData] = useState([]);
+
+    const [supplierSummary, setSupplierSummary] = useState([]);
+    const [supplierSummarySearchTerm, setSupplierSummarySearchTerm] = useState('');
+    const [supplierSummaryStatusFilter, setSupplierSummaryStatusFilter] = useState('ALL');
+    const [supplierSummarySortConfig, setSupplierSummarySortConfig] = useState({ key: 'bill_count', direction: 'DESC' });
+    const [supplierSummaryPage, setSupplierSummaryPage] = useState(1);
+    const [supplierSummaryPageSize, setSupplierSummaryPageSize] = useState(25);
+    const [supplierSummaryTotal, setSupplierSummaryTotal] = useState(0);
+
+    const [selectedAgingBucket, setSelectedAgingBucket] = useState(null);
+    const [selectedSupplierId, setSelectedSupplierId] = useState(null);
+
+    const fetchDashboardData = useCallback(async () => {
+        if (!hasPermission('ap:view')) return;
+        setLoading(true);
+        setOverviewError('');
+        try {
+            const [statsRes, agingRes] = await Promise.all([
+                api.get('/ap/summary-stats'),
+                api.get('/ap/aging-summary'),
+            ]);
+            setKpiData(statsRes.data);
+            setAgingData(agingRes.data || []);
+        } catch {
+            setOverviewError('Failed to load AP overview data.');
+        } finally {
+            setLoading(false);
+        }
+    }, [hasPermission]);
+
+    const fetchSupplierSummary = useCallback(async () => {
+        if (!hasPermission('ap:view')) return;
+        try {
+            const response = await api.get('/ap/supplier-summary', {
+                params: {
+                    paginated: 1,
+                    page: supplierSummaryPage,
+                    pageSize: supplierSummaryPageSize,
+                    search: supplierSummarySearchTerm,
+                    status: supplierSummaryStatusFilter === 'ALL' ? undefined : supplierSummaryStatusFilter,
+                    sortBy: supplierSummarySortConfig.key,
+                    sortDir: supplierSummarySortConfig.direction,
+                }
+            });
+            setSupplierSummary(response.data?.data || []);
+            setSupplierSummaryTotal(response.data?.total || 0);
+        } catch {
+            setOverviewError('Failed to load supplier summary.');
+        }
+    }, [hasPermission, supplierSummaryPage, supplierSummaryPageSize, supplierSummarySearchTerm, supplierSummaryStatusFilter, supplierSummarySortConfig]);
+
+    useEffect(() => { fetchDashboardData(); }, [fetchDashboardData]);
+    useEffect(() => { fetchSupplierSummary(); }, [fetchSupplierSummary]);
+
+    const handleAgingBucketClick = useCallback((bucketName) => {
+        setSelectedAgingBucket(bucketName);
+    }, []);
+
+    const handleCloseDrillDown = useCallback(() => setSelectedAgingBucket(null), []);
+
+    const handleSupplierClick = useCallback((supplier) => {
+        setSelectedSupplierId(supplier.supplier_id);
+    }, []);
+
+    const handleCloseSupplierDrawer = useCallback(() => setSelectedSupplierId(null), []);
+
+    return {
+        loading,
+        overviewError,
+        kpiData,
+        agingData,
+        onBucketClick: handleAgingBucketClick,
+        selectedAgingBucket,
+        onCloseDrillDown: handleCloseDrillDown,
+        supplierSummary,
+        supplierSummarySearchTerm,
+        setSupplierSummarySearchTerm,
+        supplierSummaryStatusFilter,
+        setSupplierSummaryStatusFilter,
+        supplierSummarySortConfig,
+        setSupplierSummarySortConfig,
+        supplierSummaryPage,
+        setSupplierSummaryPage,
+        supplierSummaryPageSize,
+        setSupplierSummaryPageSize,
+        supplierSummaryTotal,
+        selectedSupplierId,
+        onSupplierClick: handleSupplierClick,
+        onCloseSupplierDrawer: handleCloseSupplierDrawer,
+        fetchDashboardData,
+        fetchSupplierSummary,
+    };
+};
+
+export default useAPOverviewData;

--- a/packages/web/src/pages/AccountsPayablePage.jsx
+++ b/packages/web/src/pages/AccountsPayablePage.jsx
@@ -1,0 +1,128 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useAuth } from '../contexts/AuthContext';
+import Icon from '../components/ui/Icon';
+import { ICONS } from '../constants';
+import SegmentedTabs from '../components/ui/SegmentedTabs';
+import KPICard from '../components/ui/KPICard';
+import PaginationControls from '../components/ui/PaginationControls';
+import ErrorBoundary from '../components/ui/ErrorBoundary';
+import BillAgingSummaryChart from '../components/accounts-payable/BillAgingSummaryChart';
+import SupplierSummaryTable from '../components/accounts-payable/SupplierSummaryTable';
+import SupplierDetailDrawer from '../components/suppliers/SupplierDetailDrawer';
+import useAPOverviewData from '../hooks/useAPOverviewData';
+
+const OverviewTab = ({ overview, onOpenSupplier }) => {
+    const kpi = overview.kpiData || {};
+    return (
+        <div className="space-y-6">
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+                <KPICard icon="currency" title="Total Payables" value={kpi.totalPayables || 0} isMonetary color="blue" loading={overview.loading} />
+                <KPICard icon="warning" title="Overdue" value={kpi.overdueAmount || 0} isMonetary subtitle={`${kpi.overdueCount || 0} bill(s)`} color="red" urgent={(kpi.overdueCount || 0) > 0} loading={overview.loading} />
+                <KPICard icon="receipt" title="Due Next 7 Days" value={kpi.dueNext7Amount || 0} isMonetary subtitle={`${kpi.dueNext7Count || 0} bill(s)`} color="amber" loading={overview.loading} />
+                <KPICard icon="package" title="Suppliers On Hold" value={kpi.suppliersOnHold || 0} color="purple" loading={overview.loading} />
+            </div>
+
+            <BillAgingSummaryChart agingData={overview.agingData} loading={overview.loading} onBucketClick={overview.onBucketClick} />
+
+            <SupplierSummaryTable
+                suppliers={overview.supplierSummary}
+                onSupplierClick={onOpenSupplier}
+                loading={overview.loading}
+                searchTerm={overview.supplierSummarySearchTerm}
+                onSearchChange={(val) => { overview.setSupplierSummarySearchTerm(val); overview.setSupplierSummaryPage(1); }}
+                statusFilter={overview.supplierSummaryStatusFilter}
+                onStatusFilterChange={(val) => { overview.setSupplierSummaryStatusFilter(val); overview.setSupplierSummaryPage(1); }}
+                sortConfig={overview.supplierSummarySortConfig}
+                onSortChange={(cfg) => { overview.setSupplierSummarySortConfig(cfg); overview.setSupplierSummaryPage(1); }}
+            />
+            <PaginationControls
+                page={overview.supplierSummaryPage}
+                pageSize={overview.supplierSummaryPageSize}
+                total={overview.supplierSummaryTotal}
+                onPageChange={overview.setSupplierSummaryPage}
+                onPageSizeChange={(value) => { overview.setSupplierSummaryPageSize(value); overview.setSupplierSummaryPage(1); }}
+            />
+        </div>
+    );
+};
+
+const AccountsPayablePage = ({ onNavigate }) => {
+    const { hasPermission } = useAuth();
+    const [activeTab, setActiveTab] = useState('overview');
+    const [selectedSupplier, setSelectedSupplier] = useState(null);
+
+    const overview = useAPOverviewData({ hasPermission });
+
+    const handleOpenSupplier = useCallback((supplier) => setSelectedSupplier(supplier), []);
+    const handleCloseSupplier = useCallback(() => setSelectedSupplier(null), []);
+    const handleSupplierUpdated = useCallback((updated) => {
+        setSelectedSupplier((prev) => prev ? { ...prev, ...updated } : prev);
+        overview.fetchSupplierSummary();
+    }, [overview]);
+
+    const handleRefresh = useCallback(() => {
+        overview.fetchDashboardData();
+        overview.fetchSupplierSummary();
+    }, [overview]);
+
+    const tabs = useMemo(() => ([
+        { key: 'overview', label: 'Overview & Aging' },
+    ]), []);
+
+    if (!hasPermission('ap:view')) {
+        return (
+            <div className="text-center p-8">
+                <h1 className="text-2xl font-bold text-danger-600 dark:text-danger-400">Access Denied</h1>
+                <p className="text-gray-600 dark:text-slate-400 mt-2">You do not have permission to view this page.</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-6">
+            <header className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
+                <div>
+                    <h1 className="text-2xl md:text-3xl font-bold text-gray-900 dark:text-slate-100">Accounts Payable</h1>
+                    <p className="text-sm text-gray-500 dark:text-slate-400 mt-1">
+                        Monitor supplier balances, bill aging, and upcoming due dates.
+                    </p>
+                </div>
+                <div className="flex items-center gap-3">
+                    <button
+                        onClick={() => onNavigate && onNavigate('cheques_treasury')}
+                        className="px-4 py-2 border border-gray-300 dark:border-slate-600 text-gray-700 dark:text-slate-200 rounded-md hover:bg-gray-50 dark:hover:bg-slate-700 text-sm transition-colors font-medium flex items-center gap-1.5"
+                    >
+                        Outbound Cheques &amp; Treasury <Icon path={ICONS.chevronDown} className="w-3.5 h-3.5 -rotate-90" />
+                    </button>
+                    <button
+                        onClick={handleRefresh}
+                        disabled={overview.loading}
+                        className="px-4 py-2 bg-primary-600 text-white rounded-md hover:bg-primary-700 disabled:opacity-50 text-sm transition-colors font-medium flex items-center gap-1.5"
+                    >
+                        <Icon path={ICONS.refresh} className="w-4 h-4" /> Refresh
+                    </button>
+                </div>
+            </header>
+
+            <div className="border-b border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 rounded-xl shadow-xs px-4 pt-2">
+                <SegmentedTabs tabs={tabs} active={activeTab} onChange={setActiveTab} />
+            </div>
+
+            <ErrorBoundary title="Overview & Aging tab failed to load" description="Try refreshing the page.">
+                {activeTab === 'overview' && (
+                    <OverviewTab overview={overview} onOpenSupplier={handleOpenSupplier} />
+                )}
+            </ErrorBoundary>
+
+            <SupplierDetailDrawer
+                supplier={selectedSupplier}
+                isOpen={!!selectedSupplier}
+                onClose={handleCloseSupplier}
+                onSupplierUpdated={handleSupplierUpdated}
+                initialTab="bills"
+            />
+        </div>
+    );
+};
+
+export default AccountsPayablePage;

--- a/packages/web/src/pages/AccountsPayablePage.jsx
+++ b/packages/web/src/pages/AccountsPayablePage.jsx
@@ -9,6 +9,7 @@ import ErrorBoundary from '../components/ui/ErrorBoundary';
 import BillAgingSummaryChart from '../components/accounts-payable/BillAgingSummaryChart';
 import SupplierSummaryTable from '../components/accounts-payable/SupplierSummaryTable';
 import SupplierDetailDrawer from '../components/suppliers/SupplierDetailDrawer';
+import AddPayableModal from '../components/accounts-payable/AddPayableModal';
 import useAPOverviewData from '../hooks/useAPOverviewData';
 
 const OverviewTab = ({ overview, onOpenSupplier }) => {
@@ -50,6 +51,7 @@ const AccountsPayablePage = ({ onNavigate }) => {
     const { hasPermission } = useAuth();
     const [activeTab, setActiveTab] = useState('overview');
     const [selectedSupplier, setSelectedSupplier] = useState(null);
+    const [isAddPayableOpen, setIsAddPayableOpen] = useState(false);
 
     const overview = useAPOverviewData({ hasPermission });
 
@@ -94,6 +96,14 @@ const AccountsPayablePage = ({ onNavigate }) => {
                     >
                         Outbound Cheques &amp; Treasury <Icon path={ICONS.chevronDown} className="w-3.5 h-3.5 -rotate-90" />
                     </button>
+                    {hasPermission('ap:manage') && (
+                        <button
+                            onClick={() => setIsAddPayableOpen(true)}
+                            className="px-4 py-2 bg-success-600 text-white rounded-md hover:bg-success-700 text-sm transition-colors font-medium flex items-center gap-1.5"
+                        >
+                            <Icon path={ICONS.plus} className="w-4 h-4" /> New Payable
+                        </button>
+                    )}
                     <button
                         onClick={handleRefresh}
                         disabled={overview.loading}
@@ -120,6 +130,12 @@ const AccountsPayablePage = ({ onNavigate }) => {
                 onClose={handleCloseSupplier}
                 onSupplierUpdated={handleSupplierUpdated}
                 initialTab="bills"
+            />
+
+            <AddPayableModal
+                isOpen={isAddPayableOpen}
+                onClose={() => setIsAddPayableOpen(false)}
+                onCreated={handleRefresh}
             />
         </div>
     );

--- a/packages/web/src/pages/GoodsReceiptPage.jsx
+++ b/packages/web/src/pages/GoodsReceiptPage.jsx
@@ -10,6 +10,7 @@ import useDraft from '../hooks/useDraft';
 import { formatApplicationText } from '../helpers/applicationTextHelper';
 import { enrichPartsArray } from '../helpers/applicationCache';
 import GoodsReceiptModals from '../components/ui/GoodsReceiptModals';
+import { formatCurrency } from '../utils/currency';
 
 const GoodsReceiptPage = ({ user, onNavigate }) => {
     const [suppliers, setSuppliers] = useState([]);
@@ -41,13 +42,13 @@ const GoodsReceiptPage = ({ user, onNavigate }) => {
         }
     }, [searchTerm]);
 
-    const { getInputProps, getItemProps, reset } = useTypeahead({ 
-        items: searchResults, 
-        onSelect: (item) => { addPartToLines(item); setSearchResults([]); }, 
+    const { getInputProps, getItemProps, reset } = useTypeahead({
+        items: searchResults,
+        onSelect: (item) => { addPartToLines(item); setSearchResults([]); },
         onEnterUnselected: handleRapidScan,
         inputRef: searchInputRef,
-        inputId, 
-        listboxId: resultsId 
+        inputId,
+        listboxId: resultsId
     });
     const [loading, setLoading] = useState(true);
     const [isSupplierModalOpen, setIsSupplierModalOpen] = useState(false);
@@ -58,11 +59,19 @@ const GoodsReceiptPage = ({ user, onNavigate }) => {
     const [currentEditPart, setCurrentEditPart] = useState(null);
     const [openPOs, setOpenPOs] = useState([]);
     const [selectedPO, setSelectedPO] = useState('');
+    const [posting, setPosting] = useState(false);
 
     // Reusable draft hook
     const draftData = useMemo(() => ({ selectedSupplier, lines, selectedPO }), [selectedSupplier, lines, selectedPO]);
     const isEmpty = useMemo(() => (d) => (!d?.selectedSupplier && (!d?.lines || d.lines.length === 0) && !d?.selectedPO), []);
     const { status: draftStatus, lastSavedAt, draft, loaded: draftLoaded, clearDraft } = useDraft('goods-receipt', { data: draftData, isEmpty, debounceMs: 750 });
+
+    const totals = useMemo(() => {
+        const totalQuantity = lines.reduce((sum, l) => sum + (parseFloat(l.quantity) || 0), 0);
+        const totalCost = lines.reduce((sum, l) => sum + (parseFloat(l.quantity) || 0) * (parseFloat(l.cost_price) || 0), 0);
+        const totalSaleValue = lines.reduce((sum, l) => sum + (parseFloat(l.quantity) || 0) * (parseFloat(l.sale_price) || 0), 0);
+        return { totalQuantity, totalCost, totalSaleValue, lineCount: lines.length };
+    }, [lines]);
 
     useEffect(() => {
         if (searchTerm.trim() === '') {
@@ -108,7 +117,7 @@ const GoodsReceiptPage = ({ user, onNavigate }) => {
             setLoading(false);
         }
     };
-    
+
     const fetchSuppliers = async () => {
         const response = await api.get('/suppliers');
         setSuppliers(response.data);
@@ -140,7 +149,7 @@ const GoodsReceiptPage = ({ user, onNavigate }) => {
         const po = openPOs.find(p => p.po_id === parseInt(poId));
         setSelectedPO(po);
         setSelectedSupplier(po.supplier_id);
-        
+
         try {
             toast.loading('Loading PO items...');
             const response = await api.get(`/purchase-orders/${poId}/lines`);
@@ -225,12 +234,12 @@ const GoodsReceiptPage = ({ user, onNavigate }) => {
                 line.part_id === part.part_id ? { ...line, quantity: line.quantity + 1 } : line
             ));
         } else {
-            setLines([...lines, { 
-                ...part, 
-                part_id: part.part_id, 
-                quantity: 1, 
+            setLines([...lines, {
+                ...part,
+                part_id: part.part_id,
+                quantity: 1,
                 cost_price: typeof part.last_cost !== 'undefined' ? part.last_cost : 0,
-                sale_price: typeof part.last_sale_price !== 'undefined' ? part.last_sale_price : 0 
+                sale_price: typeof part.last_sale_price !== 'undefined' ? part.last_sale_price : 0
             }]);
         }
         setSearchTerm('');
@@ -265,54 +274,67 @@ const GoodsReceiptPage = ({ user, onNavigate }) => {
             po_id: selectedPO ? selectedPO.po_id : null,
         };
 
+        setPosting(true);
         const promise = api.post('/goods-receipts', payload);
 
-    toast.promise(promise, {
+        toast.promise(promise, {
             loading: 'Posting transaction...',
             success: () => {
                 setLines([]);
                 setSelectedSupplier('');
                 setSelectedPO('');
                 fetchInitialData(); // Refresh PO list
-        clearDraft();
+                clearDraft();
+                setPosting(false);
                 return 'Goods receipt created successfully!';
             },
-            error: 'Failed to create goods receipt.',
+            error: () => {
+                setPosting(false);
+                return 'Failed to create goods receipt.';
+            },
         });
     };
 
-    if (loading) return <p>Loading data...</p>;
+    if (loading) return <p className="text-gray-600 dark:text-slate-400">Loading data...</p>;
+
+    const inputClass = "w-full h-9 px-2 border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100 rounded-md text-sm text-center focus:outline-none focus:ring-2 focus:ring-primary-500";
+    const labelClass = "block text-sm font-medium text-gray-700 dark:text-slate-300 mb-1";
+    const selectClass = "w-full px-3 py-2 border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 disabled:opacity-60 disabled:cursor-not-allowed";
 
     return (
-        <div>
-            <div className="flex items-center justify-between mb-6">
-                <h1 className="text-2xl font-semibold text-gray-800">New Goods Receipt</h1>
+        <div className="space-y-6">
+            <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
+                <div>
+                    <h1 className="text-2xl md:text-3xl font-bold text-gray-900 dark:text-slate-100">New Goods Receipt</h1>
+                    <p className="text-sm text-gray-500 dark:text-slate-400 mt-1">Receive stock from a supplier, against a purchase order or directly.</p>
+                </div>
                 <button
                     onClick={() => onNavigate('goods_receipt_history')}
-                    className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition text-sm font-medium"
+                    className="px-4 py-2 border border-gray-300 dark:border-slate-600 text-gray-700 dark:text-slate-200 rounded-lg hover:bg-gray-50 dark:hover:bg-slate-700 transition text-sm font-medium flex items-center gap-1.5"
                 >
-                    View History
+                    <Icon path={ICONS.history} className="h-4 w-4" /> View History
                 </button>
             </div>
-            <div className="bg-white p-6 rounded-xl border border-gray-200 space-y-6">
+
+            <div className="bg-white dark:bg-slate-800 p-6 rounded-xl border border-gray-200 dark:border-slate-700 space-y-6 shadow-xs">
                 {/* Draft saved indicator */}
-                <div className="flex items-center justify-end text-xs text-gray-500">
+                <div className="flex items-center justify-end text-xs text-gray-500 dark:text-slate-400">
                     {draftStatus === 'saving' && <span>Saving draft…</span>}
                     {draftStatus === 'saved' && (
                         <span>Draft saved{lastSavedAt ? ` at ${lastSavedAt.toLocaleTimeString()}` : ''}</span>
                     )}
-                    {draftStatus === 'error' && <span className="text-red-600">Draft save failed</span>}
+                    {draftStatus === 'error' && <span className="text-danger-600 dark:text-danger-400">Draft save failed</span>}
                         {(draftStatus === 'saved' || draftStatus === 'saving' || draft) && (
                             <button
                                 type="button"
-                                onClick={async () => { 
-                                    await clearDraft(); 
-                                    setSelectedSupplier(''); 
-                                    setLines([]); 
-                                    setSelectedPO(''); 
-                                    toast.success('Draft cleared'); 
+                                onClick={async () => {
+                                    await clearDraft();
+                                    setSelectedSupplier('');
+                                    setLines([]);
+                                    setSelectedPO('');
+                                    toast.success('Draft cleared');
                                 }}
-                                className="text-sm text-gray-600 hover:text-gray-800 ml-3"
+                                className="text-sm text-gray-600 dark:text-slate-400 hover:text-gray-800 dark:hover:text-slate-200 ml-3"
                             >
                                 Clear Draft
                             </button>
@@ -320,14 +342,14 @@ const GoodsReceiptPage = ({ user, onNavigate }) => {
                 </div>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div>
-                        <label className="block text-sm font-medium text-gray-700 mb-1">Receive Against Purchase Order (Optional)</label>
-                        <select value={selectedPO ? selectedPO.po_id : ''} onChange={e => handleSelectPO(e.target.value)} className="w-full px-3 py-2 border border-gray-300 rounded-lg">
+                        <label className={labelClass}>Receive Against Purchase Order (Optional)</label>
+                        <select value={selectedPO ? selectedPO.po_id : ''} onChange={e => handleSelectPO(e.target.value)} className={selectClass}>
                             <option value="">-- Select a PO --</option>
                             {openPOs.map(po => <option key={po.po_id} value={po.po_id}>{po.po_number} - {po.supplier_name}</option>)}
                         </select>
                     </div>
                     <div>
-                        <label className="block text-sm font-medium text-gray-700 mb-1">Supplier</label>
+                        <label className={labelClass}>Supplier</label>
                         <div className="flex items-center space-x-2">
                             <div className="flex-grow">
                                 <Combobox
@@ -338,13 +360,13 @@ const GoodsReceiptPage = ({ user, onNavigate }) => {
                                     disabled={!!selectedPO}
                                 />
                             </div>
-                            <button onClick={() => setIsSupplierModalOpen(true)} className="px-3 py-2 bg-gray-200 text-gray-800 rounded-lg hover:bg-gray-300 text-sm" disabled={!!selectedPO}>New</button>
+                            <button onClick={() => setIsSupplierModalOpen(true)} className="px-3 py-2 bg-gray-200 dark:bg-slate-700 text-gray-800 dark:text-slate-100 rounded-lg hover:bg-gray-300 dark:hover:bg-slate-600 text-sm disabled:opacity-60 disabled:cursor-not-allowed" disabled={!!selectedPO}>New</button>
                         </div>
                     </div>
                 </div>
-                
+
                 <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">Add Part Manually</label>
+                    <label className={labelClass}>Add Part Manually</label>
                     <div className="flex items-center space-x-2">
                         <div className="relative flex-grow">
                             <SearchBar
@@ -357,18 +379,18 @@ const GoodsReceiptPage = ({ user, onNavigate }) => {
                                 disabled={!!selectedPO}
                             />
                             {searchResults.length > 0 && (
-                                <ul id={resultsId} role="listbox" className="absolute z-10 w-full bg-white border rounded-md mt-1 shadow-lg max-h-60 overflow-y-auto scrollbar-thin">
+                                <ul id={resultsId} role="listbox" className="absolute z-10 w-full bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-md mt-1 shadow-lg max-h-60 overflow-y-auto scrollbar-thin">
                                     {searchResults.map((part, idx) => {
                                         const itemProps = getItemProps(idx);
                                         return (
                                                 <li
                                                     key={part.part_id}
                                                     {...itemProps}
-                                                    className={`px-4 py-2 cursor-pointer ${itemProps['aria-selected'] ? 'bg-blue-100' : 'hover:bg-blue-50'}`}
+                                                    className={`px-4 py-2 cursor-pointer ${itemProps['aria-selected'] ? 'bg-primary-100 dark:bg-primary-900/30' : 'hover:bg-primary-50 dark:hover:bg-slate-700/60'}`}
                                                 >
                                                     <div className="flex items-baseline space-x-2">
-                                                        <div className="text-sm font-medium text-gray-800 truncate">{part.display_name}</div>
-                                                        {part.applications && <div className="text-xs text-gray-500 truncate">{formatApplicationText(part.applications, { style: 'searchSuggestion' })}</div>}
+                                                        <div className="text-sm font-medium text-gray-800 dark:text-slate-100 truncate">{part.display_name}</div>
+                                                        {part.applications && <div className="text-xs text-gray-500 dark:text-slate-400 truncate">{formatApplicationText(part.applications, { style: 'searchSuggestion' })}</div>}
                                                     </div>
                                                 </li>
                                             );
@@ -376,40 +398,41 @@ const GoodsReceiptPage = ({ user, onNavigate }) => {
                                 </ul>
                             )}
                         </div>
-                        <button onClick={() => setIsNewPartModalOpen(true)} className="bg-blue-600 text-white px-4 py-2 rounded-lg font-semibold hover:bg-blue-700 transition whitespace-nowrap" disabled={!!selectedPO}>
+                        <button onClick={() => setIsNewPartModalOpen(true)} className="bg-primary-600 text-white px-4 py-2 rounded-lg font-semibold hover:bg-primary-700 transition whitespace-nowrap disabled:opacity-60 disabled:cursor-not-allowed" disabled={!!selectedPO}>
                            New Part
                         </button>
                     </div>
                 </div>
 
-                <div className="overflow-x-auto">
+                <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-slate-700">
                     <table className="w-full text-left">
-                        <thead className="border-b">
+                        <thead className="bg-gray-50 dark:bg-slate-900/60 border-b border-gray-200 dark:border-slate-700">
                             <tr>
-                                <th className="p-3 text-sm font-semibold text-gray-600">Part Detail</th>
-                                <th className="p-3 text-sm font-semibold text-gray-600 w-28">Quantity</th>
-                                <th className="p-3 text-sm font-semibold text-gray-600 w-32">Cost Price</th>
-                                <th className="p-3 text-sm font-semibold text-gray-600 w-32">Sale Price</th>
-                                <th className="p-3 text-sm font-semibold text-gray-600 w-16 text-center"></th>
+                                <th className="p-3 text-xs font-semibold text-gray-600 dark:text-slate-300 uppercase tracking-wide">Part Detail</th>
+                                <th className="p-3 text-xs font-semibold text-gray-600 dark:text-slate-300 uppercase tracking-wide w-28 text-center">Quantity</th>
+                                <th className="p-3 text-xs font-semibold text-gray-600 dark:text-slate-300 uppercase tracking-wide w-32 text-center">Cost Price</th>
+                                <th className="p-3 text-xs font-semibold text-gray-600 dark:text-slate-300 uppercase tracking-wide w-32 text-center">Sale Price</th>
+                                <th className="p-3 text-xs font-semibold text-gray-600 dark:text-slate-300 uppercase tracking-wide w-32 text-right">Line Total</th>
+                                <th className="p-3 text-xs font-semibold text-gray-600 dark:text-slate-300 uppercase tracking-wide w-16 text-center"></th>
                             </tr>
                         </thead>
                         <tbody>
                             {lines.map(line => (
-                                <tr key={line.part_id} className="border-b">
+                                <tr key={line.part_id} className="border-b border-gray-100 dark:border-slate-700 hover:bg-gray-50 dark:hover:bg-slate-700/40 transition-colors">
                                     <td className="p-2 align-middle">
                                         <div className="flex items-center justify-between gap-2">
-                                            <div className="min-w-0 flex-1 truncate text-sm font-medium text-gray-800">{line.display_name}</div>
+                                            <div className="min-w-0 flex-1 truncate text-sm font-medium text-gray-800 dark:text-slate-100">{line.display_name}</div>
                                             <div className="flex items-center gap-1">
                                                 <button
                                                     onClick={() => { setCurrentEditPart(line); setIsEditPartModalOpen(true); }}
-                                                    className="inline-flex items-center justify-center h-8 w-8 text-blue-600 hover:text-blue-800 rounded hover:bg-blue-50"
+                                                    className="inline-flex items-center justify-center h-8 w-8 text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-300 rounded hover:bg-primary-50 dark:hover:bg-primary-900/30"
                                                     title="Edit Part"
                                                 >
                                                     <Icon path={ICONS.edit} className="h-5 w-5"/>
                                                 </button>
                                                 <button
                                                     onClick={() => { setCurrentPart(line); setIsAppModalOpen(true); }}
-                                                    className="inline-flex items-center justify-center h-8 w-8 text-green-600 hover:text-green-800 rounded hover:bg-green-50"
+                                                    className="inline-flex items-center justify-center h-8 w-8 text-success-600 dark:text-success-400 hover:text-success-800 dark:hover:text-success-300 rounded hover:bg-success-50 dark:hover:bg-success-900/30"
                                                     title="Manage Applications"
                                                 >
                                                     <Icon path={ICONS.link} className="h-5 w-5"/>
@@ -417,39 +440,42 @@ const GoodsReceiptPage = ({ user, onNavigate }) => {
                                             </div>
                                         </div>
                                     </td>
-                                    <td className="p-2 align-middle text-center">
+                                    <td className="p-2 align-middle">
                                         <input
                                             type="number"
                                             value={line.quantity}
                                             onChange={e => handleLineChange(line.part_id, 'quantity', e.target.value)}
                                             onFocus={e => e.target.select()}
-                                            className="w-full h-9 px-2 border rounded-md text-sm"
+                                            className={inputClass}
                                         />
                                     </td>
-                                    <td className="p-2 align-middle text-center">
+                                    <td className="p-2 align-middle">
                                         <input
                                             type="number"
                                             step="0.01"
                                             value={line.cost_price}
                                             onChange={e => handleLineChange(line.part_id, 'cost_price', e.target.value)}
                                             onFocus={e => e.target.select()}
-                                            className="w-full h-9 px-2 border rounded-md text-sm"
+                                            className={inputClass}
                                         />
                                     </td>
-                                    <td className="p-2 align-middle text-center">
+                                    <td className="p-2 align-middle">
                                         <input
                                             type="number"
                                             step="0.01"
                                             value={line.sale_price}
                                             onChange={e => handleLineChange(line.part_id, 'sale_price', e.target.value)}
                                             onFocus={e => e.target.select()}
-                                            className="w-full h-9 px-2 border rounded-md text-sm"
+                                            className={inputClass}
                                         />
+                                    </td>
+                                    <td className="p-2 align-middle text-right font-mono text-sm font-medium text-gray-900 dark:text-slate-100">
+                                        {formatCurrency((parseFloat(line.quantity) || 0) * (parseFloat(line.cost_price) || 0))}
                                     </td>
                                     <td className="p-2 align-middle text-center">
                                         <button
                                             onClick={() => removeLine(line.part_id)}
-                                            className="inline-flex items-center justify-center h-8 w-8 text-red-500 hover:text-red-700 rounded hover:bg-red-50"
+                                            className="inline-flex items-center justify-center h-8 w-8 text-danger-500 dark:text-danger-400 hover:text-danger-700 dark:hover:text-danger-300 rounded hover:bg-danger-50 dark:hover:bg-danger-900/30"
                                             title="Remove"
                                         >
                                             <Icon path={ICONS.trash} className="h-5 w-5"/>
@@ -457,13 +483,45 @@ const GoodsReceiptPage = ({ user, onNavigate }) => {
                                     </td>
                                 </tr>
                             ))}
+                            {lines.length === 0 && (
+                                <tr>
+                                    <td colSpan="6" className="p-8 text-center text-sm text-gray-500 dark:text-slate-400">
+                                        No items added yet. Search for a part above, scan a barcode, or select a purchase order to begin.
+                                    </td>
+                                </tr>
+                            )}
                         </tbody>
                     </table>
                 </div>
 
-                <div className="flex justify-end pt-4 border-t">
-                    <button onClick={handlePostTransaction} className="bg-green-600 text-white px-6 py-2 rounded-lg font-semibold hover:bg-green-700 transition">
-                        Post Transaction
+                <div className="flex flex-col sm:flex-row items-stretch sm:items-center justify-between gap-4 pt-4 border-t border-gray-200 dark:border-slate-700">
+                    <div className="flex flex-wrap items-center gap-x-8 gap-y-1 text-sm">
+                        <div>
+                            <span className="text-gray-500 dark:text-slate-400">Items: </span>
+                            <span className="font-semibold text-gray-900 dark:text-slate-100">{totals.lineCount}</span>
+                        </div>
+                        <div>
+                            <span className="text-gray-500 dark:text-slate-400">Total Quantity: </span>
+                            <span className="font-semibold text-gray-900 dark:text-slate-100">{totals.totalQuantity.toLocaleString()}</span>
+                        </div>
+                        <div>
+                            <span className="text-gray-500 dark:text-slate-400">Total Cost: </span>
+                            <span className="font-mono font-bold text-lg text-gray-900 dark:text-slate-100">{formatCurrency(totals.totalCost)}</span>
+                        </div>
+                    </div>
+                    <button
+                        onClick={handlePostTransaction}
+                        disabled={posting || !selectedSupplier || lines.length === 0}
+                        className="bg-success-600 text-white px-6 py-2.5 rounded-lg font-semibold hover:bg-success-700 transition disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+                    >
+                        {posting ? (
+                            <>
+                                <span className="h-4 w-4 animate-spin rounded-full border-2 border-white/40 border-t-white" />
+                                Posting...
+                            </>
+                        ) : (
+                            'Post Transaction'
+                        )}
                     </button>
                 </div>
             </div>

--- a/packages/web/src/pages/SuppliersPage.jsx
+++ b/packages/web/src/pages/SuppliersPage.jsx
@@ -5,19 +5,23 @@ import Modal from '../components/ui/Modal';
 import Icon from '../components/ui/Icon';
 import { ICONS } from '../constants';
 import SupplierForm from '../components/forms/SupplierForm';
-import FilterBar from '../components/ui/FilterBar';
+import SupplierDetailDrawer from '../components/suppliers/SupplierDetailDrawer';
+import StatusBadge from '../components/ui/StatusBadge';
+import SegmentedTabs from '../components/ui/SegmentedTabs';
 import PaginationControls from '../components/ui/PaginationControls';
 import SortableHeader from '../components/ui/SortableHeader';
-import { useAuth } from '../contexts/AuthContext'; // <-- NEW: Import useAuth
-import { sortData } from '../utils/sortData';
+import { useAuth } from '../contexts/AuthContext';
+import { formatCurrency } from '../utils/currency';
 
 const SuppliersPage = () => {
-    const { hasPermission } = useAuth(); // <-- NEW: Use the auth context
+    const { hasPermission } = useAuth();
+    const canViewAp = hasPermission('ap:view');
     const [suppliers, setSuppliers] = useState([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState('');
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [currentSupplier, setCurrentSupplier] = useState(null);
+    const [selectedSupplier, setSelectedSupplier] = useState(null);
     const [statusFilter, setStatusFilter] = useState('active');
     const [sortConfig, setSortConfig] = useState({ key: 'supplier_name', direction: 'ASC' });
     const [page, setPage] = useState(1);
@@ -44,9 +48,24 @@ const SuppliersPage = () => {
                     sortOrder: sortConfig.direction
                 }
             });
-            setSuppliers(response.data?.data || []);
+            const baseSuppliers = response.data?.data || [];
             setTotal(response.data?.total || 0);
-        } catch (err) {
+
+            if (!canViewAp || baseSuppliers.length === 0) {
+                setSuppliers(baseSuppliers);
+                return;
+            }
+
+            // Enrich with AP balance/aging in one extra call rather than a full
+            // second round trip per row; falls back gracefully if unavailable.
+            try {
+                const apRes = await api.get('/ap/supplier-summary', { params: { pageSize: 100 } });
+                const apBySupplierId = new Map((apRes.data?.data || apRes.data || []).map(s => [s.supplier_id, s]));
+                setSuppliers(baseSuppliers.map(s => ({ ...s, ap: apBySupplierId.get(s.supplier_id) || null })));
+            } catch {
+                setSuppliers(baseSuppliers);
+            }
+        } catch {
             setError('Failed to fetch suppliers.');
         } finally {
             setLoading(false);
@@ -55,6 +74,7 @@ const SuppliersPage = () => {
 
     useEffect(() => {
         fetchSuppliers();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [statusFilter, page, pageSize, sortConfig]);
 
     useEffect(() => {
@@ -87,7 +107,7 @@ const SuppliersPage = () => {
             </div>
         ));
     };
-    
+
     const confirmDelete = async (supplierId) => {
         const promise = api.delete(`/suppliers/${supplierId}`);
         toast.promise(promise, {
@@ -113,55 +133,78 @@ const SuppliersPage = () => {
         });
     };
 
+    const handleRowClick = (supplier) => {
+        setSelectedSupplier(supplier.ap ? { ...supplier, ...supplier.ap } : supplier);
+    };
+
+    const handleSupplierUpdated = (updated) => {
+        setSelectedSupplier((prev) => prev ? { ...prev, ...updated } : prev);
+        fetchSuppliers();
+    };
+
     return (
         <div>
             <div className="flex justify-between items-center mb-6">
-                <h1 className="text-2xl font-semibold text-gray-800">Suppliers</h1>
+                <div>
+                    <h1 className="text-2xl font-semibold text-gray-800 dark:text-slate-100">Suppliers</h1>
+                    <p className="text-sm text-gray-500 dark:text-slate-400 mt-1">Directory, payables balance, and payment status for every supplier.</p>
+                </div>
                 {hasPermission('suppliers:edit') && (
-                    <button onClick={handleAdd} className="bg-blue-600 text-white px-4 py-2 rounded-lg font-semibold hover:bg-blue-700 transition">
+                    <button onClick={handleAdd} className="bg-primary-600 text-white px-4 py-2 rounded-lg font-semibold hover:bg-primary-700 transition">
                         Add Supplier
                     </button>
                 )}
             </div>
 
-            <FilterBar 
-                tabs={filterTabs}
-                activeTab={statusFilter}
-                onTabClick={setStatusFilter}
-            />
+            <div className="border-b border-gray-200 dark:border-slate-700 mb-4">
+                <SegmentedTabs tabs={filterTabs} active={statusFilter} onChange={setStatusFilter} />
+            </div>
 
-            <div className="bg-white p-6 rounded-xl border border-gray-200">
-                {loading && <p>Loading suppliers...</p>}
-                {error && <p className="text-red-500">{error}</p>}
+            <div className="bg-white dark:bg-slate-800 p-6 rounded-xl border border-gray-200 dark:border-slate-700">
+                {loading && <p className="text-gray-600 dark:text-slate-400">Loading suppliers...</p>}
+                {error && <p className="text-danger-500">{error}</p>}
                 {!loading && !error && (
                     <>
                     <div className="overflow-x-auto">
                         <table className="w-full text-left">
-                            <thead className="border-b">
+                            <thead className="border-b border-gray-200 dark:border-slate-700">
                                 <tr>
                                     <SortableHeader column="supplier_name" sortConfig={sortConfig} onSort={handleSort}>Name</SortableHeader>
                                     <SortableHeader className="hidden sm:table-cell" column="contact_person" sortConfig={sortConfig} onSort={handleSort}>Contact Person</SortableHeader>
                                     <SortableHeader className="hidden md:table-cell" column="phone" sortConfig={sortConfig} onSort={handleSort}>Phone</SortableHeader>
+                                    {canViewAp && <th className="p-3 text-sm font-semibold text-gray-600 dark:text-slate-300 text-right">AP Balance</th>}
                                     <SortableHeader className="text-center" column="status" sortConfig={sortConfig} onSort={handleSort}>Status</SortableHeader>
-                                    <th className="p-3 text-sm font-semibold text-gray-600 text-right">Actions</th>
+                                    <th className="p-3 text-sm font-semibold text-gray-600 dark:text-slate-300 text-right">Actions</th>
                                 </tr>
                             </thead>
                             <tbody>
                                 {suppliers.map(supplier => (
-                                    <tr key={supplier.supplier_id} className="border-b hover:bg-gray-50">
-                                        <td className="p-3 text-sm font-medium text-gray-800">{supplier.supplier_name}</td>
-                                        <td className="p-3 text-sm hidden sm:table-cell">{supplier.contact_person}</td>
-                                        <td className="p-3 text-sm hidden md:table-cell">{supplier.phone}</td>
-                                        <td className="p-3 text-sm text-center">
-                                            <span className={`px-2 py-1 text-xs font-semibold rounded-full ${supplier.is_active ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'}`}>
-                                                {supplier.is_active ? 'Active' : 'Inactive'}
-                                            </span>
+                                    <tr
+                                        key={supplier.supplier_id}
+                                        onClick={() => handleRowClick(supplier)}
+                                        className="border-b border-gray-100 dark:border-slate-700 hover:bg-gray-50 dark:hover:bg-slate-700/50 cursor-pointer"
+                                    >
+                                        <td className="p-3 text-sm font-medium text-gray-800 dark:text-slate-100">
+                                            <div className="flex items-center gap-2">
+                                                <span>{supplier.supplier_name}</span>
+                                                {supplier.ap?.payment_hold && <StatusBadge tone="danger" label="ON HOLD" />}
+                                            </div>
                                         </td>
-                                        <td className="p-3 text-sm text-right">
+                                        <td className="p-3 text-sm hidden sm:table-cell text-gray-700 dark:text-slate-300">{supplier.contact_person}</td>
+                                        <td className="p-3 text-sm hidden md:table-cell text-gray-700 dark:text-slate-300">{supplier.phone}</td>
+                                        {canViewAp && (
+                                            <td className="p-3 text-sm text-right font-mono text-gray-900 dark:text-slate-100">
+                                                {supplier.ap ? formatCurrency(supplier.ap.total_balance_due) : '—'}
+                                            </td>
+                                        )}
+                                        <td className="p-3 text-sm text-center">
+                                            <StatusBadge tone={supplier.is_active ? 'success' : 'neutral'} label={supplier.is_active ? 'Active' : 'Inactive'} />
+                                        </td>
+                                        <td className="p-3 text-sm text-right" onClick={(e) => e.stopPropagation()}>
                                             {hasPermission('suppliers:edit') && (
                                                 <>
-                                                    <button onClick={() => handleEdit(supplier)} className="text-blue-600 hover:text-blue-800 mr-4"><Icon path={ICONS.edit} className="h-5 w-5"/></button>
-                                                    <button onClick={() => handleDelete(supplier.supplier_id)} className="text-red-600 hover:text-red-800"><Icon path={ICONS.trash} className="h-5 w-5"/></button>
+                                                    <button onClick={() => handleEdit(supplier)} className="text-primary-600 dark:text-primary-400 hover:text-primary-800 dark:hover:text-primary-300 mr-4"><Icon path={ICONS.edit} className="h-5 w-5"/></button>
+                                                    <button onClick={() => handleDelete(supplier.supplier_id)} className="text-danger-600 dark:text-danger-400 hover:text-danger-800 dark:hover:text-danger-300"><Icon path={ICONS.trash} className="h-5 w-5"/></button>
                                                 </>
                                             )}
                                         </td>
@@ -186,6 +229,15 @@ const SuppliersPage = () => {
             <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} title={currentSupplier ? 'Edit Supplier' : 'Add New Supplier'}>
                 <SupplierForm supplier={currentSupplier} onSave={handleSave} onCancel={() => setIsModalOpen(false)} />
             </Modal>
+            {canViewAp && (
+                <SupplierDetailDrawer
+                    supplier={selectedSupplier}
+                    isOpen={!!selectedSupplier}
+                    onClose={() => setSelectedSupplier(null)}
+                    onSupplierUpdated={handleSupplierUpdated}
+                    initialTab="profile"
+                />
+            )}
         </div>
     );
 };


### PR DESCRIPTION
## Summary

Introduces a comprehensive Accounts Payable (AP) monitoring dashboard mirroring the existing AR (Accounts Receivable) functionality. This includes bill aging analysis, supplier-level payable summaries, payment hold management, and the ability to create and manage supplier bills directly without requiring a Purchase Order.

## Key Changes

### Backend API Routes & Services
- **New `/ap/` routes** (`packages/api/routes/apRoutes.js`):
  - `GET /ap/aging-summary` — Bill aging buckets (Current, 1-30, 31-60, 61-90, 90+ Days)
  - `GET /ap/summary-stats` — KPI metrics (total payables, overdue count/amount, due-soon, suppliers on hold)
  - `GET /ap/supplier-summary` — Paginated, searchable, sortable supplier-level AP summary with balance, earliest due date, and aging status
  - `PATCH /ap/suppliers/{id}/payment-hold` — Toggle supplier payment hold with reason tracking
  - `POST /ap/supplier-bills` — Create manual supplier bills (for invoices arriving before/without PO)
  - `GET /ap/supplier-bills` — List bills with filtering and pagination
  - `PATCH /ap/supplier-bills/{id}/due-date` — Edit bill due dates with audit logging
  - `GET /ap/supplier-bills/{id}/items` — Retrieve items attached to a bill

- **New service**: `apDueDateReminderService.js` — Daily cron job scanning for bills due today or overdue (logs structured summary, mirrors PDC reminder pattern)

- **Enhanced `goodsReceiptRoutes.js`**: Added optional `bill_id` parameter to attach stock-in to pre-existing manually-created supplier bills (enables "attach items" workflow)

- **Enhanced `apPdcRoutes.js`**: Added `override_payment_hold` flag to cheque-issuing endpoint with permission check (`ap:manage` required for non-admins)

### Database Migrations
- `20260813_01_*`: Add `supplier.payment_terms_days` column and indexes on `supplier_bill` for aging queries
- `20260813_02_*`: Create `supplier_bill_due_date_log` audit table (mirrors AR's `due_date_log`)
- `20260813_03_*`: Seed `ap:view` and `ap:manage` permissions (separate from `ap-pdc:*` to avoid granting cheque-issuing rights)
- `20260813_04_*`: Add unique index on `supplier_bill.grn_id` to ensure one auto-generated bill per goods receipt
- `20260813_05_*`: Add optional `goods_receipt.bill_id` foreign key
- `20260813_06_*`: Backfill `goods_receipt.bill_id` for receipts with auto-created bills

### Frontend Pages & Components
- **New `AccountsPayablePage.jsx`**: Main AP dashboard with Overview and Aging tabs
  - Overview: KPI cards (total payables, overdue, due-soon, suppliers on hold), aging chart, supplier summary table
  - Aging: Detailed bill list filtered by aging bucket
  - Supplier detail drawer integration

- **New `SupplierDetailDrawer.jsx`**: Supplier profile modal with:
  - Contact info, payment terms, address
  - Payment hold toggle with reason management
  - Bills tab: list of supplier bills with due-date editing, payment recording, item attachment
  - Expandable bill items panel showing attached GRN line items

- **New `AddPayableModal.jsx`**: Create manual supplier bills (for invoices without PO/GRN)

- **New `AttachItemsModal.jsx`**: Attach items to a pre-existing bill via real goods receipt (stock-in happens when items are attached)

- **New `BillAgingSummaryChart.jsx`**: Horizontal stacked bar chart showing bill aging distribution (structural clone of AR's `InvoiceAgingSummaryChart`)

- **New `SupplierSummaryTable.jsx`**: Paginated, searchable, sortable table of supplier AP bal

https://claude.ai/code/session_01BDSkUkkFsVwSsUy5eEVPkS